### PR TITLE
Oracle provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -306,6 +306,12 @@
   version = "v1.2.0"
 
 [[projects]]
+  name = "github.com/oracle/oci-go-sdk"
+  packages = ["common"]
+  revision = "ad5c34ed0cf8169d6817e2a37ec3e4521f856368"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
@@ -430,6 +436,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5782d8a2b712a24f26e07c683ac6643efd2ef809acd187df5d4efc7b5b67be3a"
+  inputs-digest = "8bd2faca8d3d8fa829b8d6f3aaa157de1f78e23434e77c40f18f88aa6b93f8a0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client/api.go
+++ b/client/api.go
@@ -1,50 +1,103 @@
 package client
 
 import (
+	"crypto/rsa"
 	"fmt"
+	"io/ioutil"
 	"net/url"
-	"os"
+	"syscall"
 
 	"github.com/fnproject/cli/config"
 	fnclient "github.com/fnproject/fn_go/client"
 	openapi "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/oracle/oci-go-sdk/common"
 	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func Host() string {
-	h, err := HostURL()
-	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-	return h.Host
+	hostURL := HostURL()
+	return hostURL.Host
 }
 
-func HostURL() (*url.URL, error) {
+func HostURL() *url.URL {
 	apiURL := viper.GetString(config.EnvFnAPIURL)
-	return url.Parse(apiURL)
+
+	url, err := url.Parse(apiURL)
+	if err != nil {
+		panic(fmt.Sprintf("Unparsable FN API Url: %s. Error: %s", apiURL, err))
+	}
+
+	return url
 }
 
-func GetTransportAndRegistry() (*openapi.Runtime, strfmt.Registry) {
-	transport := openapi.New(Host(), "/v1", []string{"http"})
-
-	switch viper.GetString(config.ContextProvider) {
-	}
+func defaultProvider(transport *openapi.Runtime) {
 	if token := viper.GetString(config.EnvFnToken); token != "" {
 		transport.DefaultAuthentication = openapi.BearerToken(token)
 	}
+}
+
+func challengeForPKeyPassword() string {
+	fmt.Print("Private Key Phrase: ")
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		panic(fmt.Sprintf("%s", err))
+	}
+	password := string(bytePassword)
+	fmt.Println()
+
+	return password
+}
+
+func privateKey(pkeyFilePath string) *rsa.PrivateKey {
+	keyBytes, err := ioutil.ReadFile(pkeyFilePath)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to load private key from file: %s. Error: %s", pkeyFilePath, err))
+	}
+
+	pKeyPword := challengeForPKeyPassword()
+	key, err := common.PrivateKeyFromBytes(keyBytes, common.String(pKeyPword))
+	if err != nil {
+		panic(fmt.Sprintf("Unable to load private key from file bytes: %s. Error: %s", pkeyFilePath, err))
+	}
+	return key
+}
+
+func oracleProvider(transport *openapi.Runtime) {
+	keyID := viper.GetString(config.OracleKeyID)
+	pKey := privateKey(viper.GetString(config.OraclePrivateKey))
+	compartmentID := viper.GetString(config.OracleCompartmentID)
+
+	if viper.GetBool(config.OracleDisableCerts) {
+		transport.Transport = InsecureRoundTripper(transport.Transport)
+	}
+
+	transport.Transport =
+		NewCompartmentIDRoundTripper(
+			compartmentID,
+			NewOCISigningRoundTripper(
+				keyID,
+				pKey,
+				transport.Transport))
+}
+
+func GetTransportAndRegistry() (*openapi.Runtime, strfmt.Registry) {
+	hostURL := HostURL()
+	transport := openapi.New(hostURL.Host, hostURL.Path, []string{hostURL.Scheme})
+
+	switch viper.GetString(config.ContextProvider) {
+	case "default":
+		defaultProvider(transport)
+	case "oracle":
+		oracleProvider(transport)
+	default:
+		defaultProvider(transport)
+	}
+
 	return transport, strfmt.Default
 }
 
 func APIClient() *fnclient.Fn {
-	transport := openapi.New(Host(), "/v1", []string{"http"})
-	if token := viper.GetString(config.EnvFnToken); token != "" {
-		transport.DefaultAuthentication = openapi.BearerToken(token)
-	}
-
-	// create the API client, with the transport
-	client := fnclient.New(GetTransportAndRegistry())
-
-	return client
+	return fnclient.New(GetTransportAndRegistry())
 }

--- a/client/oracle_provider.go
+++ b/client/oracle_provider.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"crypto/rsa"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/common"
+)
+
+type OCIKeyProvider struct {
+	ID  string
+	key *rsa.PrivateKey
+}
+
+func (kp OCIKeyProvider) PrivateRSAKey() (*rsa.PrivateKey, error) {
+	return kp.key, nil
+}
+
+func (kp OCIKeyProvider) KeyID() (string, error) {
+	return kp.ID, nil
+}
+
+type OCISigningRoundTripper struct {
+	ociClient common.HTTPRequestSigner
+	transport http.RoundTripper
+}
+
+func NewOCISigningRoundTripper(keyID string, key *rsa.PrivateKey, transport http.RoundTripper) http.RoundTripper {
+	ociClient := initializeClient(keyID, key)
+	return OCISigningRoundTripper{
+		transport: transport,
+		ociClient: ociClient,
+	}
+}
+
+func (t OCISigningRoundTripper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	if request.Header.Get("Date") == "" {
+		request.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+	}
+	request, err = signRequest(t.ociClient, request)
+
+	if err != nil {
+		return
+	}
+
+	response, err = t.transport.RoundTrip(request)
+
+	return
+}
+
+func initializeClient(keyID string, key *rsa.PrivateKey) common.HTTPRequestSigner {
+	provider := OCIKeyProvider{
+		ID:  keyID,
+		key: key,
+	}
+	return common.RequestSigner(provider, []string{"date", "(request-target)"}, []string{"content-length", "content-type", "x-content-sha256"})
+}
+
+// Add the necessary headers and sign the request
+func signRequest(signer common.HTTPRequestSigner, request *http.Request) (signedRequest *http.Request, err error) {
+	// Check that a Date header is set, otherwise authentication will fail
+	if request.Header.Get("Date") == "" {
+		return nil, fmt.Errorf("Date header must be present and non-empty on request")
+	}
+	if request.Method == "POST" || request.Method == "PATCH" || request.Method == "PUT" {
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Content-Length", fmt.Sprintf("%d", request.ContentLength))
+	}
+
+	err = signer.Sign(request)
+
+	return request, err
+}
+
+//  http.RoundTripper middleware that adds a compartmentId query parameter to all requests
+type CompartmentIDRoundTripper struct {
+	transport     http.RoundTripper
+	compartmentID string
+}
+
+func NewCompartmentIDRoundTripper(compartmentID string, transport http.RoundTripper) CompartmentIDRoundTripper {
+	return CompartmentIDRoundTripper{
+		transport:     transport,
+		compartmentID: compartmentID,
+	}
+}
+
+func (t CompartmentIDRoundTripper) RoundTrip(request *http.Request) (response *http.Response, e error) {
+	params := request.URL.Query()
+	params.Add("compartmentId", t.compartmentID)
+	request.URL.RawQuery = params.Encode()
+	response, e = t.transport.RoundTrip(request)
+	return
+}
+
+// Skip verification of insecure certs
+func InsecureRoundTripper(roundTripper http.RoundTripper) http.RoundTripper {
+	transport := roundTripper.(*http.Transport)
+	if transport != nil {
+		if transport.TLSClientConfig != nil {
+			transport.TLSClientConfig.InsecureSkipVerify = true
+		} else {
+			transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+	}
+
+	return transport
+}

--- a/config/config.go
+++ b/config/config.go
@@ -28,12 +28,17 @@ const (
 	EnvFnToken    = "token"
 	EnvFnAPIURL   = "api_url"
 	EnvFnContext  = "context"
+
+	OracleKeyID         = "key_id"
+	OraclePrivateKey    = "private_key"
+	OracleCompartmentID = "compartment_id"
+	OracleDisableCerts  = "disable_certs"
 )
 
 var defaultRootConfigContents = map[string]string{CurrentContext: "default"}
 var defaultContextConfigContents = map[string]string{
 	ContextProvider: "default",
-	EnvFnAPIURL:     "https://localhost:8080",
+	EnvFnAPIURL:     "http://localhost:8080/v1",
 	EnvFnRegistry:   "",
 }
 

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func init() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	viper.SetEnvPrefix("fn")
-	viper.SetDefault(config.EnvFnAPIURL, "http://localhost:8080")
+	viper.SetDefault(config.EnvFnAPIURL, "http://localhost:8080/v1")
 
 	config.EnsureConfiguration()
 }

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ if [[ -z "$FN_REGISTRY" ]]; then
 fi
 $fn --version
 
