### PR TITLE
Pass through appName to call() to match that in fn_go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,6 +103,15 @@
   revision = "5df930a27be2502f99b292b7cc09ebad4d0891f4"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/fnproject/fdk-go"
+  packages = [
+    ".",
+    "utils"
+  ]
+  revision = "1eb29530716f262bad5b83eb9a5b3f7483636949"
+
+[[projects]]
   name = "github.com/fnproject/fn_go"
   packages = [
     ".",
@@ -117,8 +126,8 @@
     "provider/defaultprovider",
     "provider/oracle"
   ]
-  revision = "ba119f998930f50ffb458ee509253811461fe150"
-  version = "0.2.7"
+  revision = "9c0630b825a7027d528352d40dbf8d0afbf84b85"
+  version = "0.2.8"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -446,6 +455,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9fb59c4f1c50d687685ce680db95a15284084f91e2f9fb0bd99cf8c6dc97a430"
+  inputs-digest = "be155a89285ed602a44bacb101071c757e56f9513360af00ec51126dc525683b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client/call_fn.go
+++ b/client/call_fn.go
@@ -41,8 +41,11 @@ type callID struct {
 }
 
 func CallFN(provider provider.Provider, appName string, route string, content io.Reader, output io.Writer, method string, env []string, contentType string, includeCallID bool) error {
-	u := *provider.CallURL()
-	u.Path = strings.Join([]string{"r", appName, route},"/")
+	u, err := provider.CallURL(appName)
+	if err != nil {
+		return err
+	}
+	u.Path = strings.Join([]string{"r", appName, route}, "/")
 
 	if method == "" {
 		if content == nil {

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -228,10 +228,14 @@ func (a *appsCmd) inspect(c *cli.Context) error {
 	appName := c.Args().First()
 	prop := c.Args().Get(1)
 
-	resp, err := a.client.Apps.GetAppsApp(&apiapps.GetAppsAppParams{
+	params := &apiapps.GetAppsAppParams{
 		Context: context.Background(),
 		App:     appName,
-	})
+	}
+
+	resp, err := a.client.Apps.GetAppsApp(params)
+
+	fmt.Println("Resp: ", resp)
 
 	if err != nil {
 		switch e := err.(type) {

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -228,14 +228,10 @@ func (a *appsCmd) inspect(c *cli.Context) error {
 	appName := c.Args().First()
 	prop := c.Args().Get(1)
 
-	params := &apiapps.GetAppsAppParams{
+	resp, err := a.client.Apps.GetAppsApp(&apiapps.GetAppsAppParams{
 		Context: context.Background(),
 		App:     appName,
-	}
-
-	resp, err := a.client.Apps.GetAppsApp(params)
-
-	fmt.Println("Resp: ", resp)
+	})
 
 	if err != nil {
 		switch e := err.(type) {

--- a/objects/route/routes.go
+++ b/objects/route/routes.go
@@ -121,7 +121,10 @@ func (r *routesCmd) list(c *cli.Context) error {
 		params.Cursor = &resp.Payload.NextCursor
 	}
 
-	callURL := r.provider.CallURL()
+	callURL, err := r.provider.CallURL(appName)
+	if err != nil {
+		return err
+	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	fmt.Fprint(w, "path", "\t", "image", "\t", "endpoint", "\n")


### PR DESCRIPTION
*Append shortcode to call-url [#10](https://github.com/fnproject/fn_go/pull/10) must be merged before this PR.*

Pass through the name of the app when using `fn call <app> <route>` to be used by fn_go call URL function. 