### PR TITLE
Adds build-server command for adding extensions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:alpine AS build-env
+FROM golang:1.9-alpine AS build-env
 RUN apk --no-cache add build-base git bzr mercurial gcc
 ENV D=/go/src/github.com/fnproject/cli
 # If dep ever gets decent enough to use, try `dep ensure --vendor-only` from here: https://medium.com/travis-on-docker/triple-stage-docker-builds-with-go-and-angular-1b7d2006cb88

--- a/build_server.go
+++ b/build_server.go
@@ -1,0 +1,187 @@
+// This command builds a custom fn server with extensions compiled into it.
+//
+// NOTES:
+// * We could just add extensions in the imports, but then there's no way to order them or potentially add extra config (although config should almost always be via env vars)
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+
+	"github.com/urfave/cli"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func buildServer() cli.Command {
+	cmd := buildServerCmd{}
+	flags := append([]cli.Flag{}, cmd.flags()...)
+	return cli.Command{
+		Name:   "build-server",
+		Usage:  "build custom fn server",
+		Flags:  flags,
+		Action: cmd.buildServer,
+	}
+}
+
+type buildServerCmd struct {
+	verbose bool
+	noCache bool
+}
+
+func (b *buildServerCmd) flags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:        "v",
+			Usage:       "verbose mode",
+			Destination: &b.verbose,
+		},
+		cli.BoolFlag{
+			Name:        "no-cache",
+			Usage:       "Don't use docker cache",
+			Destination: &b.noCache,
+		},
+		cli.StringFlag{
+			Name:  "tag,t",
+			Usage: "image name and optional tag",
+		},
+	}
+}
+
+// steps:
+// • Yaml file with extensions listed
+// • NO‎TE: All extensions should use env vars for config
+// • ‎Generating main.go with extensions
+// * Generate a Dockerfile that gets all the extensions (using dep)
+// • ‎then generate a main.go with extensions
+// • ‎compile, throw in another container like main dockerfile
+func (b *buildServerCmd) buildServer(c *cli.Context) error {
+
+	if c.String("tag") == "" {
+		return errors.New("docker tag required")
+	}
+
+	// path, err := os.Getwd()
+	// if err != nil {
+	// 	return err
+	// }
+	fpath := "ext.yaml"
+	bb, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return fmt.Errorf("could not open %s for parsing. Error: %v", fpath, err)
+	}
+	ef := &extFile{}
+	err = yaml.Unmarshal(bb, ef)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll("tmp", 0777)
+	if err != nil {
+		return err
+	}
+	err = os.Chdir("tmp")
+	if err != nil {
+		return err
+	}
+	err = generateMain(ef)
+	if err != nil {
+		return err
+	}
+	err = generateDockerfile()
+	if err != nil {
+		return err
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	err = runBuild(dir, c.String("tag"), "Dockerfile", false)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Custom Fn server built successfully.\n")
+	return nil
+}
+
+func generateMain(ef *extFile) error {
+	tmpl, err := template.New("main").Parse(mainTmpl)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create("main.go")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = tmpl.Execute(f, ef)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateDockerfile() error {
+	if err := ioutil.WriteFile("Dockerfile", []byte(dockerFileTmpl), os.FileMode(0644)); err != nil {
+		return err
+	}
+	return nil
+}
+
+type extFile struct {
+	Extensions []*extInfo `yaml:"extensions"`
+}
+
+type extInfo struct {
+	Name string `yaml:"name"`
+	// will have version and other things down the road
+}
+
+var mainTmpl = `package main
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/server"
+	
+	{{- range .Extensions }}
+		_ "{{ .Name }}"
+	{{- end}}
+)
+
+func main() {
+	ctx := context.Background()
+	funcServer := server.NewFromEnv(ctx)
+	{{- range .Extensions }}
+		funcServer.AddExtension("{{ .Name }}")
+	{{- end}}
+	funcServer.Start(ctx)
+}
+`
+
+// NOTE: Getting build errors with dep, probably because our vendor dir is wack. Might work again once we switch to dep.
+// vendor/github.com/fnproject/fn/api/agent/drivers/docker/registry.go:93: too many arguments in call to client.NewRepository
+// have ("context".Context, reference.Named, string, http.RoundTripper) want (reference.Named, string, http.RoundTripper)
+// go build github.com/x/y/vendor/github.com/rdallman/migrate/database/mysql: no buildable Go source files in /go/src/github.com/x/y/vendor/github.com/rdallman/migrate/database/mysql
+// # github.com/x/y/vendor/github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/scribe
+// vendor/github.com/openzipkin/zipkin-go-opentracing/thrift/gen-go/scribe/scribe.go:210: undefined: thrift.TClient
+var dockerFileTmpl = `# build stage
+FROM golang:1.9-alpine AS build-env
+RUN apk --no-cache add build-base git bzr mercurial gcc
+# RUN go get -u github.com/golang/dep/cmd/dep
+ENV D=/go/src/github.com/x/y
+ADD main.go $D/
+RUN cd $D && go get
+# RUN cd $D && dep init && dep ensure
+RUN cd $D && go build -o fnserver && cp fnserver /tmp/
+
+# final stage
+FROM alpine
+RUN apk add --no-cache ca-certificates curl
+WORKDIR /app
+COPY --from=build-env /tmp/fnserver /app/fnserver
+ENTRYPOINT ["./fnserver"]
+`

--- a/build_server.go
+++ b/build_server.go
@@ -156,7 +156,7 @@ func main() {
 	ctx := context.Background()
 	funcServer := server.NewFromEnv(ctx)
 	{{- range .Extensions }}
-		funcServer.AddExtension("{{ .Name }}")
+		funcServer.AddExtensionByName("{{ .Name }}")
 	{{- end}}
 	funcServer.Start(ctx)
 }

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ GLOBAL OPTIONS:
 		calls(),
 		logs(),
 		testfn(),
+		buildServer(),
 	}
 	app.Commands = append(app.Commands, aliasesFn()...)
 

--- a/testfn.go
+++ b/testfn.go
@@ -49,7 +49,7 @@ func (t *testcmd) flags() []cli.Flag {
 		// },
 		cli.StringFlag{
 			Name:        "remote",
-			Usage:       "run tests by calling the function on `appname`",
+			Usage:       "run tests against a remote fn server",
 			Destination: &t.remote,
 		},
 	}


### PR DESCRIPTION
Adds ways to build custom fn server images with extensions. User creates an `ext.yaml` like this:

```yaml
extensions:
  - name: github.com/treeder/fn-ext-example/logspam
  - name: github.com/treeder/fn-ext-example2/logspam2
```

Then runs:

```sh
fn build-server -t user/image
```

Requires https://github.com/fnproject/fn/pull/554 
Example usage here: https://github.com/treeder/fn-ext-example/pull/2
