### PR TITLE
Java: use our custom build image

### DIFF
--- a/langs/java.go
+++ b/langs/java.go
@@ -19,7 +19,7 @@ type JavaLangHelper struct {
 }
 
 // BuildFromImage returns the Docker image used to compile the Maven function project
-func (lh *JavaLangHelper) BuildFromImage() string { return "fnproject/fn-java-fdk:dev" }
+func (lh *JavaLangHelper) BuildFromImage() string { return "fnproject/fn-java-fdk-build:latest" }
 
 // RunFromImage returns the Docker image used to run the Java function.
 func (lh *JavaLangHelper) RunFromImage() string {

--- a/langs/java.go
+++ b/langs/java.go
@@ -17,7 +17,7 @@ type JavaLangHelper struct {
 }
 
 // BuildFromImage returns the Docker image used to compile the Maven function project
-func (lh *JavaLangHelper) BuildFromImage() string { return "maven:3.5-jdk-8-alpine" }
+func (lh *JavaLangHelper) BuildFromImage() string { return "fnproject/fn-java-fdk:dev" }
 
 // RunFromImage returns the Docker image used to run the Java function.
 func (lh *JavaLangHelper) RunFromImage() string {


### PR DESCRIPTION
We now have an independently revving build image for Java, so we'll use the latest of that.