### PR TITLE
Route annotations can be specified in func.yaml.

### DIFF
--- a/funcfile.go
+++ b/funcfile.go
@@ -60,15 +60,16 @@ type funcfile struct {
 
 	// Route params
 	// TODO embed models.Route
-	Type        string              `yaml:"type,omitempty" json:"type,omitempty"`
-	Memory      uint64              `yaml:"memory,omitempty" json:"memory,omitempty"`
-	Cpus        string              `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Format      string              `yaml:"format,omitempty" json:"format,omitempty"`
-	Timeout     *int32              `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	Path        string              `yaml:"path,omitempty" json:"path,omitempty"`
-	Config      map[string]string   `yaml:"config,omitempty" json:"config,omitempty"`
-	Headers     map[string][]string `yaml:"headers,omitempty" json:"headers,omitempty"`
-	IDLETimeout *int32              `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
+	Type             string                 `yaml:"type,omitempty" json:"type,omitempty"`
+	Memory           uint64                 `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Cpus             string                 `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Format           string                 `yaml:"format,omitempty" json:"format,omitempty"`
+	Timeout          *int32                 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Path             string                 `yaml:"path,omitempty" json:"path,omitempty"`
+	Config           map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
+	Headers          map[string][]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
+	IDLETimeout      *int32                 `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
+	RouteAnnotations map[string]interface{} `yaml:"route_annotations,omitempty" json:"type:omitempty"`
 
 	// Run/test
 	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`

--- a/funcfile.go
+++ b/funcfile.go
@@ -60,16 +60,16 @@ type funcfile struct {
 
 	// Route params
 	// TODO embed models.Route
-	Type             string                 `yaml:"type,omitempty" json:"type,omitempty"`
-	Memory           uint64                 `yaml:"memory,omitempty" json:"memory,omitempty"`
-	Cpus             string                 `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Format           string                 `yaml:"format,omitempty" json:"format,omitempty"`
-	Timeout          *int32                 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
-	Path             string                 `yaml:"path,omitempty" json:"path,omitempty"`
-	Config           map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
-	Headers          map[string][]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
-	IDLETimeout      *int32                 `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
-	RouteAnnotations map[string]interface{} `yaml:"route_annotations,omitempty" json:"type:omitempty"`
+	Type        string                 `yaml:"type,omitempty" json:"type,omitempty"`
+	Memory      uint64                 `yaml:"memory,omitempty" json:"memory,omitempty"`
+	Cpus        string                 `yaml:"cpus,omitempty" json:"cpus,omitempty"`
+	Format      string                 `yaml:"format,omitempty" json:"format,omitempty"`
+	Timeout     *int32                 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Path        string                 `yaml:"path,omitempty" json:"path,omitempty"`
+	Config      map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
+	Headers     map[string][]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
+	IDLETimeout *int32                 `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 
 	// Run/test
 	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`

--- a/routes.go
+++ b/routes.go
@@ -354,7 +354,9 @@ func routeWithFuncFile(ff *funcfile, rt *fnmodels.Route) error {
 	if len(ff.Config) != 0 {
 		rt.Config = ff.Config
 	}
-
+	if len(ff.RouteAnnotations) != 0 {
+		rt.Annotations = ff.RouteAnnotations
+	}
 	return nil
 }
 

--- a/routes.go
+++ b/routes.go
@@ -354,8 +354,8 @@ func routeWithFuncFile(ff *funcfile, rt *fnmodels.Route) error {
 	if len(ff.Config) != 0 {
 		rt.Config = ff.Config
 	}
-	if len(ff.RouteAnnotations) != 0 {
-		rt.Annotations = ff.RouteAnnotations
+	if len(ff.Annotations) != 0 {
+		rt.Annotations = ff.Annotations
 	}
 	return nil
 }


### PR DESCRIPTION
Annotations for a route can be specified using `route_annotations` in
the func.yaml. For example:

```
route_annotations:
    a: x
```

Here, `x` can be any valid JSON or YAML value. This allows more
complex annotation values to be specified, such as arrays:

```
route_annotations:
    a:
    - x
    - y
```

Or maps:

```
route_annotations:
    a:
        b: 1
        c: 2
```