### PR TITLE
Read Oracle credentials from /.oci/config file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -316,7 +316,7 @@
   packages = [
     ".",
     "common"
-  ]
+  ] 
   revision = "da236067a45ec155db5196363079c8db6fb7657e"
   version = "v1.4.0"
 
@@ -445,6 +445,10 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
+<<<<<<< HEAD
   inputs-digest = "4636dc75bd93dc8837fa60dcc9c3ff25d40fab3f3eaba6bab340f8bd81cb6bca"
+=======
+  inputs-digest = "45e59942884c330ac0680379310c97d6ad2dbb8fa78e38850aff6f0bb0a0abeb"
+>>>>>>> e4a8ff5... Add the ability to have no pass-phrase for a private key.
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,10 +445,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-<<<<<<< HEAD
   inputs-digest = "4636dc75bd93dc8837fa60dcc9c3ff25d40fab3f3eaba6bab340f8bd81cb6bca"
-=======
-  inputs-digest = "45e59942884c330ac0680379310c97d6ad2dbb8fa78e38850aff6f0bb0a0abeb"
->>>>>>> e4a8ff5... Add the ability to have no pass-phrase for a private key.
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/apps.go
+++ b/apps.go
@@ -28,8 +28,9 @@ func apps() cli.Command {
 		Name:  "apps",
 		Usage: "manage applications",
 		Before: func(c *cli.Context) error {
-			a.client = client.APIClient()
-			return nil
+			var err error
+			a.client, err = client.APIClient()
+			return err
 		},
 		Subcommands: []cli.Command{
 			{

--- a/calls.go
+++ b/calls.go
@@ -24,8 +24,9 @@ func calls() cli.Command {
 		Name:  "calls",
 		Usage: "manage function calls for apps",
 		Before: func(cxt *cli.Context) error {
-			c.client = client.APIClient()
-			return nil
+			var err error
+			c.client, err = client.APIClient()
+			return err
 		},
 		Subcommands: []cli.Command{
 			{

--- a/client/api.go
+++ b/client/api.go
@@ -64,7 +64,6 @@ func defaultProvider(transport *openapi.Runtime) {
 }
 
 func challengeForPKeyPassword() string {
-	fmt.Print("Private Key Phrase: ")
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		panic(fmt.Sprintf("%s", err))

--- a/config/config.go
+++ b/config/config.go
@@ -29,15 +29,6 @@ const (
 	EnvFnToken    = "token"
 	EnvFnAPIURL   = "api-url"
 	EnvFnContext  = "context"
-
-	OracleTenancyID     = "oracle.tenancy-id"
-	OracleUserID        = "oracle.user-id"
-	OracleFingerprint   = "oracle.fingerprint"
-	OracleKeyFile       = "oracle.key-file"
-	OraclePassPhrase    = "oracle.pass-phrase"
-	OracleCompartmentID = "oracle.compartment-id"
-	OracleDisableCerts  = "oracle.disable-certs"
-	OracleProfile       = "oracle.profile"
 )
 
 var defaultRootConfigContents = &ContextMap{CurrentContext: ""}

--- a/config/config.go
+++ b/config/config.go
@@ -30,10 +30,15 @@ const (
 	EnvFnAPIURL   = "api-url"
 	EnvFnContext  = "context"
 
-	OracleKeyID         = "key-id"
-	OraclePrivateKey    = "private-key"
-	OracleCompartmentID = "compartment-id"
+	OracleSubnetID      = "oracle.subnet-id"
+	OracleTenancyID     = "oracle.tenancy-id"
+	OracleUserID        = "oracle.user-id"
+	OracleFingerprint   = "oracle.fingerprint"
+	OracleKeyFile       = "oracle.key-file"
+	OraclePassPhrase    = "oracle.pass-phrase"
+	OracleCompartmentID = "oracle.compartment-id"
 	OracleDisableCerts  = "disable-certs"
+	OracleProfile       = "oracle.profile"
 )
 
 var defaultRootConfigContents = &ContextMap{CurrentContext: ""}

--- a/config/config.go
+++ b/config/config.go
@@ -30,14 +30,13 @@ const (
 	EnvFnAPIURL   = "api-url"
 	EnvFnContext  = "context"
 
-	OracleSubnetID      = "oracle.subnet-id"
 	OracleTenancyID     = "oracle.tenancy-id"
 	OracleUserID        = "oracle.user-id"
 	OracleFingerprint   = "oracle.fingerprint"
 	OracleKeyFile       = "oracle.key-file"
 	OraclePassPhrase    = "oracle.pass-phrase"
 	OracleCompartmentID = "oracle.compartment-id"
-	OracleDisableCerts  = "disable-certs"
+	OracleDisableCerts  = "oracle.disable-certs"
 	OracleProfile       = "oracle.profile"
 )
 

--- a/deploy.go
+++ b/deploy.go
@@ -25,8 +25,9 @@ func deploy() cli.Command {
 		Flags:  flags,
 		Action: cmd.deploy,
 		Before: func(cxt *cli.Context) error {
-			cmd.Fn = client.APIClient()
-			return nil
+			var err error
+			cmd.Fn, err = client.APIClient()
+			return err
 		},
 	}
 }
@@ -292,8 +293,11 @@ func setRootFuncInfo(ff *funcfile, appName string) {
 
 func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *funcfile) error {
 	fmt.Printf("Updating route %s using image %s...\n", ff.Path, ff.ImageName())
-
-	routesCmd := routesCmd{client: client.APIClient()}
+	client, err := client.APIClient()
+	if err != nil {
+		return err
+	}
+	routesCmd := routesCmd{client: client}
 	rt := &models.Route{}
 	if err := routeWithFuncFile(ff, rt); err != nil {
 		return fmt.Errorf("error getting route with funcfile: %s", err)

--- a/logs.go
+++ b/logs.go
@@ -23,8 +23,9 @@ func logs() cli.Command {
 		Name:  "logs",
 		Usage: "manage function calls for apps",
 		Before: func(cxt *cli.Context) error {
-			c.client = client.APIClient()
-			return nil
+			var err error
+			c.client, err = client.APIClient()
+			return err
 		},
 		Subcommands: []cli.Command{
 			{

--- a/routes.go
+++ b/routes.go
@@ -75,8 +75,9 @@ func routes() cli.Command {
 		Name:  "routes",
 		Usage: "manage routes",
 		Before: func(c *cli.Context) error {
-			r.client = client.APIClient()
-			return nil
+			var err error
+			r.client, err = client.APIClient()
+			return err
 		},
 		Subcommands: []cli.Command{
 			{
@@ -177,8 +178,9 @@ func call() cli.Command {
 
 	return cli.Command{
 		Before: func(c *cli.Context) error {
-			r.client = client.APIClient()
-			return nil
+			var err error
+			r.client, err = client.APIClient()
+			return err
 		},
 		Name:      "call",
 		Usage:     "call a remote function",

--- a/testfn.go
+++ b/testfn.go
@@ -32,8 +32,9 @@ func testfn() cli.Command {
 		Flags:  cmd.flags(),
 		Action: cmd.test,
 		Before: func(cxt *cli.Context) error {
-			cmd.Fn = client.APIClient()
-			return nil
+			var err error
+			cmd.Fn, err = client.APIClient()
+			return err
 		},
 	}
 }

--- a/version.go
+++ b/version.go
@@ -20,7 +20,10 @@ func version() cli.Command {
 }
 
 func versionCMD(c *cli.Context) error {
-	t, reg := client.GetTransportAndRegistry()
+	t, reg, err := client.GetTransportAndRegistry()
+	if err != nil {
+		return err
+	}
 	// dirty hack, swagger paths live under /v1
 	// version is also there, but it shouldn't
 	// dropping base path to get appropriate URL for request eventually


### PR DESCRIPTION
Replace `key-id` in context file with the 3 join values, `oracle.tenancy-id`, `oracle.user-id` & `oracle.fingerprint` and join them together in code instead.

Replace panics with prints to stderr and os.Exit() if pass-phrase is wrong.

Try to get private Key without a password in the case the private key isn't encrypted. Check if pass-phrase is present in the context file if so use don't prompt each time for a password.

Read from `/.oci/config` if values are not present in the context file. 

Add `profile` key to Oracle provider context files which enables users to use the different profiles present in the `config` file. If no provider is specified, default to "DEFAULT"