### PR TITLE
cli: circle-ci keep clean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
           cd tmp
           sudo rm -rf /usr/local/go
           wget https://storage.googleapis.com/golang/go$GOVERSION.$OS-$ARCH.tar.gz
-          # mkdir -p $HOME/golang
-          # tar -C $HOME/golang -xzf go1.8.3.linux-amd64.tar.gz
           sudo tar -C /usr/local -xzf go$GOVERSION.$OS-$ARCH.tar.gz
           export PATH=$PATH:$HOME/go/bin
       - run: go version


### PR DESCRIPTION
Contents of each run step shows up in circle-ci web UI. But it's hard to see if something is commented out or not due to line wrap.