### PR TITLE
Adds --privileged flag to fn start

### DIFF
--- a/start.go
+++ b/start.go
@@ -45,6 +45,7 @@ func start(c *cli.Context) error {
 		"-v", fmt.Sprintf("%s/data:/app/data", wd),
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-p", "8080:8080",
+		"--privileged",
 	}
 	for _, v := range denvs {
 		args = append(args, "-e", v)


### PR DESCRIPTION
Trying to cleanup the warnings/errors on startup, using privileged flag fixes most of it. Goes from this:

```sh
mount: permission denied (are you root?)
Could not mount /sys/kernel/security.
AppArmor detection and --privileged mode might break.
mount: permission denied (are you root?)
time="2017-12-14T17:44:55Z" level=info msg="datastore dialed" datastore=sqlite3 max_idle_connections=256
time="2017-12-14T17:44:55Z" level=info msg="started tracer" url=
time="2017-12-14T17:44:55Z" level=info msg="no docker auths from config files found (this is fine)" error="open /root/.dockercfg: no such file or directory"
time="2017-12-14T17:44:55Z" level=info msg="available memory" availMemory=1487618048 cgroupLimit=9223372036854771712 headRoom=268435456 totalMemory=1756053504
time="2017-12-14T17:44:55Z" level=info msg="sync and async reservations" ramAsync=1190094439 ramAsyncHWMark=952075551 ramSync=297523609
time="2017-12-14T17:44:55Z" level=info msg="Serving Functions API on address `:8080`"

        ______
       / ____/___
      / /_  / __ \
     / __/ / / / /
    /_/   /_/ /_/
        v0.3.216
```

to this:

```sh
can't create unix socket /var/run/docker.sock: device or resource busy
time="2017-12-14T21:15:57Z" level=info msg="datastore dialed" datastore=sqlite3 max_idle_connections=256
time="2017-12-14T21:15:57Z" level=info msg="started tracer" url=
time="2017-12-14T21:15:57Z" level=info msg="no docker auths from config files found (this is fine)" error="open /root/.dockercfg: no such file or directory"
time="2017-12-14T21:15:57Z" level=info msg="available memory" availMemory=1490137088 cgroupLimit=9223372036854771712 headRoom=268435456 totalMemory=1758572544
time="2017-12-14T21:15:57Z" level=info msg="sync and async reservations" ramAsync=1192109671 ramAsyncHWMark=953687736 ramSync=298027417

        ______
       / ____/___
      / /_  / __ \
     / __/ / / / /
    /_/   /_/ /_/
        v0.3.216
```
