### PR TITLE
Changes order of things in Dockerfile for Go.

### DIFF
--- a/langs/go.go
+++ b/langs/go.go
@@ -42,18 +42,22 @@ func (h *GoLangHelper) DockerfileBuildCmds() []string {
 	r := []string{}
 	// more info on Go multi-stage builds: https://medium.com/travis-on-docker/multi-stage-docker-builds-for-creating-tiny-go-images-e0e1867efe5a
 	// TODO: if we keep the Gopkg.lock on user's drive, we can put this after the dep commands and then the dep layers will be cached.
-	r = append(r, "ADD . /go/src/func/")
 	vendor := exists("vendor/")
 	// skip dep tool install if vendor is there
 	if !vendor {
 		if exists("Gopkg.toml") {
 			r = append(r, "RUN go get -u github.com/golang/dep/cmd/dep")
 			if exists("Gopkg.lock") {
+				r = append(r, "ADD Gopkg.* /go/src/func/")
 				r = append(r, "RUN cd /go/src/func/ && dep ensure --vendor-only")
+				r = append(r, "ADD . /go/src/func/")
 			} else {
+				r = append(r, "ADD . /go/src/func/")
 				r = append(r, "RUN cd /go/src/func/ && dep ensure")
 			}
 		}
+	} else {
+		r = append(r, "ADD . /go/src/func/")
 	}
 
 	r = append(r, "RUN cd /go/src/func/ && go build -o func")


### PR DESCRIPTION
Rearranged dep commands to try to be faster. 

Still should make it generate the lock file and keep it on the user's disk to speed it up even more. 