### PR TITLE
Add Oracle provider authentication to `fn call`

### DIFF
--- a/client/call_fn.go
+++ b/client/call_fn.go
@@ -10,6 +10,10 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/fnproject/cli/config"
 )
 
 const (
@@ -80,7 +84,7 @@ func CallFN(appName string, route string, content io.Reader, output io.Writer, m
 		EnvAsHeader(req, env)
 	}
 
-	transport, err := oracleTransport(http.DefaultTransport)
+	transport, err := getTransport()
 	if err != nil {
 		return err
 	}
@@ -121,4 +125,15 @@ func CallFN(appName string, route string, content io.Reader, output io.Writer, m
 	}
 
 	return nil
+}
+
+func getTransport() (http.RoundTripper, error) {
+	switch viper.GetString(config.ContextProvider) {
+	case "default":
+		return http.DefaultTransport, nil
+	case "oracle":
+		return oracleTransport(http.DefaultTransport)
+	default:
+		return http.DefaultTransport, nil
+	}
 }

--- a/routes.go
+++ b/routes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -253,15 +252,8 @@ func (a *routesCmd) list(c *cli.Context) error {
 func (a *routesCmd) call(c *cli.Context) error {
 	appName := c.Args().Get(0)
 	route := cleanRoutePath(c.Args().Get(1))
-
-	u := url.URL{
-		Scheme: "http",
-		Host:   client.Host(),
-	}
-	u.Path = path.Join(u.Path, "r", appName, route)
 	content := stdin()
-
-	return client.CallFN(u.String(), content, os.Stdout, c.String("method"), c.StringSlice("e"), c.String("content-type"), c.Bool("display-call-id"))
+	return client.CallFN(appName, route, content, os.Stdout, c.String("method"), c.StringSlice("e"), c.String("content-type"), c.Bool("display-call-id"))
 }
 
 func routeWithFlags(c *cli.Context, rt *fnmodels.Route) {

--- a/testfn.go
+++ b/testfn.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -250,11 +248,6 @@ func (t *testcmd) runremotetest(ff *funcfile, in *inputMap, expectedOut *outputM
 	if ff.Path == "" {
 		return errors.New("execution of tests on remote server demand that this function has a `path`")
 	}
-	baseURL := client.HostURL()
-
-	u, err := url.Parse("../")
-	u.Path = path.Join(u.Path, "r", t.remote, ff.Path)
-	target := baseURL.ResolveReference(u).String()
 
 	inBytes, err := json.Marshal(in)
 	if err != nil {
@@ -270,7 +263,7 @@ func (t *testcmd) runremotetest(ff *funcfile, in *inputMap, expectedOut *outputM
 	}
 	var stdout bytes.Buffer
 
-	if err := client.CallFN(target, stdin, &stdout, "", envVars, "application/json", false); err != nil {
+	if err := client.CallFN(t.remote, ff.Path, stdin, &stdout, "", envVars, "application/json", false); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\n", err, stdout.String())
 	}
 


### PR DESCRIPTION
This uses a similar `switch` to that in `client/api.go` to check the configured provider and use that to set up the appropriate `RoundTripper` implementation to make the call. Some code in `client/api.go` that sets up the `RoundTripper` for the `openapi` client is made more generic so that it can be reused. This could eventually be abstracted into a method implemented by any configured provider.

Additionally, this allows `fn call` to work for HTTPS, as it reuses the `HostURL` function from `client/api.go`, rather than the URL being constructed in `routes.go`.