### PR TITLE
Test harness runs fn with `--verbose`.

### DIFF
--- a/testharness/harness.go
+++ b/testharness/harness.go
@@ -268,6 +268,8 @@ func (h *CLIHarness) FnWithInput(input string, args ...string) *CmdResult {
 
 	stdOut := bytes.Buffer{}
 	stdErr := bytes.Buffer{}
+
+	args = append([]string{"--verbose"}, args...)
 	cmd := exec.Command(h.cliPath, args...)
 	cmd.Stderr = &stdErr
 	cmd.Stdout = &stdOut


### PR DESCRIPTION
This makes the output of failed tests more useful.