### PR TITLE
don't extract message from 'default' errors

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -133,13 +133,8 @@ func (a *appsCmd) list(c *cli.Context) error {
 			switch e := err.(type) {
 			case *apiapps.GetAppsAppNotFound:
 				return fmt.Errorf("%v", e.Payload.Error.Message)
-			case *apiapps.GetAppsAppDefault:
-				return fmt.Errorf("%v", e.Payload.Error.Message)
-			case *apiapps.GetAppsDefault:
-				// this is the one getting called, not sure what the one above is?
-				return fmt.Errorf("%v", e.Payload.Error.Message)
 			default:
-				return fmt.Errorf("%v", err)
+				return err
 			}
 		}
 
@@ -187,10 +182,8 @@ func (a *appsCmd) create(c *cli.Context) error {
 			return fmt.Errorf("%v", e.Payload.Error.Message)
 		case *apiapps.PostAppsConflict:
 			return fmt.Errorf("%v", e.Payload.Error.Message)
-		case *apiapps.PostAppsDefault:
-			return fmt.Errorf("%v", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -306,10 +299,8 @@ func (a *appsCmd) patchApp(appName string, app *models.App) error {
 			return errors.New(e.Payload.Error.Message)
 		case *apiapps.PatchAppsAppNotFound:
 			return errors.New(e.Payload.Error.Message)
-		case *apiapps.PatchAppsAppDefault:
-			return errors.New(e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -333,10 +324,8 @@ func (a *appsCmd) inspect(c *cli.Context) error {
 		switch e := err.(type) {
 		case *apiapps.GetAppsAppNotFound:
 			return fmt.Errorf("%v", e.Payload.Error.Message)
-		case *apiapps.GetAppsAppDefault:
-			return fmt.Errorf("%v", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -385,10 +374,8 @@ func (a *appsCmd) delete(c *cli.Context) error {
 		switch e := err.(type) {
 		case *apiapps.DeleteAppsAppNotFound:
 			return errors.New(e.Payload.Error.Message)
-		case *apiapps.DeleteAppsAppDefault:
-			return errors.New(e.Payload.Error.Message)
 		}
-		return fmt.Errorf("%v", err)
+		return err
 	}
 
 	fmt.Println("App", appName, "deleted")

--- a/routes.go
+++ b/routes.go
@@ -214,8 +214,6 @@ func (a *routesCmd) list(c *cli.Context) error {
 			switch e := err.(type) {
 			case *apiroutes.GetAppsAppRoutesNotFound:
 				return fmt.Errorf("%s", e.Payload.Error.Message)
-			case *apiroutes.GetAppsAppRoutesDefault:
-				return fmt.Errorf("%s", e.Payload.Error.Message)
 			default:
 				return err
 			}
@@ -384,10 +382,8 @@ func (a *routesCmd) postRoute(c *cli.Context, appName string, rt *fnmodels.Route
 			return fmt.Errorf("%s", e.Payload.Error.Message)
 		case *apiroutes.PostAppsAppRoutesConflict:
 			return fmt.Errorf("%s", e.Payload.Error.Message)
-		case *apiroutes.PostAppsAppRoutesDefault:
-			return fmt.Errorf("%s", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -416,10 +412,8 @@ func (a *routesCmd) patchRoute(c *cli.Context, appName, routePath string, r *fnm
 			return fmt.Errorf("%s", e.Payload.Error.Message)
 		case *apiroutes.PatchAppsAppRoutesRouteNotFound:
 			return fmt.Errorf("%s", e.Payload.Error.Message)
-		case *apiroutes.PatchAppsAppRoutesRouteDefault:
-			return fmt.Errorf("%s", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -437,10 +431,8 @@ func (a *routesCmd) putRoute(c *cli.Context, appName, routePath string, r *fnmod
 		switch e := err.(type) {
 		case *apiroutes.PutAppsAppRoutesRouteBadRequest:
 			return fmt.Errorf("%s", e.Payload.Error.Message)
-		case *apiroutes.PutAppsAppRoutesRouteDefault:
-			return fmt.Errorf("%s", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 	return nil
@@ -565,10 +557,8 @@ func (a *routesCmd) inspect(c *cli.Context) error {
 		switch e := err.(type) {
 		case *apiroutes.GetAppsAppRoutesRouteNotFound:
 			return fmt.Errorf("%s", e.Payload.Error.Message)
-		case *apiroutes.GetAppsAppRoutesRouteDefault:
-			return fmt.Errorf("%s", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 
@@ -613,10 +603,8 @@ func (a *routesCmd) delete(c *cli.Context) error {
 		switch e := err.(type) {
 		case *apiroutes.DeleteAppsAppRoutesRouteNotFound:
 			return fmt.Errorf("%s", e.Payload.Error.Message)
-		case *apiroutes.DeleteAppsAppRoutesRouteDefault:
-			return fmt.Errorf("%s", e.Payload.Error.Message)
 		default:
-			return fmt.Errorf("%v", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
the swagger error handling is not very fun, default errors are not necessarily
able to parse certain errors into each errors' 'default' type. in theory, we
should be able to `return err` but we would get errors that look like this:

```
return fmt.Sprintf("[PUT /apps/{app}/routes/{route}][%d] PutAppsAppRoutesRoute default  %+v", o._statusCode, o.Payload)
```

so the compromise seems to leave us to handle specific errors in the cli
itself, and let default errors print the uglier, more detailed blob like
above, since the error types themselves only implement `Error() string` and
`Code() int` and don't allow us to get at the `Payload` field, which is
sometimes nil, itself. looked for 15 minutes and couldn't find a way to do
this, at least. for the more interesting errors, we probably want to get the
code and the full body / route anyway, to help debug.

closes https://github.com/fnproject/fn/issues/907