### PR TITLE
Add a default FN_REGISTRY for tests (fixes fork builds)

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,9 @@ set -ex
 make build
 export fn="$(pwd)/fn"
 export FN_REGISTRY=$DOCKER_USER
+if [[ -z "$FN_REGISTRY" ]]; then
+  export FN_REGISTRY=default_docker_user_does_not_push
+fi
 $fn --version
 
 go test $(go list ./... | grep -v /vendor/ | grep -v /tests)


### PR DESCRIPTION
At the moment we are using $DOCKER_USER as the FN_REGISTRY for the tests, but $DOCKER_USER is not defined in fork builds on CircleCI because of course we don't want to reveal our creds.

This change adds a default FN_REGISTRY for tests to fix fork builds. We're not pushing anything to docker hub in the tests so this is safe to do.