### PR TITLE
Context management commands

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Context command
 
-Context files are used to define deplployment enviroments. Multiple contexts representing different enviroments can be created with each context specifying an appropriate provider  and a set of properties required/understood by that provider with the ability to switch between them. Contexts are persisted in individual files under the `.fn` directory which, if not present, is created on launch.
+Context files are used to define deployment enviroments. Multiple contexts representing different enviroments can be created with each context specifying an appropriate provider  and a set of properties required/understood by that provider with the ability to switch between them. Contexts are persisted in individual files under the `.fn` directory which, if not present, is created on launch.
 
 ```
 ~ 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,19 +43,19 @@ $ fn context create <context>
 $ fn context create <context> --api-url foo --provider bar --registry <dockerhub-username>
 ```
 
-### Setting a Context 
+### Using a Context
 
-To set a context use `s` or `set`.
+To use a context use `u` or `use`.
 
 ```
-$ fn context set <context>
+$ fn context use <context>
 ```
 
 ### Deleting a Context 
  
 To delete a context use `d` or `delete`.
 
-_You can not delete the currently set context or the default context as it is protected._
+_You can not delete the currently used context or the default context as it is protected._
 
 ```
 $ fn context delete <context>

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,74 @@
+# Context command
+
+Context files are used to define deplployment enviroments. Multiple contexts representing different enviroments can be created with each context specifying an appropriate provider  and a set of properties required/understood by that provider with the ability to switch between them. Contexts are persisted in individual files under the `.fn` directory which, if not present, is created on launch.
+
+```
+~ 
+  .fn
+     config.yaml
+     contexts
+        default.yaml
+```
+
+The `config.yaml` contains the name of currently selected context, when first created the current context is not set:
+
+ ```
+ current-context: ""
+ ``` 
+
+Within the `default.yaml` default values are set: 
+```
+api_url: http://localhost:8080/v1
+provider: default
+registry: ""
+```
+
+* api_url - the fn-server endpoint.
+* provider - the a specific provider which identifies a set of properties required/understood by that provider.
+* registry - the Docker registry username to push images to 
+[registry.hub.docker.com/`registry`].
+
+### Listing Contexts
+The `fn context` command accepts either `l` or `list` to view a list of contexts.
+```
+$ fn context list
+```
+
+### Creating a Context 
+
+To create a context use `c` or `create`. The context file will be created with default values but option flags can be used override.
+
+```
+$ fn context create <context>
+$ fn context create <context> --api-url foo --provider bar --registry <dockerhub-username>
+```
+
+### Setting a Context 
+
+To set a context use `s` or `set`.
+
+```
+$ fn context set <context>
+```
+
+### Deleting a Context 
+ 
+To delete a context use `d` or `delete`.
+
+_You can not delete the currently set context or the default context as it is protected._
+
+```
+$ fn context delete <context>
+```
+
+### Unsetting Context 
+
+To unset the current context use `unset`:
+
+```
+$ fn context unset
+```
+
+# Enviroment Variables
+
+_The current supported env vars 'FN_API_URL' and 'FN_REGISTRY' will override the configured context properties_.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -269,6 +269,12 @@
   version = "v0.0.3"
 
 [[projects]]
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
+  version = "v0.0.2"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
@@ -285,6 +291,12 @@
   packages = ["pkg/jsonmessage"]
   revision = "90d35abf7b3535c1c319c872900fbd76374e521c"
   version = "v17.05.0-ce-rc3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/olekukonko/tablewriter"
+  packages = ["."]
+  revision = "d5dd8a50526aadb3d5f2c9b5233277bc2db90e88"
 
 [[projects]]
   name = "github.com/onsi/gomega"
@@ -436,6 +448,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8bd2faca8d3d8fa829b8d6f3aaa157de1f78e23434e77c40f18f88aa6b93f8a0"
+  inputs-digest = "701d1abf3fcc45951b7223234e0cae3586feb0681e6684f3e864b8f7d720a383"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/apps.go
+++ b/apps.go
@@ -132,7 +132,6 @@ func (a *appsCmd) list(c *cli.Context) error {
 	var resApps []*models.App
 	for {
 		resp, err := a.client.Apps.GetApps(params)
-
 		if err != nil {
 			switch e := err.(type) {
 			case *apiapps.GetAppsAppNotFound:

--- a/client/api.go
+++ b/client/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"syscall"
 
@@ -27,14 +28,21 @@ func HostURL() *url.URL {
 }
 
 func hostURL(urlStr string) *url.URL {
+	apiUrl := os.Getenv("FN_API_URL")
+	currentContext := viper.Get(config.CurrentContext)
+	if apiUrl != "" && currentContext != "" {
+		fmt.Println("Warning: environment variable FN_API_URL is overriding configured context property api_url from current-context")
+	}
 
 	if !strings.Contains(urlStr, "://") {
 		urlStr = fmt.Sprint("http://", urlStr)
 	}
 
 	url, err := url.Parse(urlStr)
+
 	if err != nil {
-		panic(fmt.Sprintf("Unparsable FN API Url: %s. Error: %s", urlStr, err))
+		fmt.Printf("Unparsable FN API Url: %s. Error: %s", urlStr, err)
+		os.Exit(1)
 	}
 
 	if url.Port() == "" {

--- a/client/api.go
+++ b/client/api.go
@@ -31,7 +31,7 @@ func hostURL(urlStr string) *url.URL {
 	apiUrl := os.Getenv("FN_API_URL")
 	currentContext := viper.Get(config.CurrentContext)
 	if apiUrl != "" && currentContext != "" {
-		fmt.Println("Warning: environment variable FN_API_URL is overriding configured context property api_url from current-context")
+		fmt.Fprintf(os.Stderr, "Warning: environment variable FN_API_URL is overriding configured context property api_url from current-context \n")
 	}
 
 	if !strings.Contains(urlStr, "://") {
@@ -41,7 +41,7 @@ func hostURL(urlStr string) *url.URL {
 	url, err := url.Parse(urlStr)
 
 	if err != nil {
-		fmt.Printf("Unparsable FN API Url: %s. Error: %s", urlStr, err)
+		fmt.Fprintf(os.Stderr, "Unparsable FN API Url: %s. Error: %s \n", urlStr, err)
 		os.Exit(1)
 	}
 

--- a/client/api.go
+++ b/client/api.go
@@ -28,12 +28,6 @@ func HostURL() *url.URL {
 }
 
 func hostURL(urlStr string) *url.URL {
-	apiUrl := os.Getenv("FN_API_URL")
-	currentContext := viper.Get(config.CurrentContext)
-	if apiUrl != "" && currentContext != "" {
-		fmt.Fprintf(os.Stderr, "Warning: environment variable FN_API_URL is overriding configured context property api_url from current-context \n")
-	}
-
 	if !strings.Contains(urlStr, "://") {
 		urlStr = fmt.Sprint("http://", urlStr)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -61,7 +61,7 @@ func EnsureConfiguration() {
 	rootConfigPath := filepath.Join(home, RootConfigPathName)
 	if _, err := os.Stat(rootConfigPath); os.IsNotExist(err) {
 		if err = os.Mkdir(rootConfigPath, readWritePerms); err != nil {
-			fmt.Printf("error creating .fn directory %v", err)
+			fmt.Fprintf(os.Stderr, "error creating .fn directory %v \n", err)
 		}
 	}
 
@@ -69,19 +69,19 @@ func EnsureConfiguration() {
 	if _, err := os.Stat(contextConfigFilePath); os.IsNotExist(err) {
 		_, err = os.Create(contextConfigFilePath)
 		if err != nil {
-			fmt.Printf("error creating config.yaml file %v", err)
+			fmt.Fprintf(os.Stderr, "error creating config.yaml file %v \n", err)
 		}
 
 		err = WriteYamlFile(contextConfigFilePath, DefaultRootConfigContents)
 		if err != nil {
-			fmt.Printf("%v", err)
+			fmt.Fprintf(os.Stderr, "%v \n", err)
 		}
 	}
 
 	contextsPath := filepath.Join(rootConfigPath, ContextsPathName)
 	if _, err := os.Stat(contextsPath); os.IsNotExist(err) {
 		if err = os.Mkdir(contextsPath, readWritePerms); err != nil {
-			fmt.Printf("error creating contexts directory %v", err)
+			fmt.Fprintf(os.Stderr, "error creating contexts directory %v \n", err)
 		}
 	}
 
@@ -89,12 +89,12 @@ func EnsureConfiguration() {
 	if _, err := os.Stat(defaultContextPath); os.IsNotExist(err) {
 		_, err = os.Create(defaultContextPath)
 		if err != nil {
-			fmt.Printf("error creating default.yaml context file %v", err)
+			fmt.Fprintf(os.Stderr, "error creating default.yaml context file %v \n", err)
 		}
 
 		err = WriteYamlFile(defaultContextPath, DefaultContextConfigContents)
 		if err != nil {
-			fmt.Printf("%v", err)
+			fmt.Fprintf(os.Stderr, "%v \n", err)
 		}
 	}
 }
@@ -103,7 +103,7 @@ func LoadConfiguration(c *cli.Context) {
 	// Find home directory.
 	home, err := GetHomeDir()
 	if err != nil {
-		fmt.Printf("%v", err)
+		fmt.Fprintf(os.Stderr, "%v \n", err)
 	}
 
 	context := ""
@@ -112,7 +112,7 @@ func LoadConfiguration(c *cli.Context) {
 		viper.SetConfigName(ConfigName)
 
 		if err := readConfig(); err != nil {
-			fmt.Printf("%v: ", err)
+			fmt.Fprintf(os.Stderr, "%v \n", err)
 		}
 
 		context = viper.GetString(CurrentContext)
@@ -122,12 +122,12 @@ func LoadConfiguration(c *cli.Context) {
 	viper.SetConfigName(context)
 
 	if err := readConfig(); err != nil {
-		fmt.Printf("%v \n", err)
+		fmt.Fprintf(os.Stderr, "%v \n", err)
 		configFilePath := filepath.Join(home, RootConfigPathName, ContextConfigFileName)
 		configCurrentContext := map[string]string{CurrentContext: "default"}
 		err = WriteYamlFile(configFilePath, configCurrentContext)
 		if err != nil {
-			fmt.Printf("%v \n", err)
+			fmt.Fprintf(os.Stderr, "%v \n", err)
 		}
 
 		fmt.Println("current context has been set to default")

--- a/config/config.go
+++ b/config/config.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	RootConfigPathName     = ".fn"
-	ContextsPathName       = "contexts"
-	ConfigName             = "config"
-	ContextConfigFileName  = "config.yaml"
-	DefaultContextFileName = "default.yaml"
-	DefaultLocalApiUrl     = "http://localhost:8080/v1"
+	rootConfigPathName = ".fn"
+
+	contextsPathName       = "contexts"
+	configName             = "config"
+	contextConfigFileName  = "config.yaml"
+	defaultContextFileName = "default.yaml"
+	defaultLocalAPIURL     = "http://localhost:8080/v1"
 	DefaultProvider        = "default"
 
 	readWritePerms = os.FileMode(0755)
@@ -29,25 +30,26 @@ const (
 
 	EnvFnRegistry = "registry"
 	EnvFnToken    = "token"
-	EnvFnAPIURL   = "api_url"
+	EnvFnAPIURL   = "api-url"
 	EnvFnContext  = "context"
 
-	OracleKeyID         = "key_id"
-	OraclePrivateKey    = "private_key"
-	OracleCompartmentID = "compartment_id"
-	OracleDisableCerts  = "disable_certs"
+	OracleKeyID         = "key-id"
+	OraclePrivateKey    = "private-key"
+	OracleCompartmentID = "compartment-id"
+	OracleDisableCerts  = "disable-certs"
 )
 
-var DefaultRootConfigContents = map[string]string{CurrentContext: ""}
-var DefaultContextConfigContents = map[string]string{
+var defaultRootConfigContents = map[string]string{CurrentContext: ""}
+var defaultContextConfigContents = map[string]string{
 	ContextProvider: DefaultProvider,
-	EnvFnAPIURL:     DefaultLocalApiUrl,
+	EnvFnAPIURL:     defaultLocalAPIURL,
 	EnvFnRegistry:   "",
 }
 
+// ContextFile defines the internal structure of a default context
 type ContextFile struct {
 	ContextProvider string `yaml:"provider"`
-	EnvFnAPIURL     string `yaml:"api_url"`
+	EnvFnAPIURL     string `yaml:"api-url"`
 	EnvFnRegistry   string `yaml:"registry"`
 }
 
@@ -56,7 +58,7 @@ type ContextFile struct {
 func EnsureConfiguration() error {
 	home := GetHomeDir()
 
-	rootConfigPath := filepath.Join(home, RootConfigPathName)
+	rootConfigPath := filepath.Join(home, rootConfigPathName)
 	if _, err := os.Stat(rootConfigPath); os.IsNotExist(err) {
 		if err = os.Mkdir(rootConfigPath, readWritePerms); err != nil {
 			return fmt.Errorf("error creating .fn directory %v", err)
@@ -64,34 +66,34 @@ func EnsureConfiguration() error {
 		}
 	}
 
-	contextConfigFilePath := filepath.Join(rootConfigPath, ContextConfigFileName)
+	contextConfigFilePath := filepath.Join(rootConfigPath, contextConfigFileName)
 	if _, err := os.Stat(contextConfigFilePath); os.IsNotExist(err) {
 		_, err = os.Create(contextConfigFilePath)
 		if err != nil {
 			return fmt.Errorf("error creating config.yaml file %v", err)
 		}
 
-		err = WriteYamlFile(contextConfigFilePath, DefaultRootConfigContents)
+		err = WriteYamlFile(contextConfigFilePath, defaultRootConfigContents)
 		if err != nil {
 			return err
 		}
 	}
 
-	contextsPath := filepath.Join(rootConfigPath, ContextsPathName)
+	contextsPath := filepath.Join(rootConfigPath, contextsPathName)
 	if _, err := os.Stat(contextsPath); os.IsNotExist(err) {
 		if err = os.Mkdir(contextsPath, readWritePerms); err != nil {
 			return fmt.Errorf("error creating contexts directory %v", err)
 		}
 	}
 
-	defaultContextPath := filepath.Join(contextsPath, DefaultContextFileName)
+	defaultContextPath := filepath.Join(contextsPath, defaultContextFileName)
 	if _, err := os.Stat(defaultContextPath); os.IsNotExist(err) {
 		_, err = os.Create(defaultContextPath)
 		if err != nil {
 			return fmt.Errorf("error creating default.yaml context file %v", err)
 		}
 
-		err = WriteYamlFile(defaultContextPath, DefaultContextConfigContents)
+		err = WriteYamlFile(defaultContextPath, defaultContextConfigContents)
 		if err != nil {
 			return err
 		}
@@ -100,13 +102,19 @@ func EnsureConfiguration() error {
 	return nil
 }
 
+// GetContextsPath : Returns the path to the contexts directory.
+func GetContextsPath() string {
+	contextsPath := filepath.Join(rootConfigPathName, contextsPathName)
+	return contextsPath
+}
+
 func LoadConfiguration(c *cli.Context) error {
 	// Find home directory.
 	home := GetHomeDir()
 	context := ""
 	if context = c.String(EnvFnContext); context == "" {
-		viper.AddConfigPath(filepath.Join(home, RootConfigPathName))
-		viper.SetConfigName(ConfigName)
+		viper.AddConfigPath(filepath.Join(home, rootConfigPathName))
+		viper.SetConfigName(configName)
 
 		if err := viper.ReadInConfig(); err != nil {
 			return err
@@ -114,7 +122,7 @@ func LoadConfiguration(c *cli.Context) error {
 		context = viper.GetString(CurrentContext)
 	}
 
-	viper.AddConfigPath(filepath.Join(home, RootConfigPathName, ContextsPathName))
+	viper.AddConfigPath(filepath.Join(home, rootConfigPathName, contextsPathName))
 	viper.SetConfigName(context)
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -149,7 +157,7 @@ func WriteYamlFile(filename string, value map[string]string) error {
 func WriteCurrentContextToConfigFile(value string) error {
 	home := GetHomeDir()
 
-	configFilePath := filepath.Join(home, RootConfigPathName, ContextConfigFileName)
+	configFilePath := filepath.Join(home, rootConfigPathName, contextConfigFileName)
 	file, err := decodeYAMLFile(configFilePath)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
@@ -53,16 +54,28 @@ type ContextFile struct {
 	EnvFnRegistry   string `yaml:"registry"`
 }
 
+// Init : Initialise/load config direc
+func Init() error {
+	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvPrefix("fn")
+
+	replacer := strings.NewReplacer("-", "_")
+	viper.SetEnvKeyReplacer(replacer)
+
+	viper.SetDefault(EnvFnAPIURL, defaultLocalAPIURL)
+
+	return ensureConfiguration()
+}
+
 // EnsureConfiguration ensures context configuration directory hierarchy is in place, if not
 // creates it and the default context configuration files
-func EnsureConfiguration() error {
+func ensureConfiguration() error {
 	home := GetHomeDir()
 
 	rootConfigPath := filepath.Join(home, rootConfigPathName)
 	if _, err := os.Stat(rootConfigPath); os.IsNotExist(err) {
 		if err = os.Mkdir(rootConfigPath, readWritePerms); err != nil {
 			return fmt.Errorf("error creating .fn directory %v", err)
-
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -52,16 +53,14 @@ type ContextFile struct {
 
 // EnsureConfiguration ensures context configuration directory hierarchy is in place, if not
 // creates it and the default context configuration files
-func EnsureConfiguration() {
-	home, err := GetHomeDir()
-	if err != nil {
-		fmt.Printf("%v", err)
-	}
+func EnsureConfiguration() error {
+	home := GetHomeDir()
 
 	rootConfigPath := filepath.Join(home, RootConfigPathName)
 	if _, err := os.Stat(rootConfigPath); os.IsNotExist(err) {
 		if err = os.Mkdir(rootConfigPath, readWritePerms); err != nil {
-			fmt.Fprintf(os.Stderr, "error creating .fn directory %v \n", err)
+			return fmt.Errorf("error creating .fn directory %v", err)
+
 		}
 	}
 
@@ -69,19 +68,19 @@ func EnsureConfiguration() {
 	if _, err := os.Stat(contextConfigFilePath); os.IsNotExist(err) {
 		_, err = os.Create(contextConfigFilePath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error creating config.yaml file %v \n", err)
+			return fmt.Errorf("error creating config.yaml file %v", err)
 		}
 
 		err = WriteYamlFile(contextConfigFilePath, DefaultRootConfigContents)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v \n", err)
+			return err
 		}
 	}
 
 	contextsPath := filepath.Join(rootConfigPath, ContextsPathName)
 	if _, err := os.Stat(contextsPath); os.IsNotExist(err) {
 		if err = os.Mkdir(contextsPath, readWritePerms); err != nil {
-			fmt.Fprintf(os.Stderr, "error creating contexts directory %v \n", err)
+			return fmt.Errorf("error creating contexts directory %v", err)
 		}
 	}
 
@@ -89,82 +88,110 @@ func EnsureConfiguration() {
 	if _, err := os.Stat(defaultContextPath); os.IsNotExist(err) {
 		_, err = os.Create(defaultContextPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error creating default.yaml context file %v \n", err)
+			return fmt.Errorf("error creating default.yaml context file %v", err)
 		}
 
 		err = WriteYamlFile(defaultContextPath, DefaultContextConfigContents)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v \n", err)
+			return err
 		}
 	}
+
+	return nil
 }
 
-func LoadConfiguration(c *cli.Context) {
+func LoadConfiguration(c *cli.Context) error {
 	// Find home directory.
-	home, err := GetHomeDir()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v \n", err)
-	}
-
+	home := GetHomeDir()
 	context := ""
 	if context = c.String(EnvFnContext); context == "" {
 		viper.AddConfigPath(filepath.Join(home, RootConfigPathName))
 		viper.SetConfigName(ConfigName)
 
-		if err := readConfig(); err != nil {
-			fmt.Fprintf(os.Stderr, "%v \n", err)
+		if err := viper.ReadInConfig(); err != nil {
+			return err
 		}
-
 		context = viper.GetString(CurrentContext)
 	}
 
 	viper.AddConfigPath(filepath.Join(home, RootConfigPathName, ContextsPathName))
 	viper.SetConfigName(context)
 
-	if err := readConfig(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v \n", err)
-		configFilePath := filepath.Join(home, RootConfigPathName, ContextConfigFileName)
-		configCurrentContext := map[string]string{CurrentContext: "default"}
-		err = WriteYamlFile(configFilePath, configCurrentContext)
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Printf("%v \n", err)
+		err := WriteCurrentContextToConfigFile("default")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v \n", err)
+			return err
 		}
-
 		fmt.Println("current context has been set to default")
-		os.Exit(1)
+		return nil
 	}
 
 	viper.Set(CurrentContext, context)
+	return nil
 }
 
 // WriteYamlFile writes to the yaml file
 func WriteYamlFile(filename string, value map[string]string) error {
 	marshaled, err := yaml.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("%v", err)
+		return err
 	}
 
 	err = ioutil.WriteFile(filename, marshaled, readWritePerms)
 	if err != nil {
-		return fmt.Errorf("error writing to file %v", err)
+		return err
 	}
 
 	return nil
 }
 
-func readConfig() error {
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		return fmt.Errorf("%v", err)
+func WriteCurrentContextToConfigFile(value string) error {
+	home := GetHomeDir()
+
+	configFilePath := filepath.Join(home, RootConfigPathName, ContextConfigFileName)
+	file, err := decodeYAMLFile(configFilePath)
+	if err != nil {
+		return err
 	}
+
+	configValues := map[string]string{}
+
+	for k, v := range file {
+		if k == CurrentContext {
+			configValues[k] = value
+		} else {
+			configValues[k] = v
+		}
+	}
+
+	err = WriteYamlFile(configFilePath, configValues)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func GetHomeDir() (string, error) {
+func decodeYAMLFile(path string) (map[string]string, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
+	}
+
+	yf := map[string]string{}
+	err = yaml.Unmarshal(b, yf)
+	if err != nil {
+		return nil, err
+	}
+	return yf, err
+}
+
+func GetHomeDir() string {
 	home, err := homedir.Dir()
 	if err != nil {
-		return "", fmt.Errorf("error getting home directory %v", err)
+		log.Fatalln("could not get home directory:", err)
 	}
 
-	return home, nil
+	return home
 }

--- a/context.go
+++ b/context.go
@@ -60,11 +60,11 @@ func contextCmd() cli.Command {
 				Action:  list,
 			},
 			{
-				Name:      "set",
-				Aliases:   []string{"s"},
-				Usage:     "set context for future invocations",
+				Name:      "use",
+				Aliases:   []string{"u"},
+				Usage:     "use context for future invocations",
 				ArgsUsage: "<context>",
-				Action:    set,
+				Action:    use,
 			},
 			{
 				Name:   "unset",
@@ -157,7 +157,7 @@ func delete(c *cli.Context) error {
 	return nil
 }
 
-func set(c *cli.Context) error {
+func use(c *cli.Context) error {
 	context := c.Args().Get(0)
 
 	if check, err := checkContextFileExists(context); !check {
@@ -168,7 +168,7 @@ func set(c *cli.Context) error {
 	}
 
 	if context == viper.GetString(config.CurrentContext) {
-		return fmt.Errorf("context %v already set", context)
+		return fmt.Errorf("context %v currently in use", context)
 	}
 
 	err := config.WriteCurrentContextToConfigFile(context)
@@ -177,13 +177,13 @@ func set(c *cli.Context) error {
 	}
 	viper.Set(config.CurrentContext, context)
 
-	fmt.Printf("Successfully set context: %v \n", context)
+	fmt.Printf("Successfully using context: %v \n", context)
 	return nil
 }
 
 func unset(c *cli.Context) error {
 	if currentContext := viper.GetString(config.CurrentContext); currentContext == "" {
-		return errors.New("no context set")
+		return errors.New("no context currently in use")
 	}
 
 	err := config.WriteCurrentContextToConfigFile("")

--- a/context.go
+++ b/context.go
@@ -77,7 +77,7 @@ func create(c *cli.Context) error {
 	re := regexp.MustCompile("[^a-zA-Z0-9_-]+")
 
 	for range re.FindAllString(context, -1) {
-		fmt.Println("please enter a context name with ASCII characters only")
+		fmt.Fprintf(os.Stderr, "please enter a context name with ASCII characters only \n")
 		os.Exit(1)
 	}
 

--- a/context.go
+++ b/context.go
@@ -226,8 +226,7 @@ func list(c *cli.Context) error {
 		}
 		fmt.Fprint(w, current, "\t", name, "\t", v.ContextProvider, "\t", v.EnvFnAPIURL, "\t", v.EnvFnRegistry, "\n")
 	}
-	w.Flush()
-	return nil
+	return w.Flush()
 }
 
 func createFilePath(filename string) (string, error) {
@@ -263,7 +262,7 @@ func ValidateContextName(context string) error {
 	re := regexp.MustCompile("[^a-zA-Z0-9_-]+")
 
 	for range re.FindAllString(context, -1) {
-		return errors.New("please enter a context name with ASCII characters only")
+		return errors.New("please enter a context name with only Alphanumeric, _, or -")
 	}
 	return nil
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/viper"
+	yaml "gopkg.in/yaml.v2"
+
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/fnproject/cli/config"
+	"github.com/urfave/cli"
+)
+
+var contextsPath = filepath.Join(config.RootConfigPathName, config.ContextsPathName)
+var defaultContextPath string
+
+func contextCmd() cli.Command {
+	return cli.Command{
+		Name:  "context",
+		Usage: "manage context",
+		Subcommands: []cli.Command{
+			{
+				Name:      "create",
+				Aliases:   []string{"c"},
+				Usage:     "create a new context",
+				ArgsUsage: "<context>",
+				Action:    create,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "provider",
+						Usage: "context provider",
+					},
+					cli.StringFlag{
+						Name:  "api-url",
+						Usage: "context api url",
+					},
+					cli.StringFlag{
+						Name:  "registry",
+						Usage: "context registry",
+					},
+				},
+			},
+			{
+				Name:      "delete",
+				Aliases:   []string{"d"},
+				Usage:     "delete a context",
+				ArgsUsage: "<context>",
+				Action:    delete,
+			},
+			{
+				Name:    "list",
+				Aliases: []string{"l"},
+				Usage:   "list contexts",
+				Action:  list,
+			},
+			{
+				Name:      "set",
+				Aliases:   []string{"s"},
+				Usage:     "set context for future invocations",
+				ArgsUsage: "<context>",
+				Action:    set,
+			},
+		},
+	}
+}
+
+func create(c *cli.Context) error {
+	context := c.Args().Get(0)
+
+	re := regexp.MustCompile("[^a-zA-Z0-9_-]+")
+
+	for range re.FindAllString(context, -1) {
+		fmt.Println("please enter a context name with ASCII characters only")
+		os.Exit(1)
+	}
+
+	provider := config.DefaultProvider
+	if cProvider := c.String("provider"); cProvider != "" {
+		provider = cProvider
+	}
+
+	apiUrl := config.DefaultLocalApiUrl
+	if cApiUrl := c.String("api-url"); cApiUrl != "" {
+		apiUrl = cApiUrl
+	}
+
+	registry := ""
+	if cRegistry := c.String("registry"); cRegistry != "" {
+		registry = cRegistry
+	}
+
+	if check, err := checkContextFileExists(context); check {
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return errors.New("context already exists")
+
+	}
+	path, err := createFilePath(context)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	_, err = os.Create(path)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	contextValues := map[string]string{
+		config.ContextProvider: provider,
+		config.EnvFnAPIURL:     apiUrl,
+		config.EnvFnRegistry:   registry,
+	}
+
+	err = config.WriteYamlFile(path, contextValues)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	fmt.Printf("Successfully created context: %v \n", context)
+	return nil
+}
+
+func delete(c *cli.Context) error {
+	context := c.Args().Get(0)
+
+	if check, err := checkContextFileExists(context); !check {
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return errors.New("context file not found")
+	}
+
+	if context == viper.GetString(config.CurrentContext) {
+		return fmt.Errorf("can not delete the current context: %v", context)
+	}
+
+	if context == "default" {
+		return errors.New("can not delete default context")
+	}
+
+	path, err := createFilePath(context)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	os.Remove(path)
+	fmt.Printf("Context %v deleted \n", context)
+	return nil
+}
+
+func set(c *cli.Context) error {
+	context := c.Args().Get(0)
+
+	home, err := config.GetHomeDir()
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	configFilePath := filepath.Join(home, config.RootConfigPathName, config.ContextConfigFileName)
+
+	if check, err := checkContextFileExists(context); !check {
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return errors.New("context file not found")
+	}
+
+	if context == viper.GetString(config.CurrentContext) {
+		return fmt.Errorf("context %v already set", context)
+	}
+
+	viper.Set(config.CurrentContext, context)
+
+	configCurrentContext := map[string]string{config.CurrentContext: context}
+	err = config.WriteYamlFile(configFilePath, configCurrentContext)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	fmt.Printf("Successfully set context: %v \n", context)
+	return nil
+}
+
+func list(c *cli.Context) error {
+	currentContext := viper.GetString(config.CurrentContext)
+	files, err := getAvailableContexts()
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	fmt.Fprint(w, "CURRENT", "\t", "NAME", "\t", "PROVIDER", "\t", "API URL", "\t", "REGISTRY", "\n")
+
+	for _, f := range files {
+		current := ""
+
+		home, err := config.GetHomeDir()
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+
+		path := filepath.Join(home, contextsPath, f.Name())
+		yamlFile, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+
+		v := config.ContextFile{}
+		err = yaml.Unmarshal(yamlFile, &v)
+
+		name := strings.Replace(f.Name(), ".yaml", "", 1)
+		if currentContext == name {
+			current = "*"
+		}
+		fmt.Fprint(w, current, "\t", name, "\t", v.ContextProvider, "\t", v.EnvFnAPIURL, "\t", v.EnvFnRegistry, "\n")
+	}
+	w.Flush()
+	return nil
+}
+
+func createFilePath(filename string) (string, error) {
+	contextFileName := filename + ".yaml"
+	home, err := config.GetHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("%v", err)
+	}
+	path := filepath.Join(home, contextsPath, contextFileName)
+	return path, nil
+}
+
+func checkContextFileExists(filename string) (bool, error) {
+	path, err := createFilePath(filename)
+	if err != nil {
+		return false, fmt.Errorf("%v", err)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func getAvailableContexts() ([]os.FileInfo, error) {
+	home, err := config.GetHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	files, err := ioutil.ReadDir(filepath.Join(home, contextsPath))
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/context.go
+++ b/context.go
@@ -18,7 +18,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var contextsPath = filepath.Join(config.RootConfigPathName, config.ContextsPathName)
+var contextsPath = config.GetContextsPath()
 
 func contextCmd() cli.Command {
 	return cli.Command{

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidateContextName(t *testing.T) {
+	var testsCases = []struct {
+		name        string
+		expectedErr string
+	}{
+		{name: "local", expectedErr: ""},
+		{name: "Local", expectedErr: ""},
+		{name: "../local", expectedErr: "please enter a context name with ASCII characters only"},
+		{name: "local-context", expectedErr: ""},
+		{name: "local_context", expectedErr: ""},
+		{name: "local1", expectedErr: ""},
+		{name: "local-context-1", expectedErr: ""},
+		{name: "local?context", expectedErr: "please enter a context name with ASCII characters only"},
+		{name: "context>?", expectedErr: "please enter a context name with ASCII characters only"},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errString := ""
+			if err := ValidateContextName(tc.name); err != nil {
+				errString = err.Error()
+			}
+			if tc.expectedErr != errString {
+				t.Fatalf("expected %s but got %s", tc.expectedErr, errString)
+			}
+		})
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -11,13 +11,13 @@ func TestValidateContextName(t *testing.T) {
 	}{
 		{name: "local", expectedErr: ""},
 		{name: "Local", expectedErr: ""},
-		{name: "../local", expectedErr: "please enter a context name with ASCII characters only"},
+		{name: "../local", expectedErr: "please enter a context name with only Alphanumeric, _, or -"},
 		{name: "local-context", expectedErr: ""},
 		{name: "local_context", expectedErr: ""},
 		{name: "local1", expectedErr: ""},
 		{name: "local-context-1", expectedErr: ""},
-		{name: "local?context", expectedErr: "please enter a context name with ASCII characters only"},
-		{name: "context>?", expectedErr: "please enter a context name with ASCII characters only"},
+		{name: "local?context", expectedErr: "please enter a context name with only Alphanumeric, _, or -"},
+		{name: "context>?", expectedErr: "please enter a context name with only Alphanumeric, _, or -"},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -150,6 +150,10 @@ func prepareCmdArgsValidation(cmds []cli.Command) {
 func init() {
 	viper.AutomaticEnv() // read in environment variables that match
 	viper.SetEnvPrefix("fn")
+
+	replacer := strings.NewReplacer("-", "_")
+	viper.SetEnvKeyReplacer(replacer)
+
 	err := config.EnsureConfiguration()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ LEARN MORE:
 		logs(),
 		testfn(),
 		buildServer(),
+		contextCmd(),
 	}
 	app.Commands = append(app.Commands, aliasesFn()...)
 
@@ -145,10 +146,7 @@ func prepareCmdArgsValidation(cmds []cli.Command) {
 
 func init() {
 	viper.AutomaticEnv() // read in environment variables that match
-
 	viper.SetEnvPrefix("fn")
-	viper.SetDefault(config.EnvFnAPIURL, "http://localhost:8080/v1")
-
 	config.EnsureConfiguration()
 }
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,10 @@ func newFn() *cli.App {
 	app.Authors = []cli.Author{{Name: "Fn Project"}}
 	app.Description = "Fn command line tool"
 	app.Before = func(c *cli.Context) error {
-		config.LoadConfiguration(c)
+		err := config.LoadConfiguration(c)
+		if err != nil {
+			return err
+		}
 		commandArgOverrides(c)
 		return nil
 	}
@@ -147,7 +150,11 @@ func prepareCmdArgsValidation(cmds []cli.Command) {
 func init() {
 	viper.AutomaticEnv() // read in environment variables that match
 	viper.SetEnvPrefix("fn")
-	config.EnsureConfiguration()
+	err := config.EnsureConfiguration()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func commandArgOverrides(c *cli.Context) {

--- a/main.go
+++ b/main.go
@@ -148,13 +148,7 @@ func prepareCmdArgsValidation(cmds []cli.Command) {
 }
 
 func init() {
-	viper.AutomaticEnv() // read in environment variables that match
-	viper.SetEnvPrefix("fn")
-
-	replacer := strings.NewReplacer("-", "_")
-	viper.SetEnvKeyReplacer(replacer)
-
-	err := config.EnsureConfiguration()
+	err := config.Init()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)

--- a/routes.go
+++ b/routes.go
@@ -173,9 +173,13 @@ func routes() cli.Command {
 }
 
 func call() cli.Command {
-	r := routesCmd{client: client.APIClient()}
+	r := routesCmd{}
 
 	return cli.Command{
+		Before: func(c *cli.Context) error {
+			r.client = client.APIClient()
+			return nil
+		},
 		Name:      "call",
 		Usage:     "call a remote function",
 		ArgsUsage: "<app> </path>",

--- a/start.go
+++ b/start.go
@@ -88,5 +88,4 @@ func start(c *cli.Context) error {
 		}
 		return err
 	}
-	return nil
 }


### PR DESCRIPTION
Related to issue: [#217](https://github.com/fnproject/cli/issues/217) 

Added the context commands, create, delete, list, set and unset to manage context files.

Create command checks the file hasn't already been created and creates it either with 'default'
values or with values passed in through the `--provider` and `--apiurl` flags.

Delete command checks the `<context>` files exists and that it is not the current context. Only then can it be deleted. The default context cannot be deleted as it is protected.

Set checks there is a context file and sets the current context to the passed in `<context>` and
updates the config.yaml file.

Unset will update the config.yaml to `""` un-setting the current-context.

List shows all available context files, unmarshals them and appends them to a table, showing the current context with a `*`


