### PR TITLE
Init, run and test use first arg as path now (like deploy).

### DIFF
--- a/common.go
+++ b/common.go
@@ -86,9 +86,6 @@ func dockerBuild(fpath string, ff *funcfile, noCache bool) error {
 	}
 
 	dir := filepath.Dir(fpath)
-	if ff.Name == "" {
-		ff.Name = filepath.Base(dir) // todo: should probably make a copy of ff before changing it
-	}
 
 	var helper langs.LangHelper
 	dockerfile := filepath.Join(dir, "Dockerfile")

--- a/common.go
+++ b/common.go
@@ -39,6 +39,14 @@ func setRegistryEnv(hr HasRegistry) {
 	}
 }
 
+func getWd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatalln("Couldn't get working directory:", err)
+	}
+	return wd
+}
+
 func buildfunc(fpath string, funcfile *funcfile, noCache bool) (*funcfile, error) {
 	var err error
 	if funcfile.Version == "" {
@@ -78,12 +86,15 @@ func dockerBuild(fpath string, ff *funcfile, noCache bool) error {
 	}
 
 	dir := filepath.Dir(fpath)
+	if ff.Name == "" {
+		ff.Name = filepath.Base(dir) // todo: should probably make a copy of ff before changing it
+	}
 
 	var helper langs.LangHelper
 	dockerfile := filepath.Join(dir, "Dockerfile")
 	if !exists(dockerfile) {
 		if ff.Runtime == funcfileDockerRuntime {
-			return fmt.Errorf("Dockerfile not exists for 'docker' runtime")
+			return fmt.Errorf("Dockerfile does not exist for 'docker' runtime")
 		}
 		helper = langs.GetLangHelper(ff.Runtime)
 		if helper == nil {

--- a/deploy.go
+++ b/deploy.go
@@ -132,26 +132,19 @@ func (p *deploycmd) deploy(c *cli.Context) error {
 // deploySingle deploys a single function, either the current directory or if in the context
 // of an app and user provides relative path as the first arg, it will deploy that function.
 func (p *deploycmd) deploySingle(c *cli.Context, appName string, appf *appfile) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		log.Fatalln("Couldn't get working directory:", err)
-	}
+	wd := getWd()
 
 	dir := wd
 	// if we're in the context of an app, first arg is path to the function
 	path := c.Args().First()
 	if path != "" {
-		if appf != nil {
-			fmt.Printf("Deploying function at: /%s\n", path)
-			dir = filepath.Join(wd, path)
-			err := os.Chdir(dir)
-			if err != nil {
-				return err
-			}
-			defer os.Chdir(wd) // todo: wrap this so we can log the error if changing back fails
-		} else {
-			// todo: error out, invalid arg?
+		fmt.Printf("Deploying function at: /%s\n", path)
+		dir = filepath.Join(wd, path)
+		err := os.Chdir(dir)
+		if err != nil {
+			return err
 		}
+		defer os.Chdir(wd) // todo: wrap this so we can log the error if changing back fails
 	}
 
 	fpath, ff, err := findAndParseFuncfile(dir)

--- a/funcfile.go
+++ b/funcfile.go
@@ -96,13 +96,20 @@ func findFuncfile(path string) (string, error) {
 	}
 	return "", newNotFoundError("could not find function file")
 }
-func findAndParseFuncfile(path string) (fpath string, funcfile *funcfile, err error) {
+func findAndParseFuncfile(path string) (fpath string, ff *funcfile, err error) {
 	fpath, err = findFuncfile(path)
 	if err != nil {
 		return "", nil, err
 	}
-	funcfile, err = parseFuncfile(fpath)
-	return fpath, funcfile, err
+	ff, err = parseFuncfile(fpath)
+	if err != nil {
+		return "", nil, err
+	}
+	// get name from directory if it's not defined
+	if ff.Name == "" {
+		ff.Name = filepath.Base(filepath.Dir(fpath)) // todo: should probably make a copy of ff before changing it
+	}
+	return fpath, ff, err
 }
 
 func loadFuncfile() (string, *funcfile, error) {

--- a/init.go
+++ b/init.go
@@ -114,17 +114,21 @@ func initFn() cli.Command {
 func (a *initFnCmd) init(c *cli.Context) error {
 	wd := getWd()
 
+	var err error
 	path := c.Args().First()
 	if path != "" {
 		fmt.Printf("Creating function at: /%s\n", path)
 		dir := filepath.Join(wd, path)
 		// check if dir exists, if it does, then we can't create function
 		if exists(dir) {
-			return fmt.Errorf("directory %s already exists, cannot init function", dir)
-		}
-		err := os.MkdirAll(dir, 0755)
-		if err != nil {
-			return err
+			if !a.force {
+				return fmt.Errorf("directory %s already exists, cannot init function", dir)
+			}
+		} else {
+			err := os.MkdirAll(dir, 0755)
+			if err != nil {
+				return err
+			}
 		}
 		err = os.Chdir(dir)
 		if err != nil {
@@ -146,7 +150,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		}
 	}
 
-	err := a.buildFuncFile(c)
+	err = a.buildFuncFile(c)
 	if err != nil {
 		return err
 	}

--- a/test/funcfile-docker-rt-tests/fn_test.go
+++ b/test/funcfile-docker-rt-tests/fn_test.go
@@ -122,7 +122,7 @@ func runFnBuildNoDockerfile(t *testing.T, testname, fnTestBin string) {
 	t.Logf("INFO: %s Run fn build", testname)
 	res, err := exec.Command(fnTestBin, "build").CombinedOutput()
 	if err != nil {
-		if bytes.Contains(res, []byte("Dockerfile not exists")) {
+		if bytes.Contains(res, []byte("Dockerfile does not exist")) {
 			t.Logf("INFO: %s Got expected error message %s", testname, string(res))
 			return
 		}

--- a/testfn.go
+++ b/testfn.go
@@ -59,16 +59,19 @@ func (t *testcmd) test(c *cli.Context) error {
 		fmt.Println("In gomega FailHandler:", message)
 	})
 
-	// First, build it
-	err := c.App.Command("build").Run(c)
+	wd := getWd()
+
+	fpath, ff, err := findAndParseFuncfile(wd)
 	if err != nil {
 		return err
 	}
 
-	_, ff, err := loadFuncfile()
+	ff, err = buildfunc(fpath, ff, false)
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("LOADED FF:", ff)
 
 	var tests []fftest
 

--- a/testfn.go
+++ b/testfn.go
@@ -71,8 +71,6 @@ func (t *testcmd) test(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println("LOADED FF:", ff)
-
 	var tests []fftest
 
 	// Look for test.json file too

--- a/version.go
+++ b/version.go
@@ -9,8 +9,8 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Version of Functions CLI
-var Version = "0.3.95"
+// Version of Fn CLI
+var Version = "0.4.0"
 
 func version() cli.Command {
 	r := versionCmd{VersionApi: functions.NewVersionApi()}

--- a/version.go
+++ b/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version of Functions CLI
-var Version = "0.3.94"
+var Version = "0.3.95"
 
 func version() cli.Command {
 	r := versionCmd{VersionApi: functions.NewVersionApi()}


### PR DESCRIPTION
* `fn run myfunc` will run the function in the relative dir `myfunc`. 
* `fn init myfunc` will create a new dir and init the function in that dir. eg: `fn init --runtime ruby rubyfunc`

This also changes the behavior of `fn init`. It will not add the `name` value by default, instead it will use the directory name by default. This can be overridden by passing in `--name` flag or adding a `name` value to func.yaml.
