### PR TITLE
add back init route field mods

### DIFF
--- a/funcfile.go
+++ b/funcfile.go
@@ -56,6 +56,7 @@ type funcfile struct {
 	RunImage   string   `yaml:"run_image,omitempty" json:"run_image,omitempty"`     // Image to use for running
 
 	// Route params
+	// TODO embed models.Route
 	Type        string              `yaml:"type,omitempty" json:"type,omitempty"`
 	Memory      uint64              `yaml:"memory,omitempty" json:"memory,omitempty"`
 	Format      string              `yaml:"format,omitempty" json:"format,omitempty"`

--- a/install
+++ b/install
@@ -62,23 +62,19 @@ case "$(uname)" in
     $sh_c "$curl /usr/local/bin/fn $url/$version/fn_linux"
     $sh_c "chmod +x /usr/local/bin/fn"
     fn --version
-    exit 0
     ;;
   Darwin)
     $sh_c "$curl /usr/local/bin/fn $url/$version/fn_mac"
     $sh_c "chmod +x /usr/local/bin/fn"
     fn --version
-    exit 0
     ;;
   WindowsNT)
     $sh_c "$curl $url/$version/fn.exe"
     # TODO how to make executable? chmod?
     fn.exe --version
-    exit 0
     ;;
-esac
-
-cat >&2 <<'EOF'
+  *)
+    cat >&2 <<'EOF'
 
   Either your platform is not easily detectable or is not supported by this
   installer script (yet - PRs welcome! [fn/install]).
@@ -87,4 +83,16 @@ cat >&2 <<'EOF'
     https://github.com/fnproject/fn
 
 EOF
-exit 1
+    exit 1
+esac
+
+cat >&2 <<'EOF'
+
+        ______
+       / ____/___
+      / /_  / __ \
+     / __/ / / / /
+    /_/   /_/ /_/`
+
+EOF
+exit 0

--- a/routes.go
+++ b/routes.go
@@ -31,7 +31,6 @@ var routeFlags = []cli.Flag{
 	cli.Uint64Flag{
 		Name:  "memory,m",
 		Usage: "memory in MiB",
-		Value: uint64(128),
 	},
 	cli.StringFlag{
 		Name:  "type,t",
@@ -48,17 +47,14 @@ var routeFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "format,f",
 		Usage: "hot container IO format - default or http",
-		Value: "default",
 	},
 	cli.IntFlag{
 		Name:  "timeout",
 		Usage: "route timeout (eg. 30)",
-		Value: 30,
 	},
 	cli.IntFlag{
 		Name:  "idle-timeout",
 		Usage: "route idle timeout (eg. 30)",
-		Value: 30,
 	},
 }
 


### PR DESCRIPTION
seems like at some point the code to mutate some of the default route fields
such as 'memory', 'format', 'timeout', 'idle_timeout' got removed, I'd guess
in the name of simplifying the func file output which I agree with (or perhaps a mistake?), but would
be nice to modify these fields too. we could omit them
if the defaults are captured, but that means we have to sync with the fn
server so not a huge fan of that (already an issue, really). anyway, the
defaults are back to being spat out, unless modified via flags.

found the ascii text pretty obnoxious in init, removed it. just created a
bunch of empty space in my shell that i had to scroll over, provides no value.
don't even like having any output when the command succeeds but that's too
neckbeard for this project probably...

now for tutorials we can do:

```
fn init --format http
```

instead of saying "open up your func.yaml in your favorite editor and add a
line...". also, nobody has to do that anymore, which is nice, too. only
works on select fields. i didn't want to do the whole update funcy dance
today, would be nice to embed a models.Route in the funcfile struct but it
doesn't have `yaml` tags and generates ugly fields :/ so, this works for now.