### PR TITLE
Optionally fixate build and runtime images in func.yaml on init 

### DIFF
--- a/common.go
+++ b/common.go
@@ -202,7 +202,10 @@ func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *funcfile) (stri
 	dfLines := []string{}
 	bi := ff.BuildImage
 	if bi == "" {
-		bi = helper.BuildFromImage()
+		bi, err = helper.BuildFromImage()
+		if err != nil {
+			return "", err
+		}
 	}
 	if helper.IsMultiStage() {
 		// build stage
@@ -216,7 +219,10 @@ func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *funcfile) (stri
 		// final stage
 		ri := ff.RunImage
 		if ri == "" {
-			ri = helper.RunFromImage()
+			ri, err = helper.RunFromImage()
+			if err !=nil {
+				return "", err
+			}
 		}
 		dfLines = append(dfLines, fmt.Sprintf("FROM %s", ri))
 		dfLines = append(dfLines, "WORKDIR /function")

--- a/langs/base.go
+++ b/langs/base.go
@@ -23,11 +23,11 @@ func GetLangHelper(lang string) LangHelper {
 	case "ruby":
 		return &RubyLangHelper{}
 	case "python":
-		return &PythonLangHelper{Version:"2.7.13"}
+		return &PythonLangHelper{Version: "2.7.13"}
 	case "python2.7":
-		return &PythonLangHelper{Version:"2.7.13"}
+		return &PythonLangHelper{Version: "2.7.13"}
 	case "python3.6":
-		return &PythonLangHelper{Version:"3.6"}
+		return &PythonLangHelper{Version: "3.6"}
 	case "php":
 		return &PhpLangHelper{}
 	case "rust":
@@ -48,9 +48,9 @@ func GetLangHelper(lang string) LangHelper {
 
 type LangHelper interface {
 	// BuildFromImage is the base image to build off, typically fnproject/LANG:dev
-	BuildFromImage() string
+	BuildFromImage() (string, error)
 	// RunFromImage is the base image to use for deployment (usually smaller than the build images)
-	RunFromImage() string
+	RunFromImage() (string, error)
 	// If set to false, it will use a single Docker build step, rather than multi-stage
 	IsMultiStage() bool
 	// Dockerfile build lines for building dependencies or anything else language specific
@@ -58,9 +58,9 @@ type LangHelper interface {
 	// DockerfileCopyCmds will run in second/final stage of multi-stage build to copy artifacts form the build stage
 	DockerfileCopyCmds() []string
 	// Entrypoint sets the Docker Entrypoint. One of Entrypoint or Cmd is required.
-	Entrypoint() string
+	Entrypoint() (string, error)
 	// Cmd sets the Docker command. One of Entrypoint or Cmd is required.
-	Cmd() string
+	Cmd() (string, error)
 	// DefaultFormat provides the default fn format to set in func.yaml fn init, return "" for an empty format.
 	DefaultFormat() string
 	HasPreBuild() bool
@@ -71,25 +71,26 @@ type LangHelper interface {
 	// GenerateBoilerplate generates basic function boilerplate. Returns ErrBoilerplateExists if the function file
 	// already exists.
 	GenerateBoilerplate() error
+	// FixImagesOnInit determines if images should be fixed on initialization - BuildFromImage and RunFromImage will be written to func.yaml
+	FixImagesOnInit() bool
 }
 
 // BaseHelper is empty implementation of LangHelper for embedding in implementations.
 type BaseHelper struct {
 }
 
-func (h *BaseHelper) BuildFromImage() string        { return "" }
-func (h *BaseHelper) RunFromImage() string          { return h.BuildFromImage() }
 func (h *BaseHelper) IsMultiStage() bool            { return true }
 func (h *BaseHelper) DockerfileBuildCmds() []string { return []string{} }
 func (h *BaseHelper) DockerfileCopyCmds() []string  { return []string{} }
-func (h *BaseHelper) Entrypoint() string            { return "" }
-func (h *BaseHelper) Cmd() string                   { return "" }
+func (h *BaseHelper) Entrypoint() (string, error)   { return "", nil }
+func (h *BaseHelper) Cmd() (string, error)          { return "", nil }
 func (h *BaseHelper) HasPreBuild() bool             { return false }
 func (h *BaseHelper) PreBuild() error               { return nil }
 func (h *BaseHelper) AfterBuild() error             { return nil }
 func (h *BaseHelper) HasBoilerplate() bool          { return false }
 func (h *BaseHelper) GenerateBoilerplate() error    { return nil }
 func (h *BaseHelper) DefaultFormat() string         { return "" }
+func (h *BaseHelper) FixImagesOnInit() bool         { return false }
 
 // exists checks if a file exists
 func exists(name string) bool {

--- a/langs/dotnet.go
+++ b/langs/dotnet.go
@@ -9,15 +9,15 @@ type DotNetLangHelper struct {
 	BaseHelper
 }
 
-func (lh *DotNetLangHelper) BuildFromImage() string {
-	return "microsoft/dotnet:1.0.1-sdk-projectjson"
+func (lh *DotNetLangHelper) BuildFromImage() (string, error) {
+	return "microsoft/dotnet:1.0.1-sdk-projectjson", nil
 }
-func (lh *DotNetLangHelper) RunFromImage() string {
-	return "microsoft/dotnet:runtime"
+func (lh *DotNetLangHelper) RunFromImage() (string, error) {
+	return "microsoft/dotnet:runtime", nil
 }
 
-func (lh *DotNetLangHelper) Entrypoint() string {
-	return "dotnet dotnet.dll"
+func (lh *DotNetLangHelper) Entrypoint() (string, error) {
+	return "dotnet dotnet.dll", nil
 }
 
 func (lh *DotNetLangHelper) HasPreBuild() bool {

--- a/langs/go.go
+++ b/langs/go.go
@@ -10,12 +10,12 @@ type GoLangHelper struct {
 	BaseHelper
 }
 
-func (lh *GoLangHelper) BuildFromImage() string {
-	return "fnproject/go:dev"
+func (lh *GoLangHelper) BuildFromImage() (string, error) {
+	return "fnproject/go:dev", nil
 }
 
-func (lh *GoLangHelper) RunFromImage() string {
-	return "fnproject/go"
+func (lh *GoLangHelper) RunFromImage() (string, error) {
+	return "fnproject/go", nil
 }
 
 func (h *GoLangHelper) DockerfileBuildCmds() []string {
@@ -41,8 +41,8 @@ func (h *GoLangHelper) DockerfileCopyCmds() []string {
 	}
 }
 
-func (lh *GoLangHelper) Entrypoint() string {
-	return "./func"
+func (lh *GoLangHelper) Entrypoint() (string, error) {
+	return "./func", nil
 }
 
 func (lh *GoLangHelper) HasBoilerplate() bool { return true }

--- a/langs/lambda_node.go
+++ b/langs/lambda_node.go
@@ -4,16 +4,20 @@ type LambdaNodeHelper struct {
 	BaseHelper
 }
 
-func (lh *LambdaNodeHelper) BuildFromImage() string {
-	return "fnproject/lambda:node-4"
+func (lh *LambdaNodeHelper) BuildFromImage() (string, error) {
+	return "fnproject/lambda:node-4", nil
+}
+
+func (lh *LambdaNodeHelper) RunFromImage() (string, error) {
+	return "fnproject/lambda:node-4", nil
 }
 
 func (lh *LambdaNodeHelper) IsMultiStage() bool {
 	return false
 }
 
-func (lh *LambdaNodeHelper) Cmd() string {
-	return "func.handler"
+func (lh *LambdaNodeHelper) Cmd() (string, error) {
+	return "func.handler", nil
 }
 
 func (h *LambdaNodeHelper) DockerfileBuildCmds() []string {

--- a/langs/node.go
+++ b/langs/node.go
@@ -4,15 +4,15 @@ type NodeLangHelper struct {
 	BaseHelper
 }
 
-func (lh *NodeLangHelper) BuildFromImage() string {
-	return "fnproject/node:dev"
+func (lh *NodeLangHelper) BuildFromImage() (string, error) {
+	return "fnproject/node:dev", nil
 }
-func (lh *NodeLangHelper) RunFromImage() string {
-	return "fnproject/node"
+func (lh *NodeLangHelper) RunFromImage() (string, error) {
+	return "fnproject/node", nil
 }
 
-func (lh *NodeLangHelper) Entrypoint() string {
-	return "node func.js"
+func (lh *NodeLangHelper) Entrypoint() (string, error) {
+	return "node func.js", nil
 }
 
 func (h *NodeLangHelper) DockerfileBuildCmds() []string {

--- a/langs/php.go
+++ b/langs/php.go
@@ -12,11 +12,16 @@ type PhpLangHelper struct {
 	BaseHelper
 }
 
-func (lh *PhpLangHelper) BuildFromImage() string {
-	return "fnproject/php:dev"
+func (lh *PhpLangHelper) BuildFromImage() (string, error) {
+	return "fnproject/php:dev", nil
 }
-func (lh *PhpLangHelper) Entrypoint() string {
-	return "php func.php"
+
+func (lh *PhpLangHelper) RunFromImage() (string, error) {
+	return "fnproject/php:dev", nil
+}
+
+func (lh *PhpLangHelper) Entrypoint() (string, error) {
+	return "php func.php", nil
 }
 
 func (lh *PhpLangHelper) HasPreBuild() bool {
@@ -37,7 +42,7 @@ func (lh *PhpLangHelper) PreBuild() error {
 	fmt.Println("Running prebuild command:", pbcmd)
 	parts := strings.Fields(pbcmd)
 	head := parts[0]
-	parts = parts[1:len(parts)]
+	parts = parts[1:]
 	cmd := exec.Command(head, parts...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout

--- a/langs/python.go
+++ b/langs/python.go
@@ -10,20 +10,20 @@ type PythonLangHelper struct {
 	Version string
 }
 
-func (lh *PythonLangHelper) BuildFromImage() string {
-	return fmt.Sprintf("fnproject/python:%v", lh.Version)
+func (lh *PythonLangHelper) BuildFromImage() (string, error) {
+	return fmt.Sprintf("fnproject/python:%v", lh.Version), nil
 }
 
-func (lh *PythonLangHelper) RunFromImage() string {
-	return fmt.Sprintf("fnproject/python:%v", lh.Version)
+func (lh *PythonLangHelper) RunFromImage() (string, error) {
+	return fmt.Sprintf("fnproject/python:%v", lh.Version), nil
 }
 
-func (lh *PythonLangHelper) Entrypoint() string {
+func (lh *PythonLangHelper) Entrypoint() (string, error) {
 	python := "python2"
 	if strings.HasPrefix(lh.Version, "3.6") {
 		python = "python3"
 	}
-	return fmt.Sprintf("%v func.py", python)
+	return fmt.Sprintf("%v func.py", python), nil
 }
 
 func (h *PythonLangHelper) DockerfileBuildCmds() []string {

--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -11,12 +11,12 @@ type RubyLangHelper struct {
 	BaseHelper
 }
 
-func (lh *RubyLangHelper) BuildFromImage() string {
-	return "fnproject/ruby:dev"
+func (lh *RubyLangHelper) BuildFromImage() (string, error) {
+	return "fnproject/ruby:dev", nil
 }
 
-func (lh *RubyLangHelper) RunFromImage() string {
-	return "fnproject/ruby"
+func (lh *RubyLangHelper) RunFromImage() (string, error) {
+	return "fnproject/ruby", nil
 }
 
 func (h *RubyLangHelper) DockerfileBuildCmds() []string {
@@ -37,8 +37,8 @@ func (h *RubyLangHelper) DockerfileCopyCmds() []string {
 	}
 }
 
-func (lh *RubyLangHelper) Entrypoint() string {
-	return "ruby func.rb"
+func (lh *RubyLangHelper) Entrypoint() (string, error) {
+	return "ruby func.rb", nil
 }
 
 func (lh *RubyLangHelper) HasBoilerplate() bool { return true }

--- a/langs/rust.go
+++ b/langs/rust.go
@@ -11,12 +11,12 @@ type RustLangHelper struct {
 	BaseHelper
 }
 
-func (lh *RustLangHelper) BuildFromImage() string {
-	return "rust:1"
+func (lh *RustLangHelper) BuildFromImage() (string, error) {
+	return "rust:1", nil
 }
 
-func (lh *RustLangHelper) RunFromImage() string {
-	return "debian:stretch"
+func (lh *RustLangHelper) RunFromImage() (string, error) {
+	return "debian:stretch", nil
 }
 
 func (lh *RustLangHelper) HasBoilerplate() bool { return true }
@@ -66,8 +66,8 @@ func (lh *RustLangHelper) GenerateBoilerplate() error {
 	return nil
 }
 
-func (lh *RustLangHelper) Entrypoint() string {
-	return "/function/func"
+func (lh *RustLangHelper) Entrypoint() (string, error) {
+	return "/function/func", nil
 }
 
 func (lh *RustLangHelper) DockerfileCopyCmds() []string {


### PR DESCRIPTION
Reason for PR: 

Fn builds are generally unpredictable as they depend on :latest images for build and run in most cases. 

If a language binding supports working out specific tags for build and run  then let it set that in build_image and runtime_image on fn init. 

