### PR TITLE
Allow port number in FN_REGISTRY for private registry support

### DIFF
--- a/common.go
+++ b/common.go
@@ -331,15 +331,16 @@ func dockerPush(ff *funcfile) error {
 	return nil
 }
 
+// validateImageName validates that the full image name (FN_REGISTRY/name:tag) is allowed for push
+// remember that private registries must be supported here
 func validateImageName(n string) error {
-	// must have at least owner name and a tag
-	split := strings.Split(n, ":")
-	if len(split) < 2 {
-		return errors.New("image name must have a tag")
+	parts := strings.Split(n, "/")
+	if len(parts) < 2 {
+		return errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var or pass in --registry")
 	}
-	split2 := strings.Split(split[0], "/")
-	if len(split2) < 2 {
-		return errors.New("image name must have an owner and name, eg: username/myfunc. Be sure to set FN_REGISTRY env var or pass in --registry.")
+	lastParts := strings.Split(parts[len(parts)-1], ":")
+	if len(lastParts) != 2 {
+		return errors.New("image name must have a tag")
 	}
 	return nil
 }

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestValidateImageName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		expectedErr string
+	}{
+		{name: "docker.io/sally/img:0.0.1", expectedErr: ""},
+		{name: "sally/img:0.0.1", expectedErr: ""},
+		{name: "img:0.0.1", expectedErr: "image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var or pass in --registry"},
+		{name: "owner/img", expectedErr: "image name must have a tag"},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			errString := ""
+			if err := validateImageName(c.name); err != nil {
+				errString = err.Error()
+			}
+			if c.expectedErr != errString {
+				t.Fatalf("expected %s but got %s", c.expectedErr, errString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #69.

After the discussion in https://github.com/fnproject/cli/pull/72 it looks like any heavy name validation will be moved to server side. However this doesn't fix the issue of the validateImageName implementation blocking port numbers in the image prefix. This PR just makes that function a bit more flexible and allows people to move forward with custom private registry paths and the like.

This now supports FN_REGISTRY being anything like:

- `owner` (for docker.io)
- `hostname.com` (for custom registry)
- `hostname.com:port` (for custom registry on custom port)
- `hostname.com/owner` (for owner in custom registry)

Docker push automatically works out when you're talking about a custom registry or an owner in docker.io by matching on the first part of the full image name. (see https://github.com/docker/distribution/blob/master/reference/normalize.go#L33)