### PR TITLE
Migrating env vars config to viper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,6 +117,12 @@
   version = "0.2.6"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   name = "github.com/giantswarm/semver-bump"
   packages = [
     "bump",
@@ -201,6 +207,23 @@
   revision = "d509235108fcf6ab4913d2dcb3a2260c0db2108e"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+
+[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "0b12d6b5"
@@ -216,6 +239,12 @@
   name = "github.com/juju/errgo"
   packages = ["errors"]
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
   branch = "master"
@@ -269,6 +298,45 @@
   ]
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/urfave/cli"
@@ -356,6 +424,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c6b05fb1308e848d160b758f140bca8702af3e44b3a83ace91e15db189083b31"
+  inputs-digest = "f4c5f1eedb8180bb6fb2fc6239623ea1b611e4a06d943a34fcb9a075be10d5f3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client/api.go
+++ b/client/api.go
@@ -8,6 +8,7 @@ import (
 	fnclient "github.com/fnproject/fn_go/client"
 	openapi "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -24,31 +25,22 @@ func Host() string {
 }
 
 func HostURL() (*url.URL, error) {
-	apiURL := os.Getenv("FN_API_URL")
-
-	if apiURL == "" {
-		if os.Getenv("API_URL") != "" {
-			fmt.Fprint(os.Stderr, "Error: API_URL is deprecated, please use FN_API_URL.")
-			os.Exit(1)
-		}
-		apiURL = "http://localhost:8080"
-	}
-
+	apiURL := viper.GetString("api_url")
 	return url.Parse(apiURL)
 }
 
 func GetTransportAndRegistry() (*openapi.Runtime, strfmt.Registry) {
 	transport := openapi.New(Host(), "/v1", []string{"http"})
-	if os.Getenv(envFnToken) != "" {
-		transport.DefaultAuthentication = openapi.BearerToken(os.Getenv(envFnToken))
+	if token := viper.GetString("token"); token != "" {
+		transport.DefaultAuthentication = openapi.BearerToken(token)
 	}
 	return transport, strfmt.Default
 }
 
 func APIClient() *fnclient.Fn {
 	transport := openapi.New(Host(), "/v1", []string{"http"})
-	if os.Getenv(envFnToken) != "" {
-		transport.DefaultAuthentication = openapi.BearerToken(os.Getenv(envFnToken))
+	if token := viper.GetString("token"); token != "" {
+		transport.DefaultAuthentication = openapi.BearerToken(token)
 	}
 
 	// create the API client, with the transport

--- a/common.go
+++ b/common.go
@@ -26,21 +26,7 @@ const (
 	functionsDockerImage     = "fnproject/fnserver"
 	funcfileDockerRuntime    = "docker"
 	minRequiredDockerVersion = "17.5.0"
-	envFnRegistry            = "FN_REGISTRY"
 )
-
-type HasRegistry interface {
-	Registry() string
-}
-
-func setRegistryEnv(hr HasRegistry) {
-	if hr.Registry() != "" {
-		err := os.Setenv(envFnRegistry, hr.Registry())
-		if err != nil {
-			log.Fatalf("Couldn't set %s env var: %v\n", envFnRegistry, err)
-		}
-	}
-}
 
 func getWd() string {
 	wd, err := os.Getwd()
@@ -331,12 +317,12 @@ func dockerPush(ff *funcfile) error {
 	return nil
 }
 
-// validateImageName validates that the full image name (FN_REGISTRY/name:tag) is allowed for push
+// validateImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
 // remember that private registries must be supported here
 func validateImageName(n string) error {
 	parts := strings.Split(n, "/")
 	if len(parts) < 2 {
-		return errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var or pass in --registry")
+		return errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var, pass in --registry or configure your context file")
 	}
 	lastParts := strings.Split(parts[len(parts)-1], ":")
 	if len(lastParts) != 2 {

--- a/common_test.go
+++ b/common_test.go
@@ -9,7 +9,7 @@ func TestValidateImageName(t *testing.T) {
 	}{
 		{name: "docker.io/sally/img:0.0.1", expectedErr: ""},
 		{name: "sally/img:0.0.1", expectedErr: ""},
-		{name: "img:0.0.1", expectedErr: "image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var or pass in --registry"},
+		{name: "img:0.0.1", expectedErr: "image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var, pass in --registry or configure your context file"},
 		{name: "owner/img", expectedErr: "image name must have a tag"},
 	}
 	for _, c := range testCases {

--- a/deploy.go
+++ b/deploy.go
@@ -40,10 +40,6 @@ type deploycmd struct {
 	all      bool
 }
 
-func (cmd *deploycmd) Registry() string {
-	return cmd.registry
-}
-
 func (p *deploycmd) flags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
@@ -89,8 +85,6 @@ func (p *deploycmd) flags() []cli.Flag {
 // on the file system (can be overridden using the `path` arg in each `func.yaml`. The index/root function
 // is the one that lives in the same directory as the app.yaml.
 func (p *deploycmd) deploy(c *cli.Context) error {
-	setRegistryEnv(p)
-
 	appName := ""
 
 	appf, err := loadAppfile()

--- a/funcfile.go
+++ b/funcfile.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/viper"
+
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -74,8 +76,8 @@ type funcfile struct {
 func (ff *funcfile) ImageName() string {
 	fname := ff.Name
 	if !strings.Contains(fname, "/") {
-		// then we'll prefix FN_REGISTRY
-		reg := os.Getenv(envFnRegistry)
+
+		reg := viper.GetString("registry")
 		if reg != "" {
 			if reg[len(reg)-1] != '/' {
 				reg += "/"

--- a/push.go
+++ b/push.go
@@ -24,10 +24,6 @@ type pushcmd struct {
 	registry string
 }
 
-func (cmd *pushcmd) Registry() string {
-	return cmd.registry
-}
-
 func (p *pushcmd) flags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
@@ -48,8 +44,6 @@ func (p *pushcmd) flags() []cli.Flag {
 // push the container, and finally it will update function's route. Optionally,
 // the route can be overriden inside the functions file.
 func (p *pushcmd) push(c *cli.Context) error {
-	setRegistryEnv(p)
-
 	_, ff, err := loadFuncfile()
 	if err != nil {
 		if _, ok := err.(*notFoundError); ok {

--- a/test/funcfile-docker-rt-tests/fn_test.go
+++ b/test/funcfile-docker-rt-tests/fn_test.go
@@ -4,23 +4,20 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func init() {
 	dockerUser := os.Getenv("DOCKER_USER")
-	var err error
 	if dockerUser == "" {
 		dockerUser = "funcster"
 	}
-	err = os.Setenv("FN_REGISTRY", dockerUser)
-	if err != nil {
-		log.Fatalf("couldn't set env var: %v", err)
-	}
+	viper.Set("registry", dockerUser)
 	return
 }
 


### PR DESCRIPTION
Moved the creation of aliases after api_url is set within the init function in main.go due to the creation of the apiClient before viper had loaded the registry env var

Removed the hasRegistry interface in common.go and replaced with a commandArgOverride function in main.go

This is the first part of github issue #217