### PR TITLE
Upper case validation

### DIFF
--- a/build.go
+++ b/build.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/urfave/cli"
 )
@@ -48,10 +47,6 @@ func (b *buildcmd) build(c *cli.Context) error {
 	fpath, ff, err := findAndParseFuncfile(path)
 	if err != nil {
 		return err
-	}
-	// get name from directory if it's not defined
-	if ff.Name == "" {
-		ff.Name = filepath.Base(filepath.Dir(fpath)) // todo: should probably make a copy of ff before changing it
 	}
 
 	ff, err = buildfunc(c, fpath, ff, b.noCache)

--- a/init.go
+++ b/init.go
@@ -215,7 +215,7 @@ func (a *initFnCmd) buildFuncFile(c *cli.Context) error {
 
 	if a.ff.Name == "" {
 		// then defaults to current directory for name, the name must be lowercase
-		a.ff.Name = strings.ToLower(filepath.Base(filepath.Dir(wd)))
+		a.ff.Name = strings.ToLower(filepath.Base(wd))
 	}
 
 	if err = validateFuncName(a.ff.Name); err != nil {

--- a/init_test.go
+++ b/init_test.go
@@ -55,3 +55,18 @@ func TestInit(t *testing.T) {
 		t.Errorf("no entrypoint found in generated %s", ffname)
 	}
 }
+
+func funcNameValidation(name string, t *testing.T) {
+	err := validateFuncName("fooFunc")
+	if err == nil {
+		t.Error("Expected validation error for function name")
+	}
+}
+
+func TestFuncNameWithUpperCase(t *testing.T) {
+	funcNameValidation("fooFunc", t)
+}
+
+func TestFuncNameWithColon(t *testing.T) {
+	funcNameValidation("foo:func", t)
+}

--- a/init_test.go
+++ b/init_test.go
@@ -64,9 +64,9 @@ func funcNameValidation(name string, t *testing.T) {
 }
 
 func TestFuncNameWithUpperCase(t *testing.T) {
-	funcNameValidation("fooFunc", t)
+	funcNameValidation("fooMyFunc", t)
 }
 
 func TestFuncNameWithColon(t *testing.T) {
-	funcNameValidation("foo:func", t)
+	funcNameValidation("foo:myfunc", t)
 }


### PR DESCRIPTION
This change checks that the name of the function passed as parameter with the `--name` option is lowercase.
If a name is not specified the default function name will be the (lowercase) name of the current folder.