### PR TITLE
Enable bash auto completion

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func newFn() *cli.App {
 	app.Version = Version
 	app.Authors = []cli.Author{{Name: "Fn Project"}}
 	app.Description = "Fn command line tool"
+	app.EnableBashCompletion = true
 	app.Before = func(c *cli.Context) error {
 		err := config.LoadConfiguration(c)
 		if err != nil {


### PR DESCRIPTION
`urfave cli` has both bash and zsh  [auto_complete files] available (https://github.com/urfave/cli/tree/master/autocomplete).

Users can source the relevant file and set the program name to `fn` to enable auto completion commands :
```
PROG=fn source ~/cli/autocomplete/[ zsh_autocomplete | bash_autocomplete ]
```