### PR TITLE
Pagination

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -10,15 +10,15 @@ import (
 	"strings"
 
 	client "github.com/fnproject/cli/client"
-	fnclient "github.com/funcy/functions_go/client"
-	apiapps "github.com/funcy/functions_go/client/apps"
-	"github.com/funcy/functions_go/models"
+	fnclient "github.com/fnproject/fn_go/client"
+	apiapps "github.com/fnproject/fn_go/client/apps"
+	"github.com/fnproject/fn_go/models"
 	"github.com/jmoiron/jsonq"
 	"github.com/urfave/cli"
 )
 
 type appsCmd struct {
-	client *fnclient.Functions
+	client *fnclient.Fn
 }
 
 func apps() cli.Command {

--- a/calls.go
+++ b/calls.go
@@ -56,8 +56,8 @@ func calls() cli.Command {
 					},
 					cli.Int64Flag{
 						Name:  "per-page",
-						Usage: "number of calls to return, if --per-page=-1 all calls will be listed",
-						Value: int64(-1),
+						Usage: "number of calls to return",
+						Value: int64(30),
 					},
 				},
 			},

--- a/calls.go
+++ b/calls.go
@@ -120,7 +120,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		res := fromTime_int64.Unix() / int64(time.Second)
+		res := fromTime_int64.Unix()
 		params.FromTime = &res
 
 	}
@@ -130,7 +130,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		res := toTime_int64.Unix() / int64(time.Second)
+		res := toTime_int64.Unix()
 		params.ToTime = &res
 	}
 	if ctx.Int64("per-page") > 0 {

--- a/calls.go
+++ b/calls.go
@@ -120,7 +120,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		res := fromTime_int64.UnixNano() / int64(time.Second)
+		res := fromTime_int64.Unix() / int64(time.Second)
 		params.FromTime = &res
 
 	}
@@ -130,7 +130,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		res := toTime_int64.UnixNano() / int64(time.Second)
+		res := toTime_int64.Unix() / int64(time.Second)
 		params.ToTime = &res
 	}
 	if ctx.Int64("per-page") != 0 {

--- a/calls.go
+++ b/calls.go
@@ -125,7 +125,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 
 	}
 	if ctx.String("to-time") != "" {
-		toTime := ctx.String("from-time")
+		toTime := ctx.String("to-time")
 		toTime_int64, err := time.Parse(time.RFC3339, toTime)
 		if err != nil {
 			return err

--- a/calls.go
+++ b/calls.go
@@ -56,8 +56,8 @@ func calls() cli.Command {
 					},
 					cli.Int64Flag{
 						Name:  "per-page",
-						Usage: "number of calls to return",
-						Value: int64(0),
+						Usage: "number of calls to return, if --per-page=-1 all calls will be listed",
+						Value: int64(-1),
 					},
 				},
 			},
@@ -133,7 +133,7 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 		res := toTime_int64.Unix() / int64(time.Second)
 		params.ToTime = &res
 	}
