### PR TITLE
Support setting annotations on apps and routes

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -44,6 +44,10 @@ func apps() cli.Command {
 						Name:  "config",
 						Usage: "application configuration",
 					},
+					cli.StringSliceFlag{
+						Name:  "annotation",
+						Usage: "application annotations",
+					},
 				},
 			},
 			{
@@ -170,10 +174,14 @@ func (a *appsCmd) list(c *cli.Context) error {
 }
 
 func (a *appsCmd) create(c *cli.Context) error {
-	body := &models.AppWrapper{App: &models.App{
-		Name:   c.Args().Get(0),
-		Config: extractEnvConfig(c.StringSlice("config")),
-	}}
+
+	app := &models.App{
+		Name: c.Args().Get(0),
+	}
+
+	appWithFlags(c, app)
+
+	body := &models.AppWrapper{App: app}
 
 	resp, err := a.client.Apps.PostApps(&apiapps.PostAppsParams{
 		Context: context.Background(),
@@ -195,12 +203,38 @@ func (a *appsCmd) create(c *cli.Context) error {
 	return nil
 }
 
+func appWithFlags(c *cli.Context, app *models.App) {
+	if len(app.Config) == 0 {
+		app.Config = extractEnvConfig(c.StringSlice("config"))
+	}
+	if len(app.Annotations) == 0 {
+		if len(c.StringSlice("annotation")) > 0 {
+			annotations := make(map[string]interface{})
+			for _, s := range c.StringSlice("annotation") {
+				parts := strings.Split(s, "=")
+				if len(parts) == 2 {
+					var v interface{}
+					err := json.Unmarshal([]byte(parts[1]), &v)
+					if err != nil {
+						fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
+					} else {
+						annotations[parts[0]] = v
+					}
+				} else {
+					fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
+				}
+			}
+			app.Annotations = annotations
+		}
+	}
+}
+
 func (a *appsCmd) update(c *cli.Context) error {
 	appName := c.Args().First()
 
-	patchedApp := &models.App{
-		Config: extractEnvConfig(c.StringSlice("config")),
-	}
+	patchedApp := &models.App{}
+
+	appWithFlags(c, patchedApp)
 
 	err := a.patchApp(appName, patchedApp)
 	if err != nil {

--- a/apps.go
+++ b/apps.go
@@ -213,22 +213,7 @@ func appWithFlags(c *cli.Context, app *models.App) {
 	}
 	if len(app.Annotations) == 0 {
 		if len(c.StringSlice("annotation")) > 0 {
-			annotations := make(map[string]interface{})
-			for _, s := range c.StringSlice("annotation") {
-				parts := strings.Split(s, "=")
-				if len(parts) == 2 {
-					var v interface{}
-					err := json.Unmarshal([]byte(parts[1]), &v)
-					if err != nil {
-						fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
-					} else {
-						annotations[parts[0]] = v
-					}
-				} else {
-					fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
-				}
-			}
-			app.Annotations = annotations
+			app.Annotations = extractAnnotations(c)
 		}
 	}
 }

--- a/apps.go
+++ b/apps.go
@@ -66,7 +66,11 @@ func apps() cli.Command {
 				Flags: []cli.Flag{
 					cli.StringSliceFlag{
 						Name:  "config,c",
-						Usage: "route configuration",
+						Usage: "application configuration",
+					},
+					cli.StringSliceFlag{
+						Name:  "annotation",
+						Usage: "application annotations",
 					},
 				},
 			},

--- a/common.go
+++ b/common.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -347,4 +348,23 @@ func appNamePath(img string) (string, string) {
 		tag = len(img[sep:])
 	}
 	return img[:sep], img[sep : sep+tag]
+}
+
+func extractAnnotations(c *cli.Context) map[string]interface{} {
+	annotations := make(map[string]interface{})
+	for _, s := range c.StringSlice("annotation") {
+		parts := strings.Split(s, "=")
+		if len(parts) == 2 {
+			var v interface{}
+			err := json.Unmarshal([]byte(parts[1]), &v)
+			if err != nil {
+				fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
+			} else {
+				annotations[parts[0]] = v
+			}
+		} else {
+			fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
+		}
+	}
+	return annotations
 }

--- a/common.go
+++ b/common.go
@@ -358,12 +358,12 @@ func extractAnnotations(c *cli.Context) map[string]interface{} {
 			var v interface{}
 			err := json.Unmarshal([]byte(parts[1]), &v)
 			if err != nil {
-				fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
+				fmt.Fprintf(os.Stderr, "Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
 			} else {
 				annotations[parts[0]] = v
 			}
 		} else {
-			fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
+			fmt.Fprintf(os.Stderr, "Annotations must be specified in the form key='value', where value is a valid JSON string")
 		}
 	}
 	return annotations

--- a/routes.go
+++ b/routes.go
@@ -57,8 +57,8 @@ var routeFlags = []cli.Flag{
 		Usage: "route idle timeout (eg. 30)",
 	},
 	cli.StringSliceFlag{
-		Name:  "annotations",
-		Usage: "route annotations",
+		Name:  "annotation",
+		Usage: "route annotation (can be specified multiple times)",
 	},
 }
 
@@ -318,9 +318,9 @@ func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {
 		}
 	}
 	if len(rt.Annotations) == 0 {
-		if len(c.StringSlice("annotations")) > 0 {
+		if len(c.StringSlice("annotation")) > 0 {
 			annotations := make(map[string]interface{})
-			for _, s := range c.StringSlice("annotations") {
+			for _, s := range c.StringSlice("annotation") {
 				parts := strings.Split(s, "=")
 				if len(parts) == 2 {
 					var v interface{}

--- a/routes.go
+++ b/routes.go
@@ -56,6 +56,10 @@ var routeFlags = []cli.Flag{
 		Name:  "idle-timeout",
 		Usage: "route idle timeout (eg. 30)",
 	},
+	cli.StringSliceFlag{
+		Name:  "annotations",
+		Usage: "route annotations",
+	},
 }
 
 var updateRouteFlags = routeFlags
@@ -311,6 +315,26 @@ func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {
 	if len(rt.Config) == 0 {
 		if len(c.StringSlice("config")) > 0 {
 			rt.Config = extractEnvConfig(c.StringSlice("config"))
+		}
+	}
+	if len(rt.Annotations) == 0 {
+		if len(c.StringSlice("annotations")) > 0 {
+			annotations := make(map[string]interface{})
+			for _, s := range c.StringSlice("annotations") {
+				parts := strings.Split(s, "=")
+				if len(parts) == 2 {
+					var v interface{}
+					err := json.Unmarshal([]byte(parts[1]), &v)
+					if err != nil {
+						fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
+					} else {
+						annotations[parts[0]] = v
+					}
+				} else {
+					fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
+				}
+			}
+			rt.Annotations = annotations
 		}
 	}
 }

--- a/routes.go
+++ b/routes.go
@@ -319,22 +319,7 @@ func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {
 	}
 	if len(rt.Annotations) == 0 {
 		if len(c.StringSlice("annotation")) > 0 {
-			annotations := make(map[string]interface{})
-			for _, s := range c.StringSlice("annotation") {
-				parts := strings.Split(s, "=")
-				if len(parts) == 2 {
-					var v interface{}
-					err := json.Unmarshal([]byte(parts[1]), &v)
-					if err != nil {
-						fmt.Printf("Unable to parse annotation value '%v'. Annotations values must be valid JSON strings.\n", parts[1])
-					} else {
-						annotations[parts[0]] = v
-					}
-				} else {
-					fmt.Println("Annotations must be specified in the form key='value', where value is a valid JSON string")
-				}
-			}
-			rt.Annotations = annotations
+			rt.Annotations = extractAnnotations(c)
 		}
 	}
 }

--- a/test/cli_crud_test.go
+++ b/test/cli_crud_test.go
@@ -57,6 +57,18 @@ func TestRemovingRouteAnnotation(t *testing.T) {
 	h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess().AssertStdoutMissingJSONPath([]string{"annotations", "test"})
 }
 
+func TestInvalidAnnotationValue(t *testing.T) {
+	t.Parallel()
+
+	h := testharness.Create(t)
+	defer h.Cleanup()
+	appName1 := h.NewAppName()
+
+	// The route should still be created, but without the invalid annotation
+	h.Fn("routes", "create", appName1, "myroute", "--image", "foo/duffimage:0.0.1", "--annotation", "test=value").AssertSuccess().AssertStderrContains("Unable to parse annotation value 'value'. Annotations values must be valid JSON strings.")
+	h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess().AssertStdoutMissingJSONPath([]string{"annotations", "test"})
+}
+
 func TestRouteUpdateValues(t *testing.T) {
 	t.Parallel()
 

--- a/test/cli_crud_test.go
+++ b/test/cli_crud_test.go
@@ -45,6 +45,18 @@ func TestSimpleFnRouteUpdateCycle(t *testing.T) {
 	h.Fn("routes", "config", "get", appName1, "myroute", "confA").AssertFailed()
 }
 
+func TestRemovingRouteAnnotation(t *testing.T) {
+	t.Parallel()
+
+	h := testharness.Create(t)
+	defer h.Cleanup()
+	appName1 := h.NewAppName()
+	h.Fn("routes", "create", appName1, "myroute", "--image", "foo/duffimage:0.0.1", "--annotation", "test=1").AssertSuccess()
+	h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess().AssertStdoutContainsJSON([]string{"annotations", "test"}, 1.0)
+	h.Fn("routes", "update", appName1, "myroute", "--image", "foo/duffimage:0.0.1", "--annotation", `test=""`).AssertSuccess()
+	h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess().AssertStdoutMissingJSONPath([]string{"annotations", "test"})
+}
+
 func TestRouteUpdateValues(t *testing.T) {
 	t.Parallel()
 
@@ -60,6 +72,7 @@ func TestRouteUpdateValues(t *testing.T) {
 		{[]string{"--format", "default"}, []string{"format"}, "default"},
 		{[]string{"--timeout", "111"}, []string{"timeout"}, 111.0},
 		{[]string{"--idle-timeout", "128"}, []string{"idle_timeout"}, 128.0},
+		{[]string{"--annotation", "test=1"}, []string{"annotations", "test"}, 1.0},
 	}
 
 	for i, tcI := range validCases {

--- a/test/cli_crud_test.go
+++ b/test/cli_crud_test.go
@@ -1,11 +1,8 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/fnproject/cli/testharness"
-	"github.com/jmoiron/jsonq"
-	"strings"
 	"testing"
 )
 
@@ -75,24 +72,7 @@ func TestRouteUpdateValues(t *testing.T) {
 			h.Fn("routes", "create", appName1, "myroute", "--image", "foo/someimage:0.0.1").AssertSuccess()
 
 			h.Fn(append([]string{"routes", "update", appName1, "myroute"}, tc.args...)...).AssertSuccess()
-			resJson := h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess()
-
-			routeObj := map[string]interface{}{}
-			err := json.Unmarshal([]byte(resJson.Stdout), &routeObj)
-			if err != nil {
-				t.Fatalf("Failed to parse routes inspect as JSON %v, %v", err, resJson)
-			}
-
-			q := jsonq.NewQuery(routeObj)
-			val, err := q.Interface(tc.query...)
-			if err != nil {
-				t.Fatalf("Failed to find path %v in json body %v", tc.query, resJson.Stdout)
-			}
-
-			if val != tc.result {
-				t.Fatalf("Expected %s to be %s  after running %s but was %s, %v", strings.Join(tc.query, "."), tc.result, strings.Join(tc.args, " "), val, resJson)
-			}
-
+			h.Fn("routes", "inspect", appName1, "myroute").AssertSuccess().AssertStdoutContainsJSON(tc.query, tc.result)
 		})
 	}
 


### PR DESCRIPTION
This allows annotations to be set when creating or updating apps and routes.

As an example, an annotation can be added to a route when creating it:

```
fn routes create --annotation key='value' appname /routename
```

Where `'value'` should be a string containing valid JSON.