### PR TITLE
Allow boilerplate generation to set build/run image for repeatable builds

### DIFF
--- a/bump.go
+++ b/bump.go
@@ -78,7 +78,7 @@ func (b *bumpcmd) bump(c *cli.Context) error {
 	_, err = bumpItWd(wd, t)
 	return err
 }
-func bumpItWd(wd string, vtype VType) (*funcfile, error) {
+func bumpItWd(wd string, vtype VType) (*Funcfile, error) {
 	fn, err := findFuncfile(wd)
 	if err != nil {
 		return nil, err
@@ -86,8 +86,8 @@ func bumpItWd(wd string, vtype VType) (*funcfile, error) {
 	return bumpIt(fn, vtype)
 }
 
-// returns updated funcfile
-func bumpIt(fpath string, vtype VType) (*funcfile, error) {
+// returns updated Funcfile
+func bumpIt(fpath string, vtype VType) (*Funcfile, error) {
 	// fmt.Println("Bumping version in func file at: ", fpath)
 	funcfile, err := parseFuncfile(fpath)
 	if err != nil {
@@ -106,7 +106,7 @@ func bumpIt(fpath string, vtype VType) (*funcfile, error) {
 	return funcfile, nil
 }
 
-func bumpVersion(funcfile *funcfile, t VType) (*funcfile, error) {
+func bumpVersion(funcfile *Funcfile, t VType) (*Funcfile, error) {
 	funcfile.Name = cleanImageName(funcfile.Name)
 	if funcfile.Version == "" {
 		funcfile.Version = initialVersion

--- a/bump.go
+++ b/bump.go
@@ -9,6 +9,8 @@ import (
 	bumper "github.com/giantswarm/semver-bump/bump"
 	"github.com/giantswarm/semver-bump/storage"
 	"github.com/urfave/cli"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 type VType int
@@ -78,7 +80,7 @@ func (b *bumpcmd) bump(c *cli.Context) error {
 	_, err = bumpItWd(wd, t)
 	return err
 }
-func bumpItWd(wd string, vtype VType) (*Funcfile, error) {
+func bumpItWd(wd string, vtype VType) (*funcfile.Funcfile, error) {
 	fn, err := findFuncfile(wd)
 	if err != nil {
 		return nil, err
@@ -87,7 +89,7 @@ func bumpItWd(wd string, vtype VType) (*Funcfile, error) {
 }
 
 // returns updated Funcfile
-func bumpIt(fpath string, vtype VType) (*Funcfile, error) {
+func bumpIt(fpath string, vtype VType) (*funcfile.Funcfile, error) {
 	// fmt.Println("Bumping version in func file at: ", fpath)
 	funcfile, err := parseFuncfile(fpath)
 	if err != nil {
@@ -106,7 +108,7 @@ func bumpIt(fpath string, vtype VType) (*Funcfile, error) {
 	return funcfile, nil
 }
 
-func bumpVersion(funcfile *Funcfile, t VType) (*Funcfile, error) {
+func bumpVersion(funcfile *funcfile.Funcfile, t VType) (*funcfile.Funcfile, error) {
 	funcfile.Name = cleanImageName(funcfile.Name)
 	if funcfile.Version == "" {
 		funcfile.Version = initialVersion

--- a/bump_test.go
+++ b/bump_test.go
@@ -56,7 +56,7 @@ func verifyVersion(tmp, version string) error {
 		return err
 	}
 	if ff.Version != version {
-		return fmt.Errorf("funcfile version %v does not match expected version %v", ff.Version, version)
+		return fmt.Errorf("Funcfile version %v does not match expected version %v", ff.Version, version)
 	}
 	return nil
 }

--- a/common.go
+++ b/common.go
@@ -47,7 +47,7 @@ func getWd() string {
 	return wd
 }
 
-func buildfunc(fpath string, funcfile *funcfile, noCache bool) (*funcfile, error) {
+func buildfunc(fpath string, funcfile *Funcfile, noCache bool) (*Funcfile, error) {
 	var err error
 	if funcfile.Version == "" {
 		funcfile, err = bumpIt(fpath, Patch)
@@ -79,7 +79,7 @@ func localBuild(path string, steps []string) error {
 	return nil
 }
 
-func dockerBuild(fpath string, ff *funcfile, noCache bool) error {
+func dockerBuild(fpath string, ff *Funcfile, noCache bool) error {
 	err := dockerVersionCheck()
 	if err != nil {
 		return err
@@ -187,7 +187,7 @@ func exists(name string) bool {
 	return true
 }
 
-func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *funcfile) (string, error) {
+func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *Funcfile) (string, error) {
 	if ff.Entrypoint == "" && ff.Cmd == "" {
 		return "", errors.New("entrypoint and cmd are missing, you must provide one or the other")
 	}
@@ -272,7 +272,7 @@ func extractEnvConfig(configs []string) map[string]string {
 	return c
 }
 
-func dockerPush(ff *funcfile) error {
+func dockerPush(ff *Funcfile) error {
 	err := validateImageName(ff.ImageName())
 	if err != nil {
 		return err

--- a/common.go
+++ b/common.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/fnproject/cli/langs"
+	"github.com/fnproject/cli/funcfile"
 )
 
 const (
@@ -47,7 +48,7 @@ func getWd() string {
 	return wd
 }
 
-func buildfunc(fpath string, funcfile *Funcfile, noCache bool) (*Funcfile, error) {
+func buildfunc(fpath string, funcfile *funcfile.Funcfile, noCache bool) (*funcfile.Funcfile, error) {
 	var err error
 	if funcfile.Version == "" {
 		funcfile, err = bumpIt(fpath, Patch)
@@ -79,7 +80,7 @@ func localBuild(path string, steps []string) error {
 	return nil
 }
 
-func dockerBuild(fpath string, ff *Funcfile, noCache bool) error {
+func dockerBuild(fpath string, ff *funcfile.Funcfile, noCache bool) error {
 	err := dockerVersionCheck()
 	if err != nil {
 		return err
@@ -187,7 +188,7 @@ func exists(name string) bool {
 	return true
 }
 
-func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *Funcfile) (string, error) {
+func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *funcfile.Funcfile) (string, error) {
 	if ff.Entrypoint == "" && ff.Cmd == "" {
 		return "", errors.New("entrypoint and cmd are missing, you must provide one or the other")
 	}
@@ -272,7 +273,7 @@ func extractEnvConfig(configs []string) map[string]string {
 	return c
 }
 
-func dockerPush(ff *Funcfile) error {
+func dockerPush(ff *funcfile.Funcfile) error {
 	err := validateImageName(ff.ImageName())
 	if err != nil {
 		return err

--- a/deploy.go
+++ b/deploy.go
@@ -12,6 +12,7 @@ import (
 	functions "github.com/funcy/functions_go"
 	"github.com/funcy/functions_go/models"
 	"github.com/urfave/cli"
+	"github.com/fnproject/cli/funcfile"
 )
 
 func deploy() cli.Command {
@@ -221,7 +222,7 @@ func (p *deploycmd) deployAll(c *cli.Context, appName string, appf *appfile) err
 // Parse func.yaml file, bump version, build image, push to registry, and
 // finally it will update function's route. Optionally,
 // the route can be overriden inside the func.yaml file.
-func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *Funcfile) error {
+func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *funcfile.Funcfile) error {
 	if appName == "" {
 		return errors.New("app name must be provided, try `--app APP_NAME`.")
 	}
@@ -261,7 +262,7 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 	return p.updateRoute(c, appName, funcfile)
 }
 
-func setRootFuncInfo(ff *Funcfile, appName string) {
+func setRootFuncInfo(ff *funcfile.Funcfile, appName string) {
 	if ff.Name == "" {
 		fmt.Println("setting name")
 		ff.Name = fmt.Sprintf("%s-root", appName)
@@ -272,7 +273,7 @@ func setRootFuncInfo(ff *Funcfile, appName string) {
 	}
 }
 
-func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *Funcfile) error {
+func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *funcfile.Funcfile) error {
 	fmt.Printf("Updating route %s using image %s...\n", ff.Path, ff.ImageName())
 	if err := resetBasePath(p.Configuration); err != nil {
 		return fmt.Errorf("error setting endpoint: %v", err)

--- a/deploy.go
+++ b/deploy.go
@@ -221,7 +221,7 @@ func (p *deploycmd) deployAll(c *cli.Context, appName string, appf *appfile) err
 // Parse func.yaml file, bump version, build image, push to registry, and
 // finally it will update function's route. Optionally,
 // the route can be overriden inside the func.yaml file.
-func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *funcfile) error {
+func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *Funcfile) error {
 	if appName == "" {
 		return errors.New("app name must be provided, try `--app APP_NAME`.")
 	}
@@ -245,7 +245,7 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 		return err
 	}
 	funcfile.Version = funcfile2.Version
-	// TODO: this whole funcfile handling needs some love, way too confusing. Only bump makes permanent changes to it.
+	// TODO: this whole Funcfile handling needs some love, way too confusing. Only bump makes permanent changes to it.
 
 	_, err = buildfunc(funcfilePath, funcfile, p.noCache)
 	if err != nil {
@@ -261,7 +261,7 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 	return p.updateRoute(c, appName, funcfile)
 }
 
-func setRootFuncInfo(ff *funcfile, appName string) {
+func setRootFuncInfo(ff *Funcfile, appName string) {
 	if ff.Name == "" {
 		fmt.Println("setting name")
 		ff.Name = fmt.Sprintf("%s-root", appName)
@@ -272,7 +272,7 @@ func setRootFuncInfo(ff *funcfile, appName string) {
 	}
 }
 
-func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *funcfile) error {
+func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *Funcfile) error {
 	fmt.Printf("Updating route %s using image %s...\n", ff.Path, ff.ImageName())
 	if err := resetBasePath(p.Configuration); err != nil {
 		return fmt.Errorf("error setting endpoint: %v", err)
@@ -281,7 +281,7 @@ func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *funcfile) er
 	routesCmd := routesCmd{client: client.APIClient()}
 	rt := &models.Route{}
 	if err := routeWithFuncFile(ff, rt); err != nil {
-		return fmt.Errorf("error getting route with funcfile: %s", err)
+		return fmt.Errorf("error getting route with Funcfile: %s", err)
 	}
 	return routesCmd.putRoute(c, appName, ff.Path, rt)
 }

--- a/funcfile.go
+++ b/funcfile.go
@@ -42,7 +42,7 @@ type Expects struct {
 	Config []InputVar `yaml:"config" json:"config"`
 }
 
-type funcfile struct {
+type Funcfile struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// Build params
@@ -69,7 +69,7 @@ type funcfile struct {
 	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`
 }
 
-func (ff *funcfile) ImageName() string {
+func (ff *Funcfile) ImageName() string {
 	fname := ff.Name
 	if !strings.Contains(fname, "/") {
 		// then we'll prefix FN_REGISTRY
@@ -87,7 +87,7 @@ func (ff *funcfile) ImageName() string {
 	return fname
 }
 
-func (ff *funcfile) RuntimeTag() (runtime, tag string) {
+func (ff *Funcfile) RuntimeTag() (runtime, tag string) {
 	if ff.Runtime == "" {
 		return "", ""
 	}
@@ -111,7 +111,7 @@ func findFuncfile(path string) (string, error) {
 	}
 	return "", newNotFoundError("could not find function file")
 }
-func findAndParseFuncfile(path string) (fpath string, ff *funcfile, err error) {
+func findAndParseFuncfile(path string) (fpath string, ff *Funcfile, err error) {
 	fpath, err = findFuncfile(path)
 	if err != nil {
 		return "", nil, err
@@ -123,11 +123,11 @@ func findAndParseFuncfile(path string) (fpath string, ff *funcfile, err error) {
 	return fpath, ff, err
 }
 
-func loadFuncfile() (string, *funcfile, error) {
+func loadFuncfile() (string, *Funcfile, error) {
 	return findAndParseFuncfile(".")
 }
 
-func parseFuncfile(path string) (*funcfile, error) {
+func parseFuncfile(path string) (*Funcfile, error) {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
@@ -138,7 +138,7 @@ func parseFuncfile(path string) (*funcfile, error) {
 	return nil, errUnexpectedFileFormat
 }
 
-func storeFuncfile(path string, ff *funcfile) error {
+func storeFuncfile(path string, ff *Funcfile) error {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
@@ -149,30 +149,30 @@ func storeFuncfile(path string, ff *funcfile) error {
 	return errUnexpectedFileFormat
 }
 
-func decodeFuncfileJSON(path string) (*funcfile, error) {
+func decodeFuncfileJSON(path string) (*Funcfile, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &funcfile{}
+	ff := &Funcfile{}
 	// ff.Route = &fnmodels.Route{}
 	err = json.NewDecoder(f).Decode(ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func decodeFuncfileYAML(path string) (*funcfile, error) {
+func decodeFuncfileYAML(path string) (*Funcfile, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &funcfile{}
+	ff := &Funcfile{}
 	err = yaml.Unmarshal(b, ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func encodeFuncfileJSON(path string, ff *funcfile) error {
+func encodeFuncfileJSON(path string, ff *Funcfile) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("could not open %s for encoding. Error: %v", path, err)
@@ -180,7 +180,7 @@ func encodeFuncfileJSON(path string, ff *funcfile) error {
 	return json.NewEncoder(f).Encode(ff)
 }
 
-func encodeFuncfileYAML(path string, ff *funcfile) error {
+func encodeFuncfileYAML(path string, ff *Funcfile) error {
 	b, err := yaml.Marshal(ff)
 	if err != nil {
 		return fmt.Errorf("could not encode function file. Error: %v", err)

--- a/funcfile.go
+++ b/funcfile.go
@@ -6,9 +6,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 var (
@@ -18,88 +19,6 @@ var (
 		"func.json",
 	}
 )
-
-type inputMap struct {
-	Body interface{}
-}
-type outputMap struct {
-	Body interface{}
-}
-
-type fftest struct {
-	Name   string     `yaml:"name,omitempty" json:"name,omitempty"`
-	Input  *inputMap  `yaml:"input,omitempty" json:"input,omitempty"`
-	Output *outputMap `yaml:"outoutput,omitempty" json:"output,omitempty"`
-	Err    *string    `yaml:"err,omitempty" json:"err,omitempty"`
-	// Env    map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
-}
-
-type InputVar struct {
-	Name     string `yaml:"name" json:"name"`
-	Required bool   `yaml:"required" json:"required"`
-}
-type Expects struct {
-	Config []InputVar `yaml:"config" json:"config"`
-}
-
-type Funcfile struct {
-	Name string `yaml:"name,omitempty" json:"name,omitempty"`
-
-	// Build params
-	Version    string   `yaml:"version,omitempty" json:"version,omitempty"`
-	Runtime    string   `yaml:"runtime,omitempty" json:"runtime,omitempty"`
-	Entrypoint string   `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Cmd        string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
-	Build      []string `yaml:"build,omitempty" json:"build,omitempty"`
-	Tests      []fftest `yaml:"tests,omitempty" json:"tests,omitempty"`
-	BuildImage string   `yaml:"build_image,omitempty" json:"build_image,omitempty"` // Image to use as base for building
-	RunImage   string   `yaml:"run_image,omitempty" json:"run_image,omitempty"`     // Image to use for running
-
-	// Route params
-	Type        string              `yaml:"type,omitempty" json:"type,omitempty"`
-	Memory      uint64              `yaml:"memory,omitempty" json:"memory,omitempty"`
-	Format      string              `yaml:"format,omitempty" json:"format,omitempty"`
-	Timeout     *int32              `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	Path        string              `yaml:"path,omitempty" json:"path,omitempty"`
-	Config      map[string]string   `yaml:"config,omitempty" json:"config,omitempty"`
-	Headers     map[string][]string `yaml:"headers,omitempty" json:"headers,omitempty"`
-	IDLETimeout *int32              `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
-
-	// Run/test
-	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`
-}
-
-func (ff *Funcfile) ImageName() string {
-	fname := ff.Name
-	if !strings.Contains(fname, "/") {
-		// then we'll prefix FN_REGISTRY
-		reg := os.Getenv(envFnRegistry)
-		if reg != "" {
-			if reg[len(reg)-1] != '/' {
-				reg += "/"
-			}
-			fname = fmt.Sprintf("%s%s", reg, fname)
-		}
-	}
-	if ff.Version != "" {
-		fname = fmt.Sprintf("%s:%s", fname, ff.Version)
-	}
-	return fname
-}
-
-func (ff *Funcfile) RuntimeTag() (runtime, tag string) {
-	if ff.Runtime == "" {
-		return "", ""
-	}
-
-	rt := ff.Runtime
-	tagpos := strings.Index(rt, ":")
-	if tagpos == -1 {
-		return rt, ""
-	}
-
-	return rt[:tagpos], rt[tagpos+1:]
-}
 
 // findFuncfile for a func.yaml/json/yml file in path
 func findFuncfile(path string) (string, error) {
@@ -111,7 +30,8 @@ func findFuncfile(path string) (string, error) {
 	}
 	return "", newNotFoundError("could not find function file")
 }
-func findAndParseFuncfile(path string) (fpath string, ff *Funcfile, err error) {
+
+func findAndParseFuncfile(path string) (fpath string, ff *funcfile.Funcfile, err error) {
 	fpath, err = findFuncfile(path)
 	if err != nil {
 		return "", nil, err
@@ -123,11 +43,11 @@ func findAndParseFuncfile(path string) (fpath string, ff *Funcfile, err error) {
 	return fpath, ff, err
 }
 
-func loadFuncfile() (string, *Funcfile, error) {
+func loadFuncfile() (string, *funcfile.Funcfile, error) {
 	return findAndParseFuncfile(".")
 }
 
-func parseFuncfile(path string) (*Funcfile, error) {
+func parseFuncfile(path string) (*funcfile.Funcfile, error) {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
@@ -138,7 +58,7 @@ func parseFuncfile(path string) (*Funcfile, error) {
 	return nil, errUnexpectedFileFormat
 }
 
-func storeFuncfile(path string, ff *Funcfile) error {
+func storeFuncfile(path string, ff *funcfile.Funcfile) error {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
@@ -149,30 +69,30 @@ func storeFuncfile(path string, ff *Funcfile) error {
 	return errUnexpectedFileFormat
 }
 
-func decodeFuncfileJSON(path string) (*Funcfile, error) {
+func decodeFuncfileJSON(path string) (*funcfile.Funcfile, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &Funcfile{}
+	ff := &funcfile.Funcfile{}
 	// ff.Route = &fnmodels.Route{}
 	err = json.NewDecoder(f).Decode(ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func decodeFuncfileYAML(path string) (*Funcfile, error) {
+func decodeFuncfileYAML(path string) (*funcfile.Funcfile, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &Funcfile{}
+	ff := &funcfile.Funcfile{}
 	err = yaml.Unmarshal(b, ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func encodeFuncfileJSON(path string, ff *Funcfile) error {
+func encodeFuncfileJSON(path string, ff *funcfile.Funcfile) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("could not open %s for encoding. Error: %v", path, err)
@@ -180,7 +100,7 @@ func encodeFuncfileJSON(path string, ff *Funcfile) error {
 	return json.NewEncoder(f).Encode(ff)
 }
 
-func encodeFuncfileYAML(path string, ff *Funcfile) error {
+func encodeFuncfileYAML(path string, ff *funcfile.Funcfile) error {
 	b, err := yaml.Marshal(ff)
 	if err != nil {
 		return fmt.Errorf("could not encode function file. Error: %v", err)

--- a/funcfile/funcfile.go
+++ b/funcfile/funcfile.go
@@ -1,0 +1,93 @@
+package funcfile
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type InputMap struct {
+	Body interface{}
+}
+type OutputMap struct {
+	Body interface{}
+}
+
+type Fftest struct {
+	Name   string     `yaml:"name,omitempty" json:"name,omitempty"`
+	Input  *InputMap  `yaml:"input,omitempty" json:"input,omitempty"`
+	Output *OutputMap `yaml:"outoutput,omitempty" json:"output,omitempty"`
+	Err    *string    `yaml:"err,omitempty" json:"err,omitempty"`
+	// Env    map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+}
+
+type InputVar struct {
+	Name     string `yaml:"name" json:"name"`
+	Required bool   `yaml:"required" json:"required"`
+}
+type Expects struct {
+	Config []InputVar `yaml:"config" json:"config"`
+}
+
+type Funcfile struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Build params
+	Version    string   `yaml:"version,omitempty" json:"version,omitempty"`
+	Runtime    string   `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+	Entrypoint string   `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Cmd        string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
+	Build      []string `yaml:"build,omitempty" json:"build,omitempty"`
+	Tests      []Fftest `yaml:"tests,omitempty" json:"tests,omitempty"`
+	BuildImage string   `yaml:"build_image,omitempty" json:"build_image,omitempty"` // Image to use as base for building
+	RunImage   string   `yaml:"run_image,omitempty" json:"run_image,omitempty"`     // Image to use for running
+
+	// Route params
+	Type        string              `yaml:"type,omitempty" json:"type,omitempty"`
+	Memory      uint64              `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Format      string              `yaml:"format,omitempty" json:"format,omitempty"`
+	Timeout     *int32              `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Path        string              `yaml:"path,omitempty" json:"path,omitempty"`
+	Config      map[string]string   `yaml:"config,omitempty" json:"config,omitempty"`
+	Headers     map[string][]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	IDLETimeout *int32              `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
+
+	// Run/test
+	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`
+}
+
+const (
+	envFnRegistry = "FN_REGISTRY"
+)
+
+func (ff *Funcfile) ImageName() string {
+	fname := ff.Name
+	if !strings.Contains(fname, "/") {
+		// then we'll prefix FN_REGISTRY
+		reg := os.Getenv(envFnRegistry)
+		if reg != "" {
+			if reg[len(reg)-1] != '/' {
+				reg += "/"
+			}
+			fname = fmt.Sprintf("%s%s", reg, fname)
+		}
+	}
+	if ff.Version != "" {
+		fname = fmt.Sprintf("%s:%s", fname, ff.Version)
+	}
+	return fname
+}
+
+func (ff *Funcfile) RuntimeTag() (runtime, tag string) {
+	if ff.Runtime == "" {
+		return "", ""
+	}
+
+	rt := ff.Runtime
+	tagpos := strings.Index(rt, ":")
+	if tagpos == -1 {
+		return rt, ""
+	}
+
+	return rt[:tagpos], rt[tagpos+1:]
+}

--- a/init.go
+++ b/init.go
@@ -186,7 +186,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 func (a *initFnCmd) generateBoilerplate() error {
 	helper := langs.GetLangHelper(a.Runtime)
 	if helper != nil && helper.HasBoilerplate() {
-		if err := helper.GenerateBoilerplate(); err != nil {
+		if err := helper.GenerateBoilerplate(&a.Funcfile); err != nil {
 			if err == langs.ErrBoilerplateExists {
 				return nil
 			}

--- a/init.go
+++ b/init.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/fnproject/cli/langs"
+	"github.com/fnproject/cli/funcfile"
 	"github.com/funcy/functions_go/models"
 	"github.com/urfave/cli"
 )
@@ -56,7 +57,7 @@ func init() {
 
 type initFnCmd struct {
 	force bool
-	Funcfile
+	funcfile.Funcfile
 }
 
 func initFlags(a *initFnCmd) []cli.Flag {

--- a/init.go
+++ b/init.go
@@ -56,7 +56,7 @@ func init() {
 
 type initFnCmd struct {
 	force bool
-	funcfile
+	Funcfile
 }
 
 func initFlags(a *initFnCmd) []cli.Flag {
@@ -99,7 +99,7 @@ func initFlags(a *initFnCmd) []cli.Flag {
 
 func initFn() cli.Command {
 	a := &initFnCmd{}
-	// funcfile := &funcfile{}
+	// Funcfile := &Funcfile{}
 
 	return cli.Command{
 		Name:        "init",
@@ -174,7 +174,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		}
 	}
 
-	ff := a.funcfile
+	ff := a.Funcfile
 	if err := encodeFuncfileYAML("func.yaml", &ff); err != nil {
 		return err
 	}

--- a/lambda.go
+++ b/lambda.go
@@ -178,7 +178,7 @@ func createFunctionYaml(opts createImageOptions, functionName string) error {
 	strs := strings.Split(opts.Name, "/")
 	path := fmt.Sprintf("/%s", strs[1])
 
-	funcDesc := &funcfile{
+	funcDesc := &Funcfile{
 		Name:    opts.Name,
 		Version: "0.0.1",
 		Runtime: opts.Base,

--- a/lambda.go
+++ b/lambda.go
@@ -18,6 +18,8 @@ import (
 	"github.com/moby/moby/pkg/jsonmessage"
 	"github.com/urfave/cli"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 var runtimes = map[string]string{
@@ -178,7 +180,7 @@ func createFunctionYaml(opts createImageOptions, functionName string) error {
 	strs := strings.Split(opts.Name, "/")
 	path := fmt.Sprintf("/%s", strs[1])
 
-	funcDesc := &Funcfile{
+	funcDesc := &funcfile.Funcfile{
 		Name:    opts.Name,
 		Version: "0.0.1",
 		Runtime: opts.Base,

--- a/langs/base.go
+++ b/langs/base.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 //used to indicate the default supported version of java
@@ -62,9 +64,9 @@ type LangHelper interface {
 	AfterBuild() error
 	// HasBoilerplate indicates whether a language has support for generating function boilerplate.
 	HasBoilerplate() bool
-	// GenerateBoilerplate generates basic function boilerplate. Returns ErrBoilerplateExists if the function file
-	// already exists.
-	GenerateBoilerplate() error
+	// GenerateBoilerplate generates basic function boilerplate and possibly modifies values of the initial func file.
+	// Returns ErrBoilerplateExists if the function file already exists.
+	GenerateBoilerplate(ff *funcfile.Funcfile) error
 }
 
 // BaseHelper is empty implementation of LangHelper for embedding in implementations.
@@ -82,7 +84,7 @@ func (h *BaseHelper) HasPreBuild() bool             { return false }
 func (h *BaseHelper) PreBuild() error               { return nil }
 func (h *BaseHelper) AfterBuild() error             { return nil }
 func (h *BaseHelper) HasBoilerplate() bool          { return false }
-func (h *BaseHelper) GenerateBoilerplate() error    { return nil }
+func (h *BaseHelper) GenerateBoilerplate(ff *funcfile.Funcfile) error { return nil }
 
 // exists checks if a file exists
 func exists(name string) bool {

--- a/langs/go.go
+++ b/langs/go.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"github.com/fnproject/cli/funcfile"
 )
 
 type GoLangHelper struct {
@@ -47,7 +48,7 @@ func (lh *GoLangHelper) Entrypoint() string {
 
 func (lh *GoLangHelper) HasBoilerplate() bool { return true }
 
-func (lh *GoLangHelper) GenerateBoilerplate() error {
+func (lh *GoLangHelper) GenerateBoilerplate(ff *funcfile.Funcfile) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"github.com/fnproject/cli/funcfile"
 )
 
 type RubyLangHelper struct {
@@ -43,7 +44,7 @@ func (lh *RubyLangHelper) Entrypoint() string {
 
 func (lh *RubyLangHelper) HasBoilerplate() bool { return true }
 
-func (lh *RubyLangHelper) GenerateBoilerplate() error {
+func (lh *RubyLangHelper) GenerateBoilerplate(ff *funcfile.Funcfile) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/langs/rust.go
+++ b/langs/rust.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"github.com/fnproject/cli/funcfile"
 )
 
 type RustLangHelper struct {
@@ -38,7 +39,7 @@ func mainContent() string {
 `
 }
 
-func (lh *RustLangHelper) GenerateBoilerplate() error {
+func (lh *RustLangHelper) GenerateBoilerplate(ff *funcfile.Funcfile) error {
 	wd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/routes.go
+++ b/routes.go
@@ -265,7 +265,7 @@ func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {
 	}
 }
 
-func routeWithFuncFile(ff *funcfile, rt *fnmodels.Route) error {
+func routeWithFuncFile(ff *Funcfile, rt *fnmodels.Route) error {
 	var err error
 	if ff == nil {
 		_, ff, err = loadFuncfile()

--- a/routes.go
+++ b/routes.go
@@ -17,6 +17,8 @@ import (
 	fnmodels "github.com/funcy/functions_go/models"
 	"github.com/jmoiron/jsonq"
 	"github.com/urfave/cli"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 type routesCmd struct {
@@ -265,7 +267,7 @@ func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {
 	}
 }
 
-func routeWithFuncFile(ff *Funcfile, rt *fnmodels.Route) error {
+func routeWithFuncFile(ff *funcfile.Funcfile, rt *fnmodels.Route) error {
 	var err error
 	if ff == nil {
 		_, ff, err = loadFuncfile()

--- a/run.go
+++ b/run.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/urfave/cli"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 const (
@@ -66,12 +68,12 @@ func runflags() []cli.Flag {
 	}
 }
 
-func preRun(c *cli.Context) (*Funcfile, []string, error) {
+func preRun(c *cli.Context) (*funcfile.Funcfile, []string, error) {
 	wd := getWd()
 	// if image name is passed in, it will run that image
 	path := c.Args().First() // TODO: should we ditch this?
 	var err error
-	var ff *Funcfile
+	var ff *funcfile.Funcfile
 	var fpath string
 
 	if path != "" {
@@ -147,7 +149,7 @@ func (r *runCmd) run(c *cli.Context) error {
 }
 
 // TODO: share all this stuff with the Docker driver in server or better yet, actually use the Docker driver
-func runff(ff *Funcfile, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int) error {
+func runff(ff *funcfile.Funcfile, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int) error {
 	sh := []string{"docker", "run", "--rm", "-i", fmt.Sprintf("--memory=%dm", ff.Memory)}
 
 	var err error

--- a/run.go
+++ b/run.go
@@ -66,12 +66,12 @@ func runflags() []cli.Flag {
 	}
 }
 
-func preRun(c *cli.Context) (*funcfile, []string, error) {
+func preRun(c *cli.Context) (*Funcfile, []string, error) {
 	wd := getWd()
 	// if image name is passed in, it will run that image
 	path := c.Args().First() // TODO: should we ditch this?
 	var err error
-	var ff *funcfile
+	var ff *Funcfile
 	var fpath string
 
 	if path != "" {
@@ -147,7 +147,7 @@ func (r *runCmd) run(c *cli.Context) error {
 }
 
 // TODO: share all this stuff with the Docker driver in server or better yet, actually use the Docker driver
-func runff(ff *funcfile, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int) error {
+func runff(ff *Funcfile, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int) error {
 	sh := []string{"docker", "run", "--rm", "-i", fmt.Sprintf("--memory=%dm", ff.Memory)}
 
 	var err error

--- a/testfn.go
+++ b/testfn.go
@@ -17,10 +17,12 @@ import (
 	functions "github.com/funcy/functions_go"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli"
+
+	"github.com/fnproject/cli/funcfile"
 )
 
 type testStruct struct {
-	Tests []fftest `yaml:"tests,omitempty" json:"tests,omitempty"`
+	Tests []funcfile.Fftest `yaml:"tests,omitempty" json:"tests,omitempty"`
 }
 
 func testfn() cli.Command {
@@ -77,7 +79,7 @@ func (t *testcmd) test(c *cli.Context) error {
 		return err
 	}
 
-	var tests []fftest
+	var tests []funcfile.Fftest
 
 	// Look for test.json file too
 	tfile := "test.json"
@@ -153,7 +155,7 @@ func (t *testcmd) test(c *cli.Context) error {
 	return nil
 }
 
-func runlocaltest(target string, in *inputMap, expectedOut *outputMap, expectedErr *string, envVars []string) error {
+func runlocaltest(target string, in *funcfile.InputMap, expectedOut *funcfile.OutputMap, expectedErr *string, envVars []string) error {
 	inBytes, err := json.Marshal(in.Body)
 	if err != nil {
 		return err
@@ -175,7 +177,7 @@ func runlocaltest(target string, in *inputMap, expectedOut *outputMap, expectedE
 
 	var stdout, stderr bytes.Buffer
 
-	ff := &Funcfile{Name: target}
+	ff := &funcfile.Funcfile{Name: target}
 	if err := runff(ff, stdin, &stdout, &stderr, "", envVars, nil, DefaultFormat, 1); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\nstderr:%s\n", err, stdout.String(), stderr.String())
 	}
@@ -192,7 +194,7 @@ func runlocaltest(target string, in *inputMap, expectedOut *outputMap, expectedE
 	return fmt.Errorf("mismatched output found.\nexpected:\n%s\ngot:\n%s\nlogs:\n%s\n", expectedString, out, stderr.String())
 }
 
-func runremotetest(target string, in *inputMap, expectedOut *outputMap, expectedErr *string, envVars []string) error {
+func runremotetest(target string, in *funcfile.InputMap, expectedOut *funcfile.OutputMap, expectedErr *string, envVars []string) error {
 	inBytes, err := json.Marshal(in)
 	if err != nil {
 		return err

--- a/testfn.go
+++ b/testfn.go
@@ -175,7 +175,7 @@ func runlocaltest(target string, in *inputMap, expectedOut *outputMap, expectedE
 
 	var stdout, stderr bytes.Buffer
 
-	ff := &funcfile{Name: target}
+	ff := &Funcfile{Name: target}
 	if err := runff(ff, stdin, &stdout, &stderr, "", envVars, nil, DefaultFormat, 1); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\nstderr:%s\n", err, stdout.String(), stderr.String())
 	}


### PR DESCRIPTION
Users have two competing requirements for their functions:

- They want builds to be repeatable (e.g. not be broken by a change in `latest`), and
- Different functions may require different versions of the language runtime

We have seen this several times with the Java FDK and runtime, where we even have an additional problem whereby our jars are also versioned in addition to the runtime image (and there's a correspondence between jars and runtime image). Cue the "don't merge anything during demo week!" requirement. 🙂 

Note that the main problem here is not only backwards compatibility (which we can strive to maintain): it is _forward_ compatibility. If I update my `fn` cli tool and do `fn init` and the generated boilerplate uses a feature that requires a later version of the runtime compared to the one I have, I cannot build/run my newly generated function!
I'd have to manually do a `docker pull` of the `latest` image runtime, but then my builds of my previous functions are not repeatable anymore.

Using `latest` is unsatisfactory. Therefore, users should lock their build and runtime images: since last week, this is possible using the `build_image` and `run_image` properties in the func.yaml. That's good. 👍 

In order to further improve usability, we think we should do this locking for the users if/when we generate the boilerplate for a new function: at the time, we can determine a version of dependencies (jars), build image, and run image and therefore we can lock them down.

However, this requires us to be able to modify the basic func.yaml at boilerplate generation time. In order to do so, this PR does the following:

- It moves the `funcfile` data structure into its own package, making it public
- It modifies the boilerplate generation contract so that `GenerateBoilerplate` can also modify properties of the `funcfile` that is going to be written.

This may not be the best way of refactoring the `funcfile` data structure - I tried to do the minimum movement of code that would satisfy the requirements. I am open to suggestions on how to do it better.
 
Still, we would really like to be able to modify the `funcfile` during boilerplate generation.