### PR TITLE
Resubmit fn PR238 on cli

### DIFF
--- a/langs/rust.go
+++ b/langs/rust.go
@@ -1,8 +1,10 @@
 package langs
 
 import (
+	"errors"
+	"io/ioutil"
 	"os"
-	"os/exec"
+	"path/filepath"
 )
 
 type RustLangHelper struct {
@@ -10,34 +12,91 @@ type RustLangHelper struct {
 }
 
 func (lh *RustLangHelper) BuildFromImage() string {
-	return "funcy/rust:dev"
+	return "rust:1"
 }
+
+func (lh *RustLangHelper) RunFromImage() string {
+	return "debian:stretch"
+}
+
+func (lh *RustLangHelper) HasBoilerplate() bool { return true }
+
+func cargoTomlContent(username string) string {
+	return `[package]
+name = "func"
+version = "0.1.0"
+authors = ["` + username + `"]
+
+[dependencies]
+`
+}
+
+func mainContent() string {
+	return `fn main() {
+    println!("Hello, world!");
+}
+`
+}
+
+func (lh *RustLangHelper) GenerateBoilerplate() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	username := os.Getenv("USER")
+	if len(username) == 0 {
+		username = "unknown"
+	}
+
+	pathToCargoToml := filepath.Join(wd, "Cargo.toml")
+	if exists(pathToCargoToml) {
+		return ErrBoilerplateExists
+	}
+	if err := ioutil.WriteFile(pathToCargoToml, []byte(cargoTomlContent(username)), os.FileMode(0644)); err != nil {
+		return err
+	}
+	if err = os.MkdirAll(filepath.Join(wd, "src"), os.FileMode(0755)); err != nil {
+		return err
+	}
+	pathToMain := filepath.Join(wd, "src", "main.rs")
+	if err := ioutil.WriteFile(pathToMain, []byte(mainContent()), os.FileMode(0644)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (lh *RustLangHelper) Entrypoint() string {
-	return "/function/target/release/func"
+	return "/function/func"
+}
+
+func (lh *RustLangHelper) DockerfileCopyCmds() []string {
+	return []string{
+		"COPY --from=build-stage /function/src/target/release/func /function/func",
+	}
+}
+
+func (lh *RustLangHelper) DockerfileBuildCmds() []string {
+	r := []string{}
+	r = append(r, "ADD . /function/src/")
+	r = append(r, "RUN cd /function/src/ && cargo build --release")
+	return r
 }
 
 func (lh *RustLangHelper) HasPreBuild() bool {
 	return true
 }
 
-// PreBuild for rust builds the binary so the final image can be as small as possible
 func (lh *RustLangHelper) PreBuild() error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	cmd := exec.Command(
-		"docker", "run",
-		"--rm", "-v",
-		wd+":/app", "-w", "/app", "corey/rust-alpine",
-		"/bin/sh", "-c", "cargo build --release",
-	)
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
-		return dockerBuildError(err)
+	if !exists(filepath.Join(wd, "Cargo.toml")) {
+		return errors.New("Could not find Cargo.toml - are you sure this is a Rust Cargo project?")
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
From fn PR238:

"Since I'm a Rust fan, in my spare time I'm contributing to the Rust build runtime for fn. :)

This change fixes the current build runtime (which is currently broken as funcy/rust:dev does not exist) and uses the official Rust image (which now exists on DockerHub), plus it generates boilerplate for a basic Cargo project."