### PR TITLE
Java pom.xml simplified -> build tag replaced with properties

### DIFF
--- a/langs/java.go
+++ b/langs/java.go
@@ -190,13 +190,9 @@ const (
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
     <groupId>com.example.fn</groupId>
     <artifactId>hello</artifactId>
     <version>1.0.0</version>
-
     <repositories>
         <repository>
             <id>fn-release-repo</id>
@@ -229,20 +225,11 @@ const (
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>%s</source>
-                    <target>%s</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+		<maven.compiler.source>%s</maven.compiler.source>
+		<maven.compiler.target>%s</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>		
+	</properties>	
 </project>
 `
 


### PR DESCRIPTION
IMO the first pom.xml should be as simple as possible. Also: I would like to remove the dependencies to the API and tests (see e.g. https://www.youtube.com/watch?v=eWvj8ZVE5To, minute 1:46). 
The first project should be as lean as possible without any dependencies to the fn framework. 

Idea: e.g. fn init --withTests could generate integration tests as well.