### PR TITLE
Add a --selinux flag to `fn start` to deal with SELinux permissions

### DIFF
--- a/start.go
+++ b/start.go
@@ -34,7 +34,7 @@ func start(c *cli.Context) error {
 	if c.String("log-level") != "" {
 		denvs = append(denvs, "GIN_MODE="+c.String("log-level"))
 	}
-	// Socket mount: docker run --rm -it --name functions -v ${PWD}/data:/app/data:Z -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 funcy/functions
+	// Socket mount: docker run --rm -it --name functions -v ${PWD}/data:/app/data:Z -v /var/run/docker.sock:/var/run/docker.sock:Z -p 8080:8080 funcy/functions
 	// OR dind: docker run --rm -it --name functions -v ${PWD}/data:/app/data:Z --privileged -p 8080:8080 funcy/functions
 	wd, err := os.Getwd()
 	if err != nil {
@@ -43,7 +43,7 @@ func start(c *cli.Context) error {
 	args := []string{"run", "--rm", "-i",
 		"--name", "functions",
 		"-v", fmt.Sprintf("%s/data:/app/data:Z", wd),    // :Z deals with SELinux and enables write permission only for this specific container.
-		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		"-v", "/var/run/docker.sock:/var/run/docker.sock:Z",
 		"-p", "8080:8080",
 	}
 	for _, v := range denvs {

--- a/start.go
+++ b/start.go
@@ -34,15 +34,15 @@ func start(c *cli.Context) error {
 	if c.String("log-level") != "" {
 		denvs = append(denvs, "GIN_MODE="+c.String("log-level"))
 	}
-	// Socket mount: docker run --rm -it --name functions -v ${PWD}/data:/app/data -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 funcy/functions
-	// OR dind: docker run --rm -it --name functions -v ${PWD}/data:/app/data --privileged -p 8080:8080 funcy/functions
+	// Socket mount: docker run --rm -it --name functions -v ${PWD}/data:/app/data:Z -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 funcy/functions
+	// OR dind: docker run --rm -it --name functions -v ${PWD}/data:/app/data:Z --privileged -p 8080:8080 funcy/functions
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatalln("Getwd failed:", err)
 	}
 	args := []string{"run", "--rm", "-i",
 		"--name", "functions",
-		"-v", fmt.Sprintf("%s/data:/app/data", wd),
+		"-v", fmt.Sprintf("%s/data:/app/data:Z", wd),    // :Z deals with SELinux and enables write permission only for this specific container.
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-p", "8080:8080",
 	}


### PR DESCRIPTION
Closes: #91 

Using the `:Z` option on the docker volume mounts when starting the Fn container will cause SELinux to grant read/write permission to them _specifically to the Fn container_.
This is the safest way of dealing with SELinux permissions as it does not require to generally lower the `svirt_sandbox_file_t` security setting.