### PR TITLE
Change request url to `api-url` value in context file

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -213,6 +213,7 @@ func RunFF(ff *common.FuncFile, stdin io.Reader, stdout, stderr io.Writer, metho
 	if requestURL = viper.GetString("api-url"); requestURL == "" {
 		requestURL = LocalTestURL
 	}
+
 	requestURL = requestURL + "/" + TestApp + TestRoute
 
 	if format == DefaultFormat {


### PR DESCRIPTION
LocalTestURL defaults Fn API request URL to localhost [#242](https://github.com/fnproject/cli/issues/242) 

The requestURL is now read from the context file, if not present defaults to localhost.