### PR TITLE
Fixed envvar name for fn start and tweak to help text

### DIFF
--- a/start.go
+++ b/start.go
@@ -19,14 +19,14 @@ func startCmd() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "log-level",
-				Usage: "--log-level DEBUG to enable debugging",
+				Usage: "--log-level=debug to enable debugging",
 			},
 			cli.BoolFlag{
 				Name:  "detach, d",
 				Usage: "Run container in background.",
 			},
 			cli.StringFlag{
-				Name: "env-file",
+				Name:  "env-file",
 				Usage: "Path to Fn server configuration file.",
 			},
 		},
@@ -46,9 +46,9 @@ func start(c *cli.Context) error {
 		"-p", "8080:8080",
 	}
 	if c.String("log-level") != "" {
-		args = append(args, "-e", fmt.Sprintf("GIN_MODE=%v", c.String("log-level")))
+		args = append(args, "-e", fmt.Sprintf("FN_LOG_LEVEL=%v", c.String("log-level")))
 	}
-	if c.String("env-file") != ""{
+	if c.String("env-file") != "" {
 		args = append(args, "--env-file", c.String("env-file"))
 	}
 	if c.Bool("detach") {

--- a/start.go
+++ b/start.go
@@ -19,7 +19,7 @@ func startCmd() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "log-level",
-				Usage: "--log-level=debug to enable debugging",
+				Usage: "--log-level debug to enable debugging",
 			},
 			cli.BoolFlag{
 				Name:  "detach, d",


### PR DESCRIPTION
Fixes #139 and https://github.com/fnproject/fn/issues/655.

- help text was incorrect
- envvar passed to Docker container was incorrect
  