### PR TITLE
remove --net=host doesn't work on osx

### DIFF
--- a/start.go
+++ b/start.go
@@ -44,7 +44,6 @@ func start(c *cli.Context) error {
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"--privileged",
 		"-p", "8080:8080",
-		"--net", "host",
 		"--entrypoint", "./fnserver",
 	}
 	if c.String("log-level") != "" {


### PR DESCRIPTION
closes #166 

it would be nice if we could do something akin to this to prevent more feet being shot at