### PR TITLE
[258] Support build-arg in fn build, run, deploy.

### DIFF
--- a/build.go
+++ b/build.go
@@ -35,6 +35,10 @@ func (b *buildcmd) flags() []cli.Flag {
 			Usage:       "Don't use docker cache",
 			Destination: &b.noCache,
 		},
+		cli.StringSliceFlag{
+			Name:  "build-arg",
+			Usage: "set build-time variables",
+		},
 	}
 }
 
@@ -49,7 +53,8 @@ func (b *buildcmd) build(c *cli.Context) error {
 		return err
 	}
 
-	ff, err = buildfunc(c, fpath, ff, b.noCache)
+	buildArgs := c.StringSlice("build-arg")
+	ff, err = buildfunc(c, fpath, ff, buildArgs, b.noCache)
 	if err != nil {
 		return err
 	}

--- a/build_server.go
+++ b/build_server.go
@@ -99,7 +99,7 @@ func (b *buildServerCmd) buildServer(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = runBuild(c, dir, c.String("tag"), "Dockerfile", b.noCache)
+	err = runBuild(c, dir, c.String("tag"), "Dockerfile", nil, b.noCache)
 	if err != nil {
 		return err
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -81,6 +81,10 @@ func (p *deploycmd) flags() []cli.Flag {
 			Usage:       "Don't bump the version, assuming external version management",
 			Destination: &p.noBump,
 		},
+		cli.StringSliceFlag{
+			Name:  "build-arg",
+			Usage: "set build time variables",
+		},
 	}
 }
 
@@ -260,7 +264,8 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 		// TODO: this whole funcfile handling needs some love, way too confusing. Only bump makes permanent changes to it.
 	}
 
-	_, err = buildfunc(c, funcfilePath, funcfile, p.noCache)
+	buildArgs := c.StringSlice("build-arg")
+	_, err = buildfunc(c, funcfilePath, funcfile, buildArgs, p.noCache)
 	if err != nil {
 		return err
 	}

--- a/run.go
+++ b/run.go
@@ -66,6 +66,10 @@ func runflags() []cli.Flag {
 			Name:  "no-cache",
 			Usage: "Don't use Docker cache for the build",
 		},
+		cli.StringSliceFlag{
+			Name:  "build-arg",
+			Usage: "set build time variables",
+		},
 	}
 }
 
@@ -118,7 +122,8 @@ func preRun(c *cli.Context) (string, *funcfile, []string, error) {
 		ff.Name = filepath.Base(filepath.Dir(fpath)) // todo: should probably make a copy of ff before changing it
 	}
 
-	_, err = buildfunc(c, fpath, ff, c.Bool("no-cache"))
+	buildArgs := c.StringSlice("build-arg")
+	_, err = buildfunc(c, fpath, ff, buildArgs, c.Bool("no-cache"))
 	if err != nil {
 		return fpath, nil, nil, err
 	}


### PR DESCRIPTION
We have a function with a custom `pom.xml` and custom` Dockerfile`. The build has multiple profiles (default, release). The release build contains more optimisations. To support this we need to pass build arguments to the `Docker build` command. Currently there is no support for this in the `fn run` or in `fn deploy`.

This Pull Request adds a possibility to pass the `build-arg` to `fn build`, `fn run` and `fn deploy`.

Open questions:
1. The `Dockerfile` has to have an `ARG` directive for each `build-arg`. For our case it's not a problem as we have a custom `Dockerfile`. How to support the `build-arg` with `LanguageHelper`s?
