### PR TITLE
cli: fn start does not use dind, but does not disable entrypoint

### DIFF
--- a/start.go
+++ b/start.go
@@ -44,6 +44,7 @@ func start(c *cli.Context) error {
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"--privileged",
 		"-p", "8080:8080",
+		"--entry-point ./fnserver",
 	}
 	if c.String("log-level") != "" {
 		args = append(args, "-e", fmt.Sprintf("FN_LOG_LEVEL=%v", c.String("log-level")))


### PR DESCRIPTION
The stock entry point script attempts to start dockerd, which
fails with:

can't create unix socket /var/run/docker.sock: device or resource busy.

Instead, we override entrypoint to avoid dockerd start (disable dind).