### PR TITLE
Add unit tests for fn api url configuration parsing

### DIFF
--- a/client/api_test.go
+++ b/client/api_test.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"testing"
+)
+
+func TestHostURL(t *testing.T) {
+	var tests = []struct {
+		input  string
+		scheme string
+		host   string
+		port   string
+		path   string
+	}{
+		{"http://localhost:8080/v1", "http", "localhost", "8080", "/v1"},
+		{"http://localhost:8080", "http", "localhost", "8080", "/v1"},
+		{"http://localhost", "http", "localhost", "80", "/v1"},
+		{"localhost", "http", "localhost", "80", "/v1"},
+		{"localhost:8080", "http", "localhost", "8080", "/v1"},
+		{"localhost/v1", "http", "localhost", "80", "/v1"},
+		{"localhost/", "http", "localhost", "80", "/v1"},
+		{"https://localhost/v1", "https", "localhost", "443", "/v1"},
+		{"https://someprovider/specificversion/withasubpath", "https", "someprovider", "443", "/specificversion/withasubpath"},
+		{"https://someprovider:450/specificversion/withasubpath", "https", "someprovider", "450", "/specificversion/withasubpath"},
+	}
+	for _, test := range tests {
+		url := hostURL(test.input)
+
+		if url.Scheme != test.scheme {
+			t.Errorf("Scheme not parsed: %s, %s", test.input, url.Scheme)
+		}
+		if url.Hostname() != test.host {
+			t.Errorf("Host not parsed: %s, %s", test.input, url.Hostname())
+		}
+		if url.Port() != test.port {
+			t.Errorf("Port not parsed: %s, %s", test.input, url.Port())
+		}
+		if url.Path != test.path {
+			t.Errorf("Path not parsed: %s, %s", test.input, url.Path)
+		}
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -21,21 +21,8 @@ if [[ -z "$FN_REGISTRY" ]]; then
 fi
 $fn --version
 
-# test the 'full' way
-export FN_API_URL="http://localhost:8080/v1"
-
+export FN_API_URL="localhost:8080"
 go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
-
-# test various 'stripped' ways
-export FN_API_URL="http://localhost:8080"
-go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
-
-export FN_API_URL="http://localhost:8080/"
-go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
-
-# TODO this would be nice, too
-#export FN_API_URL="localhost:8080"
-#go test $(go list ./... | grep -v /vendor/ | grep -v /tests)
 
 # Our test directory
 OS=$(uname -s)


### PR DESCRIPTION
Instead of running the full test suite multiple times, test the
HostURL parsing function with a set of unit tests.

Defaults for scheme (http), scheme appropriate port, and backwards
compatible path (/v1)