-	if ctx.Int64("per-page") != 0 {
+	if ctx.Int64("per-page") > 0 {
 		per_page := ctx.Int64("per-page")
 		params.PerPage = &per_page
 	}

--- a/calls.go
+++ b/calls.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 	"fmt"
 
-	client "github.com/fnproject/cli/client"
-	fnclient "github.com/funcy/functions_go/client"
-	apicall "github.com/funcy/functions_go/client/call"
-	"github.com/funcy/functions_go/models"
+	"github.com/fnproject/cli/client"
+	fnclient "github.com/fnproject/fn_go/client"
+	apicall "github.com/fnproject/fn_go/client/call"
+	"github.com/fnproject/fn_go/models"
 	"github.com/urfave/cli"
 )
 
 type callsCmd struct {
-	client *fnclient.Functions
+	client *fnclient.Fn
 }
 
 func calls() cli.Command {
@@ -84,12 +84,12 @@ func (call *callsCmd) list(ctx *cli.Context) error {
 	}
 	if ctx.Args().Get(1) != "" {
 		route := ctx.Args().Get(1)
-		params.Route = &route
+		params.Path = &route
 	}
 	resp, err := call.client.Call.GetAppsAppCalls(&params)
 	if err != nil {
 		switch e := err.(type) {
-		case *apicall.GetCallsCallNotFound:
+		case *apicall.GetAppsAppCallsNotFound:
 			return errors.New(e.Payload.Error.Message)
 		default:
 			return err

--- a/client/api.go
+++ b/client/api.go
@@ -7,6 +7,7 @@ import (
 	fnclient "github.com/fnproject/fn_go/client"
 	openapi "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"fmt"
 )
 
 const (
@@ -16,7 +17,8 @@ const (
 func Host() string {
 	h, err := HostURL()
 	if err != nil {
-		panic(err)
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
 	}
 	return h.Host
 }

--- a/deploy.go
+++ b/deploy.go
@@ -9,14 +9,14 @@ import (
 	"time"
 
 	client "github.com/fnproject/cli/client"
-	functions "github.com/funcy/functions_go"
-	"github.com/funcy/functions_go/models"
+	fnclient "github.com/fnproject/fn_go/client"
+	"github.com/fnproject/fn_go/models"
 	"github.com/urfave/cli"
 )
 
 func deploy() cli.Command {
 	cmd := deploycmd{
-		RoutesApi: functions.NewRoutesApi(),
+		Fn: client.APIClient(),
 	}
 	var flags []cli.Flag
 	flags = append(flags, cmd.flags()...)
@@ -30,7 +30,7 @@ func deploy() cli.Command {
 
 type deploycmd struct {
 	appName string
-	*functions.RoutesApi
+	*fnclient.Fn
 
 	wd       string
 	verbose  bool
@@ -274,9 +274,6 @@ func setRootFuncInfo(ff *funcfile, appName string) {
 
 func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *funcfile) error {
 	fmt.Printf("Updating route %s using image %s...\n", ff.Path, ff.ImageName())
-	if err := resetBasePath(p.Configuration); err != nil {
-		return fmt.Errorf("error setting endpoint: %v", err)
-	}
 
 	routesCmd := routesCmd{client: client.APIClient()}
 	rt := &models.Route{}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: 7c2f789d8f4972b1cb81cc2581f8e481cc815b40b7715c0fb9aa94cf3c1bfd8e
-updated: 2017-08-23T16:53:46.159402157-07:00
+hash: af54042f7a4dca55ffb5962d600a586ad677f3353062121033e40a0daa0ee047
+updated: 2017-10-21T01:50:25.975596+03:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 15028e809df8c71964e8efa6c11e81d5c0262302
 - name: github.com/aws/aws-sdk-go
-  version: 5f216d3a320b04771edb3f39e9e063603551423a
+  version: 0b712b483e38c7e1efe9c3e0249de0a8f131cb4e
   subpackages:
   - aws
   - aws/awserr
@@ -49,13 +49,22 @@ imports:
   - pkg/term/windows
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/fnproject/fn_go
+  version: 7ce3bb2e624df60cdfbfc1ee5483f6df80bb2b1b
+  subpackages:
+  - client
+  - client/apps
+  - client/call
+  - client/operations
+  - client/routes
+  - client/version
+  - models
 - name: github.com/funcy/functions_go
   version: e046aa4ca1f1028a04fc51395297ff07515cb0b6
   subpackages:
   - client
   - client/apps
   - client/call
-  - client/operations
   - client/routes
   - models
 - name: github.com/giantswarm/semver-bump
@@ -87,8 +96,6 @@ imports:
   version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/go-openapi/validate
   version: 8a82927c942c94794a5cd8b8b50ce2f48a955c0c
-- name: github.com/go-resty/resty
-  version: 8d8edd722eb7a48130ba8bd71fefbf028e8aab26
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jmoiron/jsonq
@@ -132,7 +139,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/urfave/cli
-  version: f017f86fccc5a039a98f23311f34fdf78b014f78
+  version: 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
@@ -146,7 +153,6 @@ imports:
   - html/atom
   - html/charset
   - idna
-  - publicsuffix
 - name: golang.org/x/sys
   version: 07c182904dbd53199946ba614a412c61d3c548f5
   subpackages:

--- a/images.go
+++ b/images.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/funcy/functions_go"
+	"github.com/fnproject/fn_go/client"
 	"github.com/urfave/cli"
 )
 
 type imagesCmd struct {
-	*functions.AppsApi
+	*client.Fn
 }
 
 func images() cli.Command {

--- a/init.go
+++ b/init.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/fnproject/cli/langs"
-	"github.com/funcy/functions_go/models"
+	"github.com/fnproject/fn_go/models"
 	"github.com/urfave/cli"
 )
 

--- a/logs.go
+++ b/logs.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	client "github.com/fnproject/cli/client"
-	fnclient "github.com/funcy/functions_go/client"
-	apicall "github.com/funcy/functions_go/client/operations"
+	fnclient "github.com/fnproject/fn_go/client"
+	apicall "github.com/fnproject/fn_go/client/operations"
 	"github.com/urfave/cli"
 )
 
 type logsCmd struct {
-	client *fnclient.Functions
+	client *fnclient.Fn
 }
 
 func logs() cli.Command {

--- a/main.go
+++ b/main.go
@@ -3,11 +3,9 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
-	functions "github.com/funcy/functions_go"
 	"github.com/urfave/cli"
 )
 
@@ -136,20 +134,4 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-func resetBasePath(c *functions.Configuration) error {
-	apiURL := os.Getenv("API_URL")
-	if apiURL == "" {
-		apiURL = "http://localhost:8080"
-	}
-
-	u, err := url.Parse(apiURL)
-	if err != nil {
-		return err
-	}
-	u.Path = "/v1"
-	c.BasePath = u.String()
-
-	return nil
 }

--- a/routes.go
+++ b/routes.go
@@ -12,15 +12,15 @@ import (
 	"text/tabwriter"
 
 	client "github.com/fnproject/cli/client"
-	fnclient "github.com/funcy/functions_go/client"
-	apiroutes "github.com/funcy/functions_go/client/routes"
-	fnmodels "github.com/funcy/functions_go/models"
+	fnclient "github.com/fnproject/fn_go/client"
+	apiroutes "github.com/fnproject/fn_go/client/routes"
+	fnmodels "github.com/fnproject/fn_go/models"
 	"github.com/jmoiron/jsonq"
 	"github.com/urfave/cli"
 )
 
 type routesCmd struct {
-	client *fnclient.Functions
+	client *fnclient.Fn
 }
 
 var routeFlags = []cli.Flag{

--- a/testfn.go
+++ b/testfn.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/fnproject/cli/client"
-	functions "github.com/funcy/functions_go"
+	functions "github.com/fnproject/fn_go/client"
 	"github.com/onsi/gomega"
 	"github.com/urfave/cli"
 )
@@ -24,7 +24,7 @@ type testStruct struct {
 }
 
 func testfn() cli.Command {
-	cmd := testcmd{RoutesApi: functions.NewRoutesApi()}
+	cmd := testcmd{Fn: client.APIClient()}
 	return cli.Command{
 		Name:   "test",
 		Usage:  "run functions test if present",
@@ -34,7 +34,7 @@ func testfn() cli.Command {
 }
 
 type testcmd struct {
-	*functions.RoutesApi
+	*functions.Fn
 
 	build  bool
 	remote string
@@ -106,12 +106,9 @@ func (t *testcmd) test(c *cli.Context) error {
 	runtest := runlocaltest
 	if t.remote != "" {
 		if ff.Path == "" {
-			return errors.New("execution of tests on remote server demand that this function has a `path`.")
+			return errors.New("execution of tests on remote server demand that this function has a `path`")
 		}
-		if err := resetBasePath(t.Configuration); err != nil {
-			return fmt.Errorf("error setting endpoint: %v", err)
-		}
-		baseURL, err := url.Parse(t.Configuration.BasePath)
+		baseURL, err := client.HostURL()
 		if err != nil {
 			return fmt.Errorf("error parsing base path: %v", err)
 		}

--- a/version.go
+++ b/version.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 
-	functions "github.com/funcy/functions_go"
+	client "github.com/fnproject/cli/client"
+	versionclient "github.com/fnproject/fn_go/client/version"
 	"github.com/urfave/cli"
 )
 
@@ -13,7 +13,7 @@ import (
 var Version = "0.4.11"
 
 func version() cli.Command {
-	r := versionCmd{VersionApi: functions.NewVersionApi()}
+	r := versionCmd{client: versionclient.New(client.GetTransportAndRegistry())}
 	return cli.Command{
 		Name:   "version",
 		Usage:  "displays fn and functions daemon versions",
@@ -22,7 +22,7 @@ func version() cli.Command {
 }
 
 type versionCmd struct {
-	*functions.VersionApi
+	client *versionclient.Client
 }
 
 func (r *versionCmd) version(c *cli.Context) error {
@@ -30,18 +30,11 @@ func (r *versionCmd) version(c *cli.Context) error {
 	if apiURL == "" {
 		apiURL = "http://localhost:8080"
 	}
-
-	u, err := url.Parse(apiURL)
-	if err != nil {
-		return err
-	}
-	r.Configuration.BasePath = u.String()
-
 	fmt.Println("Client version:", Version)
-	v, _, err := r.VersionGet()
+	v, err := r.client.GetVersion(nil)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Server version", v.Version)
+	fmt.Println("Server version", v.Payload.Version)
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -24,12 +24,13 @@ func versionCMD(c *cli.Context) error {
 	// version is also there, but it shouldn't
 	// dropping base path to get appropriate URL for request eventually
 	t.BasePath = ""
-	version_client := fnclient.New(t, reg)
-	v, err := version_client.GetVersion(nil)
-	if err != nil {
-		return err
-	}
 	fmt.Println("Client version: ", Version)
+	versionClient := fnclient.New(t, reg)
+	v, err := versionClient.GetVersion(nil)
+	if err != nil {
+		fmt.Println("Server version: ", "?")
+		return nil
+	}
 	fmt.Println("Server version: ", v.Payload.Version)
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -1,40 +1,35 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
-	client "github.com/fnproject/cli/client"
-	versionclient "github.com/fnproject/fn_go/client/version"
+	"github.com/fnproject/cli/client"
+	fnclient "github.com/fnproject/fn_go/client/version"
 	"github.com/urfave/cli"
+	"fmt"
 )
 
 // Version of Fn CLI
 var Version = "0.4.11"
 
 func version() cli.Command {
-	r := versionCmd{client: versionclient.New(client.GetTransportAndRegistry())}
 	return cli.Command{
 		Name:   "version",
 		Usage:  "displays fn and functions daemon versions",
-		Action: r.version,
+		Action: versionCMD,
 	}
 }
 
-type versionCmd struct {
-	client *versionclient.Client
-}
-
-func (r *versionCmd) version(c *cli.Context) error {
-	apiURL := os.Getenv("API_URL")
-	if apiURL == "" {
-		apiURL = "http://localhost:8080"
-	}
-	fmt.Println("Client version:", Version)
-	v, err := r.client.GetVersion(nil)
+func versionCMD(c *cli.Context) error {
+	t, reg := client.GetTransportAndRegistry()
+	// dirty hack, swagger paths live under /v1
+	// version is also there, but it shouldn't
+	// dropping base path to get appropriate URL for request eventually
+	t.BasePath = ""
+	version_client := fnclient.New(t, reg)
+	v, err := version_client.GetVersion(nil)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Server version", v.Payload.Version)
+	fmt.Println("Client version: ", Version)
+	fmt.Println("Server version: ", v.Payload.Version)
 	return nil
 }


### PR DESCRIPTION
Adding pagination to calls API
```
fn calls list application --help
NAME:
   fn calls list - list all calls for the specific app. Route is optional

USAGE:
   fn calls list [command options] <app>

OPTIONS:
   --path value       function's path
   --cursor value     pagination cursor
   --from-time value  'start' timestamp
   --to-time value    'stop' timestamp
   --per-page value   number of calls to return (default: 30)
   
```

Closes: #50 #77 