### PR TITLE
Remove github call on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,11 +165,12 @@ func commandArgOverrides(c *cli.Context) {
 
 func main() {
 	app := newFn()
+	
 	err := app.Run(os.Args)
 	if err != nil {
 		// TODO: this doesn't seem to get called even when an error returns from a command, but maybe urfave is doing a non zero exit anyways? nope: https://github.com/urfave/cli/issues/610
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-		printLatestVersion()
+		fmt.Fprintf(os.Stderr,"Client version: %s\n" , Version)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Calling Github every time anybody types a wrong command makes the CLI slow and clunky and is potentailly insecure  (as in it leaks information about who is using Fn) 