### PR TITLE
fixes registry logic for case:

### DIFF
--- a/funcfile.go
+++ b/funcfile.go
@@ -72,8 +72,10 @@ type funcfile struct {
 
 func (ff *funcfile) ImageName() string {
 	fname := ff.Name
-	if !strings.Contains(fname, "/") {
-		// then we'll prefix FN_REGISTRY
+
+	// prefix FN_REGISTRY, if provided (important) AND if the image does not
+	// itself contain a registry.
+	if len(strings.SplitN(fname, "/", 3)) < 3 {
 		reg := os.Getenv(envFnRegistry)
 		if reg != "" {
 			if reg[len(reg)-1] != '/' {


### PR DESCRIPTION
previously, we if the following value for FN_REGISTRY was provided, we ignored
it if the image contained a slash, see example:

(`func.yaml` has `image: rdallman/yodawg`)

``sh
$ FN_REGISTRY=localhost:5000/ cli deploy --app myapp
Deploying rdallman/yodawg to app: myapp at path: /hello
Bumped to version 0.0.7
Building image rdallman/yodawg:0.0.7 ...
Pushing rdallman/yodawg:0.0.7 to docker registry...The push refers to a repository [docker.io/rdallman/yodawg]
```

with this patch, it's fixed:

```sh
$ FN_REGISTRY=localhost:5000/ cli deploy --app myapp
Deploying rdallman/yodawg to app: myapp at path: /hello
Bumped to version 0.0.11
Building image localhost:5000/rdallman/yodawg:0.0.11 .
Pushing localhost:5000/rdallman/yodawg:0.0.11 to docker registry...The push refers to a repository [localhost:5000/rdallman/yodawg]
```

this does mean that anyone relying on the logic of their image having a slash
in it not using an FN_REGISTRY they provided (seems odd) will be broken, the
code kind of implies this was the case but maybe not. anyway, this behavior
seems like what we want, i.e. 'if a REGISTRY_URL is provided, prepend it to
everything unless it's a fully qualified image that specifies a registry URL
itself'. to enumerate:

FN_REGISTRY!="" && image=="yodawg"                  -> image = FN_REGISTRY || image
FN_REGISTRY!="" && image=="yo/dawg"                 -> image = FN_REGISTRY || image
FN_REGISTRY!="" && image=="localhost:5000/yo/dawg"  -> image = image

of course, if FN_REGISTRY is not provided, the image is not modified. shame
this thing exists :(