### PR TITLE
Dont treat registry ports badly when cleaning image name during Bump

### DIFF
--- a/bump.go
+++ b/bump.go
@@ -135,10 +135,14 @@ func bumpVersion(funcfile *funcfile, t VType) (*funcfile, error) {
 	return funcfile, nil
 }
 
+// cleanImageName is intended to remove any trailing tag from the image name
+// since the version field conveys this information. More cleanup could be done
+// here in future if necessary.
 func cleanImageName(name string) string {
-	if i := strings.Index(name, ":"); i != -1 {
-		name = name[:i]
+	slashParts := strings.Split(name, "/")
+	l := len(slashParts) - 1
+	if i := strings.Index(slashParts[l], ":"); i > -1 {
+		slashParts[l] = slashParts[l][:i]
 	}
-
-	return name
+	return strings.Join(slashParts, "/")
 }

--- a/bump_test.go
+++ b/bump_test.go
@@ -60,3 +60,22 @@ func verifyVersion(tmp, version string) error {
 	}
 	return nil
 }
+
+func TestCleanImageName(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"someimage:latest", "someimage"},
+		{"repository/image/name:latest", "repository/image/name"},
+		{"repository:port/image/name:latest", "repository:port/image/name"},
+	}
+	for _, c := range testCases {
+		t.Run(c.input, func(t *testing.T) {
+			output := cleanImageName(c.input)
+			if output != c.expected {
+				t.Fatalf("Expected '%s' but got '%s'", c.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #151;

Fixed the cleanImageName function here.

### Behaviour before:

```
$ cat func.yaml
name: localhost:5000/rdallman/hotyodawg
version: 0.0.3
runtime: go
entrypoint: ./func
$ ../fn bump
Bumped to version 0.0.4
$ cat func.yaml
name: localhost
version: 0.0.4
runtime: go
entrypoint: ./func
```

### Behaviour after:

```
$ cat func.yaml
name: localhost
version: 0.0.4
runtime: go
entrypoint: ./func
$ ../fn bump
Bumped to version 0.0.5
$ cat func.yaml
name: localhost:5000/rdallman/hotyodawg
version: 0.0.5
runtime: go
entrypoint: ./func
```