### PR TITLE
Make sure fork builds don't run release.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: ./test.sh
       - deploy:
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [[ "${CIRCLE_BRANCH}" == "master" && -z "${CIRCLE_PR_REPONAME}" ]]; then
               docker login -u $DOCKER_USER -p $DOCKER_PASS
               git config --global user.email "ci@fnproject.com"
               git config --global user.name "CI"


### PR DESCRIPTION
Make sure fork builds don't run release.sh by checking for CIRCLE_PR_REPONAME which is only present in fork builds.