### PR TITLE
Expanded build instructions for CLI and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,75 @@
 
+# Contributing to Fn CLI
 
-Run `make install` to build and install to local machine for easy testing. 
+We welcome all contributions
+
+## How to contribute
+
+1. Fork the repo
+2. Fix an issue or create an issue and fix it
+3. Create a Pull Request that fixes the issue
+4. Sign the [CLA](http://www.oracle.com/technetwork/community/oca-486395.html)
+5. Once processed, our CLA bot will automatically clear the CLA check on the PR
+6. Good Job! Thanks for being awesome!
+
+## Documentation
+
+When creating a Pull Request, make sure that you also update the documentation
+accordingly.
+
+Most of the time, when making some behavior more explicit or adding a feature,
+documentation update is necessary.
+
+You will either update a file inside docs/ or create one. Prefer the former over
+the latter. If you are unsure, do not hesitate to open a PR with a comment
+asking for suggestions on how to address the documentation part.
+
+## How to build and get up and running ##
+
+### Build Dependencies ###
+- [Go](https://golang.org/doc/install)
+- [Dep](https://github.com/golang/dep)
+
+### Cloning the Repository ###
+
+Whether cloning from your Fn CLI repo or your own fork, you need to take care with the location.
+
+`$ mkdir $GOPATH/src/github.com/fnproject/cli `
+
+`$ cd $GOPATH/src/github.com/fnproject/cli `
+
+Then you can either
+
+1. Clone from the Fn CLI repo:
+
+	`$ git clone https://github.com/fnproject/cli.git`
+
+2. Clone from your own fork:
+
+	`$ git clone git@github.com:<YOUR-GITHUB_USERNAME>/cli.git`
+
+### Building ###
+
+1.  Change to the correct directory (if not already there):
+
+	`$ cd $GOPATH/src/github.com/fnproject/cli`
+
+2.  Download required Go package dependencies:
+
+	`$ make dep`
+
+3.  Build and install:
+
+	`$ make install`
+
+### Testing ###
+
+To test that you're client has built correctly:
+
+`$ fn --version`
+
+It should return something like:
+
+`fn version 0.4.57`
+
+Congratulations! You're all set :-)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 curl -LSs https://raw.githubusercontent.com/fnproject/cli/master/install | sh
 ```
 
+## Build from source
+
+See [CONTRIBUTING](https://github.com/fnproject/cli/blob/master/CONTRIBUTING.md) for instructions to build the CLI from source.
+
 ## Quickstart
 
 See the Fn [Quickstart](https://github.com/fnproject/fn/blob/master/README.md) for sample commands.


### PR DESCRIPTION
CONTRIBUTING.MD:
- Copied "how to contribute" from fn (core) CONTRIBUTING.md
- Added detailed instructions on how to build from source

README.md
- Added link to CONTRIBUTING.md for build from source instructions.