### PR TITLE
Command to stop local fn server

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ LEARN MORE:
 	}
 	app.Commands = []cli.Command{
 		startCmd(),
+		stopCmd(),
 		updateCmd(),
 		initFn(),
 		apps(),

--- a/start.go
+++ b/start.go
@@ -40,11 +40,12 @@ func startCmd() cli.Command {
 
 func start(c *cli.Context) error {
 	wd, err := os.Getwd()
+	name := "fnserver"
 	if err != nil {
 		log.Fatalln("Getwd failed:", err)
 	}
 	args := []string{"run", "--rm", "-i",
-		"--name", "fnserver",
+		"--name", name,
 		"-v", fmt.Sprintf("%s/data:/app/data", wd),
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"--privileged",

--- a/stop.go
+++ b/stop.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/urfave/cli"
+)
+
+func stopCmd() cli.Command {
+	return cli.Command{
+		Name:   "stop",
+		Usage:  "stops a functions server",
+		Action: stop,
+	}
+}
+func stop(c *cli.Context) error {
+	cmd := exec.Command("docker", "stop", "fnserver")
+	err := cmd.Run()
+	if err != nil {
+		return errors.New("failed to stop 'fnserver'")
+	}
+
+	fmt.Println("Successfully stopped 'fnserver'")
+
+	return err
+}


### PR DESCRIPTION
By adding a stop command:`fn stop` now gives users the ability to stop the local running fn server which is the result of `fn start -d`.

Related to issue #270 