### PR TITLE
Move the creation of fn db to ~/.fn/localdata

### DIFF
--- a/start.go
+++ b/start.go
@@ -49,7 +49,7 @@ func start(c *cli.Context) error {
 	home := config.GetHomeDir()
 
 	if c.String("data-dir") != "" {
-		fnDir = filepath.Join(c.String("data-dir"))
+		fnDir = c.String("data-dir")
 	} else {
 		fnDir = filepath.Join(home, ".fn", "jade")
 	}

--- a/start.go
+++ b/start.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
+	"github.com/fnproject/cli/config"
 	"github.com/urfave/cli"
 )
 
@@ -39,14 +41,11 @@ func startCmd() cli.Command {
 }
 
 func start(c *cli.Context) error {
-	wd, err := os.Getwd()
-	name := "fnserver"
-	if err != nil {
-		log.Fatalln("Getwd failed:", err)
-	}
+	home := config.GetHomeDir()
+	fnDir := filepath.Join(home, ".fn", "localdata")
 	args := []string{"run", "--rm", "-i",
-		"--name", name,
-		"-v", fmt.Sprintf("%s/data:/app/data", wd),
+		"--name", "fnserver",
+		"-v", fmt.Sprintf("%s/data:/app/data", fnDir),
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"--privileged",
 		"-p", fmt.Sprintf("%d:8080", c.Int("port")),
@@ -65,7 +64,7 @@ func start(c *cli.Context) error {
 	cmd := exec.Command("docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Start()
+	err := cmd.Start()
 	if err != nil {
 		log.Fatalln("starting command failed:", err)
 	}

--- a/start.go
+++ b/start.go
@@ -36,13 +36,24 @@ func startCmd() cli.Command {
 				Value: 8080,
 				Usage: "Specify port number to bind to on the host.",
 			},
+			cli.StringFlag{
+				Name:  "data-dir",
+				Usage: "--data-dir path to local Fn database",
+			},
 		},
 	}
 }
 
 func start(c *cli.Context) error {
+	var fnDir string
 	home := config.GetHomeDir()
-	fnDir := filepath.Join(home, ".fn", "localdata")
+
+	if c.String("data-dir") != "" {
+		fnDir = filepath.Join(c.String("data-dir"))
+	} else {
+		fnDir = filepath.Join(home, ".fn", "jade")
+	}
+
 	args := []string{"run", "--rm", "-i",
 		"--name", "fnserver",
 		"-v", fmt.Sprintf("%s/data:/app/data", fnDir),


### PR DESCRIPTION
This moves the creation of the local data to `.fn/localdata` 
```
- fn 
  - localdata
       - data
            - fn.db
             - fn.mq
```

Related Issue: [#278](https://github.com/fnproject/cli/issues/278)