### PR TITLE
Lang helpers define what runtime's they can handle.

### DIFF
--- a/init.go
+++ b/init.go
@@ -223,7 +223,7 @@ func (a *initFnCmd) buildFuncFile(c *cli.Context) error {
 		helper = langs.GetLangHelper(a.Runtime)
 	}
 	if helper == nil {
-		fmt.Printf("Init does not support the %s runtime, you'll have to create your own Dockerfile for this function", a.Runtime)
+		fmt.Printf("Init does not support the %s runtime, you'll have to create your own Dockerfile for this function.\n", a.Runtime)
 	} else {
 		if a.Entrypoint == "" {
 			a.Entrypoint, err = helper.Entrypoint()

--- a/init.go
+++ b/init.go
@@ -32,28 +32,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var (
-	fileExtToRuntime = map[string]string{
-		".go":   "go",
-		".js":   "node",
-		".rb":   "ruby",
-		".py":   "python",
-		".php":  "php",
-		".rs":   "rust",
-		".cs":   "dotnet",
-		".fs":   "dotnet",
-		".java": "java",
-	}
-
-	fnInitRuntimes []string
-)
-
-func init() {
-	for rt := range fileExtToRuntime {
-		fnInitRuntimes = append(fnInitRuntimes, rt)
-	}
-}
-
 type initFnCmd struct {
 	force bool
 	funcfile
@@ -73,7 +51,7 @@ func initFlags(a *initFnCmd) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:        "runtime",
-			Usage:       "choose an existing runtime - " + strings.Join(fnInitRuntimes, ", "),
+			Usage:       "choose an existing runtime - " + langsList(),
 			Destination: &a.Runtime,
 		},
 		cli.StringFlag{
@@ -95,6 +73,18 @@ func initFlags(a *initFnCmd) []cli.Flag {
 	}
 
 	return append(fgs, routeFlags...)
+}
+
+func langsList() string {
+	// var b bytes.Buffer
+	// for _, h := range helpers {
+	// 	b.Write([]byte(h.))
+	// }
+	allLangs := []string{}
+	for _, h := range langs.Helpers() {
+		allLangs = append(allLangs, h.LangStrings()...)
+	}
+	return strings.Join(allLangs, ", ")
 }
 
 func initFn() cli.Command {
@@ -225,18 +215,17 @@ func (a *initFnCmd) buildFuncFile(c *cli.Context) error {
 		return errors.New("function file runtime is 'docker', but no Dockerfile exists")
 	}
 
-	var rt string
+	var helper langs.LangHelper
 	if a.Runtime == "" {
-		rt, err = detectRuntime(wd)
+		helper, err = detectRuntime(wd)
 		if err != nil {
 			return err
 		}
-		a.Runtime = rt
-		fmt.Printf("Found %v function, assuming %v runtime.\n", rt, rt)
+		fmt.Printf("Found %v function, assuming %v runtime.\n", helper.Runtime(), helper.Runtime())
 	} else {
 		fmt.Println("Runtime:", a.Runtime)
+		helper = langs.GetLangHelper(a.Runtime)
 	}
-	helper := langs.GetLangHelper(a.Runtime)
 	if helper == nil {
 		fmt.Printf("Init does not support the %s runtime, you'll have to create your own Dockerfile for this function", a.Runtime)
 	} else {
@@ -286,18 +275,21 @@ func (a *initFnCmd) buildFuncFile(c *cli.Context) error {
 	return nil
 }
 
-func detectRuntime(path string) (runtime string, err error) {
-	for ext, runtime := range fileExtToRuntime {
-		filenames := []string{
-			filepath.Join(path, fmt.Sprintf("func%s", ext)),
-			filepath.Join(path, fmt.Sprintf("Func%s", ext)),
-			filepath.Join(path, fmt.Sprintf("src/main%s", ext)), // rust
+func detectRuntime(path string) (langs.LangHelper, error) {
+	for _, h := range langs.Helpers() {
+		filenames := []string{}
+		for _, ext := range h.Extensions() {
+			filenames = append(filenames,
+				filepath.Join(path, fmt.Sprintf("func%s", ext)),
+				filepath.Join(path, fmt.Sprintf("Func%s", ext)),
+				filepath.Join(path, fmt.Sprintf("src/main%s", ext)), // rust
+			)
 		}
 		for _, filename := range filenames {
 			if exists(filename) {
-				return runtime, nil
+				return h, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("no supported files found to guess runtime, please set runtime explicitly with --runtime flag")
+	return nil, fmt.Errorf("no supported files found to guess runtime, please set runtime explicitly with --runtime flag")
 }

--- a/init.go
+++ b/init.go
@@ -76,10 +76,6 @@ func initFlags(a *initFnCmd) []cli.Flag {
 }
 
 func langsList() string {
-	// var b bytes.Buffer
-	// for _, h := range helpers {
-	// 	b.Write([]byte(h.))
-	// }
 	allLangs := []string{}
 	for _, h := range langs.Helpers() {
 		allLangs = append(allLangs, h.LangStrings()...)

--- a/langs/base.go
+++ b/langs/base.go
@@ -6,6 +6,32 @@ import (
 	"os"
 )
 
+// not a map because some helpers can handle multiple keys
+var helpers = []LangHelper{}
+
+func init() {
+	registerHelper(&DotNetLangHelper{})
+	registerHelper(&GoLangHelper{})
+	registerHelper(&JavaLangHelper{version: "1.8"})
+	registerHelper(&JavaLangHelper{version: "9"})
+	registerHelper(&LambdaNodeHelper{})
+	registerHelper(&NodeLangHelper{})
+	registerHelper(&PhpLangHelper{})
+	registerHelper(&PythonLangHelper{Version: "2.7.13"})
+	registerHelper(&PythonLangHelper{Version: "3.6"})
+	registerHelper(&RubyLangHelper{})
+	registerHelper(&RustLangHelper{})
+
+}
+
+func registerHelper(h LangHelper) {
+	helpers = append(helpers, h)
+}
+
+func Helpers() []LangHelper {
+	return helpers
+}
+
 //used to indicate the default supported version of java
 const defaultJavaSupportedVersion = "9"
 
@@ -15,38 +41,24 @@ var (
 
 // GetLangHelper returns a LangHelper for the passed in language
 func GetLangHelper(lang string) LangHelper {
-	switch lang {
-	case "go":
-		return &GoLangHelper{}
-	case "node":
-		return &NodeLangHelper{}
-	case "ruby":
-		return &RubyLangHelper{}
-	case "python":
-		return &PythonLangHelper{Version: "2.7.13"}
-	case "python2.7":
-		return &PythonLangHelper{Version: "2.7.13"}
-	case "python3.6":
-		return &PythonLangHelper{Version: "3.6"}
-	case "php":
-		return &PhpLangHelper{}
-	case "rust":
-		return &RustLangHelper{}
-	case "dotnet":
-		return &DotNetLangHelper{}
-	case "lambda-nodejs4.3", "lambda-node-4":
-		return &LambdaNodeHelper{}
-	case "java":
-		return &JavaLangHelper{version: defaultJavaSupportedVersion}
-	case "java8":
-		return &JavaLangHelper{version: "1.8"}
-	case "java9":
-		return &JavaLangHelper{version: "9"}
+	for _, h := range helpers {
+		if h.Handles(lang) {
+			return h
+		}
 	}
 	return nil
 }
 
+// LangHelper is the interface that language helpers must implement.
 type LangHelper interface {
+	// Handles return whether it can handle the passed in lang string or not
+	Handles(string) bool
+	// LangStrings returns list of supported language strings user can use for runtime
+	LangStrings() []string
+	// Extension is the file extension this helper supports. Eg: .java, .go, .js
+	Extensions() []string
+	// Runtime that will be used for the build (includes version)
+	Runtime() string
 	// BuildFromImage is the base image to build off, typically fnproject/LANG:dev
 	BuildFromImage() (string, error)
 	// RunFromImage is the base image to use for deployment (usually smaller than the build images)
@@ -73,6 +85,15 @@ type LangHelper interface {
 	GenerateBoilerplate() error
 	// FixImagesOnInit determines if images should be fixed on initialization - BuildFromImage and RunFromImage will be written to func.yaml
 	FixImagesOnInit() bool
+}
+
+func defaultHandles(h LangHelper, lang string) bool {
+	for _, s := range h.LangStrings() {
+		if lang == s {
+			return true
+		}
+	}
+	return false
 }
 
 // BaseHelper is empty implementation of LangHelper for embedding in implementations.

--- a/langs/base.go
+++ b/langs/base.go
@@ -32,9 +32,6 @@ func Helpers() []LangHelper {
 	return helpers
 }
 
-//used to indicate the default supported version of java
-const defaultJavaSupportedVersion = "9"
-
 var (
 	ErrBoilerplateExists = errors.New("Function boilerplate already exists")
 )

--- a/langs/dotnet.go
+++ b/langs/dotnet.go
@@ -9,6 +9,19 @@ type DotNetLangHelper struct {
 	BaseHelper
 }
 
+func (h *DotNetLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *DotNetLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *DotNetLangHelper) LangStrings() []string {
+	return []string{"dotnet"}
+}
+func (lh *DotNetLangHelper) Extensions() []string {
+	return []string{".cs", ".fs"}
+}
 func (lh *DotNetLangHelper) BuildFromImage() (string, error) {
 	return "microsoft/dotnet:1.0.1-sdk-projectjson", nil
 }

--- a/langs/go.go
+++ b/langs/go.go
@@ -10,6 +10,20 @@ type GoLangHelper struct {
 	BaseHelper
 }
 
+func (h *GoLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *GoLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *GoLangHelper) LangStrings() []string {
+	return []string{"go"}
+}
+func (lh *GoLangHelper) Extensions() []string {
+	return []string{".go"}
+}
+
 func (lh *GoLangHelper) BuildFromImage() (string, error) {
 	return "fnproject/go:dev", nil
 }

--- a/langs/java.go
+++ b/langs/java.go
@@ -16,8 +16,32 @@ import (
 // JavaLangHelper provides a set of helper methods for the lifecycle of Java Maven projects
 type JavaLangHelper struct {
 	BaseHelper
-	version      string
+	version          string
 	latestFdkVersion string
+}
+
+func (h *JavaLangHelper) Handles(lang string) bool {
+	for _, s := range h.LangStrings() {
+		if lang == s {
+			return true
+		}
+	}
+	return false
+}
+func (h *JavaLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+// TOOD: same as python, I think we should just have version tags on the single runtime, eg: `java:8` or `java:9`
+func (lh *JavaLangHelper) LangStrings() []string {
+	if lh.version == "1.8" {
+		return []string{"java8"}
+	}
+	return []string{"java9", "java"}
+
+}
+func (lh *JavaLangHelper) Extensions() []string {
+	return []string{".java"}
 }
 
 // BuildFromImage returns the Docker image used to compile the Maven function project

--- a/langs/lambda_node.go
+++ b/langs/lambda_node.go
@@ -14,8 +14,10 @@ func (h *LambdaNodeHelper) Runtime() string {
 func (lh *LambdaNodeHelper) LangStrings() []string {
 	return []string{"lambda-nodejs4.3", "lambda-node-4"}
 }
+
+// This shouldn't match any auto-detection so returning empty slice here
 func (lh *LambdaNodeHelper) Extensions() []string {
-	return []string{".py"}
+	return []string{}
 }
 
 func (lh *LambdaNodeHelper) BuildFromImage() (string, error) {

--- a/langs/lambda_node.go
+++ b/langs/lambda_node.go
@@ -4,6 +4,20 @@ type LambdaNodeHelper struct {
 	BaseHelper
 }
 
+func (h *LambdaNodeHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *LambdaNodeHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *LambdaNodeHelper) LangStrings() []string {
+	return []string{"lambda-nodejs4.3", "lambda-node-4"}
+}
+func (lh *LambdaNodeHelper) Extensions() []string {
+	return []string{".py"}
+}
+
 func (lh *LambdaNodeHelper) BuildFromImage() (string, error) {
 	return "fnproject/lambda:node-4", nil
 }

--- a/langs/node.go
+++ b/langs/node.go
@@ -4,6 +4,21 @@ type NodeLangHelper struct {
 	BaseHelper
 }
 
+func (h *NodeLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *NodeLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *NodeLangHelper) LangStrings() []string {
+	return []string{"node"}
+}
+func (lh *NodeLangHelper) Extensions() []string {
+	// this won't be chosen by default
+	return []string{}
+}
+
 func (lh *NodeLangHelper) BuildFromImage() (string, error) {
 	return "fnproject/node:dev", nil
 }

--- a/langs/php.go
+++ b/langs/php.go
@@ -12,6 +12,20 @@ type PhpLangHelper struct {
 	BaseHelper
 }
 
+func (h *PhpLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *PhpLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *PhpLangHelper) LangStrings() []string {
+	return []string{"php"}
+}
+func (lh *PhpLangHelper) Extensions() []string {
+	return []string{".php"}
+}
+
 func (lh *PhpLangHelper) BuildFromImage() (string, error) {
 	return "fnproject/php:dev", nil
 }

--- a/langs/python.go
+++ b/langs/python.go
@@ -10,6 +10,24 @@ type PythonLangHelper struct {
 	Version string
 }
 
+func (h *PythonLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *PythonLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+// TODO: I feel like this whole versioning thing here could be done better. eg: `runtime: python:2` where we have a single lang, but support versions in tags (like docker tags).
+func (lh *PythonLangHelper) LangStrings() []string {
+	if strings.HasPrefix(lh.Version, "3.6") {
+		return []string{"python3.6"}
+	}
+	return []string{"python", "python2.7"}
+}
+func (lh *PythonLangHelper) Extensions() []string {
+	return []string{".py"}
+}
+
 func (lh *PythonLangHelper) BuildFromImage() (string, error) {
 	return fmt.Sprintf("fnproject/python:%v", lh.Version), nil
 }

--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -11,6 +11,20 @@ type RubyLangHelper struct {
 	BaseHelper
 }
 
+func (h *RubyLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *RubyLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+
+func (lh *RubyLangHelper) LangStrings() []string {
+	return []string{"ruby"}
+}
+func (lh *RubyLangHelper) Extensions() []string {
+	return []string{".rb"}
+}
+
 func (lh *RubyLangHelper) BuildFromImage() (string, error) {
 	return "fnproject/ruby:dev", nil
 }

--- a/langs/rust.go
+++ b/langs/rust.go
@@ -11,6 +11,19 @@ type RustLangHelper struct {
 	BaseHelper
 }
 
+func (h *RustLangHelper) Handles(lang string) bool {
+	return defaultHandles(h, lang)
+}
+func (h *RustLangHelper) Runtime() string {
+	return h.LangStrings()[0]
+}
+func (lh *RustLangHelper) LangStrings() []string {
+	return []string{"rust"}
+}
+func (lh *RustLangHelper) Extensions() []string {
+	return []string{".rs"}
+}
+
 func (lh *RustLangHelper) BuildFromImage() (string, error) {
 	return "rust:1", nil
 }

--- a/main.go
+++ b/main.go
@@ -36,34 +36,24 @@ func newFn() *cli.App {
 	app.Version = Version
 	app.Authors = []cli.Author{{Name: "Fn Project"}}
 	app.Description = "Fn command line tool"
-	app.UsageText = `Check the docs at https://github.com/fnproject/fn/blob/master/fn/README.md`
-
 	cli.AppHelpTemplate = `{{.Name}} {{.Version}}{{if .Description}}
 
 {{.Description}}{{end}}
 
-USAGE:
-   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}{{if .Commands}} command [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}
-
 ENVIRONMENT VARIABLES:
    FN_API_URL - Fn server address
-   FN_REGISTRY - Docker registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]treeder]{{if .VisibleCommands}}
+   FN_REGISTRY - Docker registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]USERNAME]{{if .VisibleCommands}}
 
 COMMANDS:{{range .VisibleCategories}}{{if .Name}}
    {{.Name}}:{{end}}{{range .VisibleCommands}}
      {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{if .VisibleFlags}}
 
-ALIASES:
-     build    (images build)
-     bump     (images bump)
-     deploy   (images deploy)
-     run      (images run)
-     call     (routes call)
-     push     (images push)
-
 GLOBAL OPTIONS:
    {{range $index, $option := .VisibleFlags}}{{if $index}}
    {{end}}{{$option}}{{end}}{{end}}
+
+LEARN MORE:
+   https://github.com/fnproject/fn
 `
 
 	app.CommandNotFound = func(c *cli.Context, cmd string) {

--- a/main_test.go
+++ b/main_test.go
@@ -111,10 +111,10 @@ func checkInit(t *testing.T, testdir, version, bin string) {
 
 	_, err = exec.Command(bin, "init", runtime).CombinedOutput()
 	if err != nil {
-		t.Errorf("ERROR: Failed to run fn init with --runtime=java%s", version)
+		t.Errorf("ERROR: Failed to run fn init with --runtime=java%s. err: %v", version, err)
 	}
 
 	if _, err = os.Stat(fmt.Sprintf("%s/src/main", testdir)); err != nil && os.IsNotExist(err) {
-		t.Errorf("ERROR: failed to create java project with --runtime=java%s", version)
+		t.Errorf("ERROR: failed to create java project with --runtime=java%s. err: %v", version, err)
 	}
 }


### PR DESCRIPTION
This helps with various issues/discrepancies so we don't have to maintain things in various places. Now the lang helpers decide what runtime strings they can handle. 

This is a somewhat annoying change as it adds a few extra methods to LangHelper which is already getting a bit out of control. Should think of a nicer way to do LangHelpers at some point. 

Closes #112, #64, #104, #78 

