### PR TITLE
Add `host` to signed request headers.

### DIFF
--- a/client/oracle_provider.go
+++ b/client/oracle_provider.go
@@ -74,7 +74,7 @@ func initializeClient(keyID string, key *rsa.PrivateKey) common.HTTPRequestSigne
 		ID:  keyID,
 		key: key,
 	}
-	return common.RequestSigner(provider, []string{"date", "(request-target)"}, []string{"content-length", "content-type", "x-content-sha256"})
+	return common.RequestSigner(provider, []string{"host", "date", "(request-target)"}, []string{"content-length", "content-type", "x-content-sha256"})
 }
 
 // Add the necessary headers and sign the request


### PR DESCRIPTION
This allows authentication against the API to work again.