### PR TITLE
Fix help text template

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ USAGE:
    {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
 
 ENVIRONMENT VARIABLES:
-   API_URL - Fn server address{{if .VisibleCommands}}
+   API_URL - Fn server address
    FN_REGISTRY - Docker registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]treeder]{{if .VisibleCommands}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}


### PR DESCRIPTION
Before:

```
panic: template: help:27: unexpected EOF

goroutine 1 [running]:
text/template.Must(0x0, 0xdaf340, 0xc42019c720, 0x0)
        /usr/lib/go/src/text/template/helper.go:23 +0x54
github.com/fnproject/cli/vendor/github.com/urfave/cli.printHelpCustom(0xdb1540, 0xc42000e018, 0xaaa12a, 0x3e6, 0xa4c7a0, 0xc420064680, 0x0)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/help.go:240 +0x2cc
github.com/fnproject/cli/vendor/github.com/urfave/cli.printHelp(0xdb1540, 0xc42000e018, 0xaaa12a, 0x3e6, 0xa4c7a0, 0xc420064680)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/help.go:254 +0x66
github.com/fnproject/cli/vendor/github.com/urfave/cli.ShowAppHelp(0xc420082dc0, 0xc420511d20, 0x7d366e)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/help.go:139 +0x166
github.com/fnproject/cli/vendor/github.com/urfave/cli.glob..func1(0xc420082dc0, 0xc420082dc0, 0xc420511d07)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/help.go:92 +0x83
github.com/fnproject/cli/vendor/github.com/urfave/cli.HandleAction(0x9bc2a0, 0xab4d60, 0xc420082dc0, 0xc4200712c0, 0x0)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/app.go:490 +0xd4
github.com/fnproject/cli/vendor/github.com/urfave/cli.(*App).Run(0xc420064680, 0xc4200102a0, 0x1, 0x1, 0x0, 0x0)
        /home/will/code/go/src/github.com/fnproject/cli/vendor/github.com/urfave/cli/app.go:264 +0x6ac
main.main()
        /home/will/code/go/src/github.com/fnproject/cli/main.go:133 +0x57
```

After:

```
fn 0.3.68

Fn command line tool

USAGE:
   Check the docs at https://github.com/fnproject/fn/blob/master/fn/README.md

ENVIRONMENT VARIABLES:
   API_URL - Fn server address
   FN_REGISTRY - Docker registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]treeder]

COMMANDS:
     start    start a functions server
     update   pulls latest functions server
     init     create a local func.yaml file
     apps     manage applications
     routes   manage routes
     images   manage function images
     lambda   create and publish lambda functions
     version  displays fn and functions daemon versions
     calls    manage function calls for apps
     logs     manage function calls for apps
     test     run functions test if present
     help, h  Shows a list of commands or help for one command

ALIASES:
     build    (images build)
     bump     (images bump)
     deploy   (images deploy)
     run      (images run)
     call     (routes call)
     push     (images push)

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```