### PR TITLE
fn start use --net=host

### DIFF
--- a/start.go
+++ b/start.go
@@ -44,6 +44,7 @@ func start(c *cli.Context) error {
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"--privileged",
 		"-p", "8080:8080",
+		"--net", "host",
 		"--entrypoint", "./fnserver",
 	}
 	if c.String("log-level") != "" {


### PR DESCRIPTION
users are running private registries or other services locally on their
machines and trying to test functions that hit them. `fn start` is 'magic' and
by default these services are not easily addressed without running a docker
command that links to them or otherwise making them accessible from within the
`fn` container. `--net=host` will make `fn start` feel more like a 'local'
experience, since `fn start` is for dev, using docker networking stuff for
security be damned.

fixes https://github.com/fnproject/fn/issues/699