-export FN_API_URL="http://localhost:8080"
+export FN_API_URL="http://localhost:8080/v1"
 
 go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 
@@ -96,7 +96,7 @@ $fn test
 # Test 'docker' runtime deploy
 cd $WORK_DIR
 funcname="dockerfunc"
-mkdir $funcname 
+mkdir $funcname
 cp ${CUR_DIR}/test/funcfile-docker-rt-tests/testfiles/Dockerfile $funcname/
 cp ${CUR_DIR}/test/funcfile-docker-rt-tests/testfiles/func.go $funcname/
 cd $funcname
@@ -110,7 +110,7 @@ $fn call myapp1 /$funcname
 # grab the route config and see if cpu is in there
 $fn routes inspect myapp1 /$funcname > ./${funcname}.route
 grep "\"cpus\": \"50m\"" ./${funcname}.route
-# todo: would be nice to have a flag to output parseable formats in cli, eg: `fn deploy --output json` would return json with version and other info 
+# todo: would be nice to have a flag to output parseable formats in cli, eg: `fn deploy --output json` would return json with version and other info
 $fn routes create myapp1 /another --image $FN_REGISTRY/$funcname:0.0.2
 $fn call myapp1 /another
 

--- a/testfn.go
+++ b/testfn.go
@@ -249,10 +249,7 @@ func (t *testcmd) runremotetest(ff *funcfile, in *inputMap, expectedOut *outputM
 	if ff.Path == "" {
 		return errors.New("execution of tests on remote server demand that this function has a `path`")
 	}
-	baseURL, err := client.HostURL()
-	if err != nil {
-		return fmt.Errorf("error parsing base path: %v", err)
-	}
+	baseURL := client.HostURL()
 
 	u, err := url.Parse("../")
 	u.Path = path.Join(u.Path, "r", t.remote, ff.Path)


### PR DESCRIPTION
Contexts that configure provider as oracle will now cause requests to
be signed with a defined private key.

An example ~/.fn/contexts/oracle.yaml file would contain:

provider: oracle
api_url: ${FN_API_URL}
key_id: ${TENANCY_OCID}/${YOUR_USER_OCID}/${YOUR_API_KEY_FINGERPRINT}
private_key: ${USERS_PRIVATE_KEY}
compartment_id: ${OCI_COMPARTMENT_ID}
disable_certs: true

Currently the user is prompted to unlock the key on each invocation.