### PR TITLE
Add content_type option to func.yaml

### DIFF
--- a/client/call_fn.go
+++ b/client/call_fn.go
@@ -42,7 +42,7 @@ type callID struct {
 
 func CallFN(provider provider.Provider, appName string, route string, content io.Reader, output io.Writer, method string, env []string, contentType string, includeCallID bool) error {
 	u := *provider.CallURL()
-	u.Path = strings.Join([]string{"r", appName, route},"/")
+	u.Path = strings.Join([]string{"r", appName, route}, "/")
 
 	if method == "" {
 		if content == nil {

--- a/commands/call.go
+++ b/commands/call.go
@@ -52,10 +52,8 @@ func (cl *callCmd) Call(c *cli.Context) error {
 		contentType = c.String("content-type")
 	} else {
 		_, ff, err := common.FindAndParseFuncfile(wd)
-		if err == nil {
-			if ff.ContentType != "" {
-				contentType = ff.ContentType
-			}
+		if err == nil && ff.ContentType != "" {
+			contentType = ff.ContentType
 		}
 	}
 

--- a/commands/call.go
+++ b/commands/call.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/fnproject/cli/client"
+	"github.com/fnproject/cli/common"
 	"github.com/fnproject/cli/objects/route"
 	"github.com/fnproject/cli/run"
 	fnclient "github.com/fnproject/fn_go/client"
@@ -40,8 +41,23 @@ func CallCommand() cli.Command {
 }
 
 func (cl *callCmd) Call(c *cli.Context) error {
+	var contentType string
+
 	appName := c.Args().Get(0)
 	route := route.WithoutSlash(c.Args().Get(1))
 	content := run.Stdin()
-	return client.CallFN(cl.provider, appName, route, content, os.Stdout, c.String("method"), c.StringSlice("e"), c.String("content-type"), c.Bool("display-call-id"))
+	wd := common.GetWd()
+
+	if c.String("content-type") != "" {
+		contentType = c.String("content-type")
+	} else {
+		_, ff, err := common.FindAndParseFuncfile(wd)
+		if err == nil {
+			if ff.ContentType != "" {
+				contentType = ff.ContentType
+			}
+		}
+	}
+
+	return client.CallFN(cl.provider, appName, route, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
 }

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -56,14 +56,15 @@ type FuncFile struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// Build params
-	Version    string   `yaml:"version,omitempty" json:"version,omitempty"`
-	Runtime    string   `yaml:"runtime,omitempty" json:"runtime,omitempty"`
-	Entrypoint string   `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Cmd        string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
-	Build      []string `yaml:"build,omitempty" json:"build,omitempty"`
-	Tests      []FFTest `yaml:"tests,omitempty" json:"tests,omitempty"`
-	BuildImage string   `yaml:"build_image,omitempty" json:"build_image,omitempty"` // Image to use as base for building
-	RunImage   string   `yaml:"run_image,omitempty" json:"run_image,omitempty"`     // Image to use for running
+	Version     string   `yaml:"version,omitempty" json:"version,omitempty"`
+	Runtime     string   `yaml:"runtime,omitempty" json:"runtime,omitempty"`
+	Entrypoint  string   `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Cmd         string   `yaml:"cmd,omitempty" json:"cmd,omitempty"`
+	Build       []string `yaml:"build,omitempty" json:"build,omitempty"`
+	Tests       []FFTest `yaml:"tests,omitempty" json:"tests,omitempty"`
+	BuildImage  string   `yaml:"build_image,omitempty" json:"build_image,omitempty"` // Image to use as base for building
+	RunImage    string   `yaml:"run_image,omitempty" json:"run_image,omitempty"`     // Image to use for running
+	ContentType string   `yaml:"content_type,omitempty" json:"content_type,omitempty"`
 
 	// Route params
 	// TODO embed models.Route

--- a/run/run.go
+++ b/run/run.go
@@ -174,8 +174,14 @@ func RunFF(ff *common.FuncFile, stdin io.Reader, stdout, stderr io.Writer, metho
 	var runEnv []string // env to pass into the container via -e's
 	callID := "12345678901234567890123456"
 	if contentType == "" {
-		contentType = "text/plain"
+		if ff.ContentType != "" {
+			contentType = ff.ContentType
+		} else {
+			contentType = "text/plain"
+		}
 	}
+
+	fmt.Println("Content type: ", contentType)
 	to := int32(30)
 	if ff.Timeout != nil {
 		to = *ff.Timeout

--- a/run/run.go
+++ b/run/run.go
@@ -181,7 +181,6 @@ func RunFF(ff *common.FuncFile, stdin io.Reader, stdout, stderr io.Writer, metho
 		}
 	}
 
-	fmt.Println("Content type: ", contentType)
 	to := int32(30)
 	if ff.Timeout != nil {
 		to = *ff.Timeout


### PR DESCRIPTION
As a developer I want to specify the content type in func.yaml so that my function receives the payload in the correct format. [#248](https://github.com/fnproject/cli/issues/248)