### PR TITLE
Read-only root filesystem and tmpfs size support in cli

### DIFF
--- a/commands/test.go
+++ b/commands/test.go
@@ -236,7 +236,7 @@ func runlocaltest(ff *common.FuncFile, in *common.InputMap, expectedOut *common.
 
 	var stdout, stderr bytes.Buffer
 
-	if err := run.RunFF(ff, stdin, &stdout, &stderr, "", envVars, nil, "", 1, "application/json"); err != nil {
+	if err := run.RunFF(ff, stdin, &stdout, &stderr, "", envVars, nil, "", 1, "application/json", false); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\nstderr:%s", err, stdout.String(), stderr.String())
 	}
 

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -77,6 +77,7 @@ type FuncFile struct {
 	Headers     map[string][]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
 	IDLETimeout *int32                 `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty" json:"annotations,omitempty"`
+	TmpFsSize   uint32                 `yaml:"tmpfs_size,omitempty" json:"tmpfs_size,omitempty"`
 
 	// Run/test
 	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`

--- a/run/run.go
+++ b/run/run.go
@@ -195,6 +195,14 @@ func RunFF(ff *common.FuncFile, stdin io.Reader, stdout, stderr io.Writer, metho
 		}
 	}
 
+	sh = append(sh, "--read-only")
+
+	if ff.TmpFsSize != 0 {
+		sh = append(sh, "--tmpfs", fmt.Sprintf("/tmp:rw,size=%dm", ff.TmpFsSize))
+	} else {
+		sh = append(sh, "--tmpfs", "/tmp:rw")
+	}
+
 	// Add expected env vars that service will add
 	// Full set here: https://github.com/fnproject/fn/pull/660#issuecomment-356157279
 	runEnv = append(runEnv, kvEq("FN_TYPE", "sync"))


### PR DESCRIPTION

TODO: TmpFs not yet in fn_go. Will need to add/update fn_go and add TmpFsSize to routes.go.