### PR TITLE
FN_API_URL was requiring new /v1 

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
+	"strings"
 	"syscall"
 
 	"github.com/fnproject/cli/config"
@@ -27,6 +28,14 @@ func HostURL() *url.URL {
 	url, err := url.Parse(apiURL)
 	if err != nil {
 		panic(fmt.Sprintf("Unparsable FN API Url: %s. Error: %s", apiURL, err))
+	}
+
+	// TODO is this ok for providers? idk, this could be specific. this allows `/v*`
+	if !strings.HasPrefix(url.Path, "/v") {
+		url.Path = "/v1"
+	}
+	if url.Scheme == "" {
+		url.Scheme = "http"
 	}
 
 	return url

--- a/test.sh
+++ b/test.sh
@@ -33,8 +33,9 @@ go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 export FN_API_URL="http://localhost:8080/"
 go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 
-export FN_API_URL="localhost:8080"
-go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
+# TODO this would be nice, too
+#export FN_API_URL="localhost:8080"
+#go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 
 # Our test directory
 OS=$(uname -s)

--- a/test.sh
+++ b/test.sh
@@ -21,8 +21,19 @@ if [[ -z "$FN_REGISTRY" ]]; then
 fi
 $fn --version
 
+# test the 'full' way
 export FN_API_URL="http://localhost:8080/v1"
 
+go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
+
+# test various 'stripped' ways
+export FN_API_URL="http://localhost:8080"
+go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
+
+export FN_API_URL="http://localhost:8080/"
+go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
+
+export FN_API_URL="localhost:8080"
 go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 
 # Our test directory


### PR DESCRIPTION
closes #239

all our docs have `FN_API_URL` without specifying a host path version. this
seems like a pretty sane default we can support anyway if a user doesn't
specify a version (maybe one day we have multiple). the tests were passing
because the tests provided `/v1` in the url used for tests. now the tests are
run in various ways that we should probably expect a user could provide
`FN_API_URL`, including without the version.  obviously, running the test
suite multiple times isn't ideal, but this could tide us over until someone
has time to do something that doesn't smell so bad (since master is broked).

breakage was from #233 changing to /v1, just seems like we need more robust
testing of expected URLs is all, not a big deal.