### PR TITLE
Making config importable

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -5,15 +5,11 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/fnproject/cli/config"
 	fnclient "github.com/fnproject/fn_go/client"
 	openapi "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/spf13/viper"
-)
-
-const (
-	envFnToken  = "token"
-	envFnAPIURL = "api_url"
 )
 
 func Host() string {
@@ -26,13 +22,16 @@ func Host() string {
 }
 
 func HostURL() (*url.URL, error) {
-	apiURL := viper.GetString(envFnAPIURL)
+	apiURL := viper.GetString(config.EnvFnAPIURL)
 	return url.Parse(apiURL)
 }
 
 func GetTransportAndRegistry() (*openapi.Runtime, strfmt.Registry) {
 	transport := openapi.New(Host(), "/v1", []string{"http"})
-	if token := viper.GetString(envFnToken); token != "" {
+
+	switch viper.GetString(config.ContextProvider) {
+	}
+	if token := viper.GetString(config.EnvFnToken); token != "" {
 		transport.DefaultAuthentication = openapi.BearerToken(token)
 	}
 	return transport, strfmt.Default
@@ -40,7 +39,7 @@ func GetTransportAndRegistry() (*openapi.Runtime, strfmt.Registry) {
 
 func APIClient() *fnclient.Fn {
 	transport := openapi.New(Host(), "/v1", []string{"http"})
-	if token := viper.GetString(envFnToken); token != "" {
+	if token := viper.GetString(config.EnvFnToken); token != "" {
 		transport.DefaultAuthentication = openapi.BearerToken(token)
 	}
 

--- a/funcfile.go
+++ b/funcfile.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fnproject/cli/config"
 	"github.com/spf13/viper"
 
 	yaml "gopkg.in/yaml.v2"
@@ -77,7 +78,7 @@ func (ff *funcfile) ImageName() string {
 	fname := ff.Name
 	if !strings.Contains(fname, "/") {
 
-		reg := viper.GetString(envFnRegistry)
+		reg := viper.GetString(config.EnvFnRegistry)
 		if reg != "" {
 			if reg[len(reg)-1] != '/' {
 				reg += "/"

--- a/main.go
+++ b/main.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/fnproject/cli/config"
 	"github.com/spf13/viper"
 	"github.com/urfave/cli"
 )
@@ -40,7 +39,7 @@ func newFn() *cli.App {
 	app.Authors = []cli.Author{{Name: "Fn Project"}}
 	app.Description = "Fn command line tool"
 	app.Before = func(c *cli.Context) error {
-		loadConfiguration(c)
+		config.LoadConfiguration(c)
 		commandArgOverrides(c)
 		return nil
 	}
@@ -148,52 +147,14 @@ func init() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	viper.SetEnvPrefix("fn")
-	viper.SetDefault(envFnAPIURL, "http://localhost:8080")
+	viper.SetDefault(config.EnvFnAPIURL, "http://localhost:8080")
 
-	EnsureConfiguration()
-}
-
-func loadConfiguration(c *cli.Context) error {
-	// Find home directory.
-	home, err := homedir.Dir()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	context := ""
-
-	if context = c.String(envFnContext); context == "" {
-		viper.AddConfigPath(filepath.Join(home, rootConfigPathName))
-		viper.SetConfigName(configName)
-
-		readConfig()
-
-		context = viper.GetString(currentContext)
-		if context == "" {
-			fmt.Println("Config file does not contain context")
-			os.Exit(1)
-		}
-	}
-
-	viper.AddConfigPath(filepath.Join(home, rootConfigPathName, contextsPathName))
-	viper.SetConfigName(context)
-	readConfig()
-
-	return nil
+	config.EnsureConfiguration()
 }
 
 func commandArgOverrides(c *cli.Context) {
-	if registry := c.String(envFnRegistry); registry != "" {
-		viper.Set(envFnRegistry, registry)
-	}
-}
-
-func readConfig() {
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+	if registry := c.String(config.EnvFnRegistry); registry != "" {
+		viper.Set(config.EnvFnRegistry, registry)
 	}
 }
 


### PR DESCRIPTION
Having the config names defined in the main package meant they
couldn't be reused in other packages, namely client/api.

This creates the config package to contain the config key definitions
and makes them exportable.

Also moved the loadConfiguration func into config from main, and it
feels like a better place for it to live.