### PR TITLE
Look up provider flag correctly.

### DIFF
--- a/objects/context/context.go
+++ b/objects/context/context.go
@@ -32,7 +32,7 @@ func create(c *cli.Context) error {
 	}
 
 	providerId := config.DefaultProvider
-	if cProvider := c.String("providerId"); cProvider != "" {
+	if cProvider := c.String("provider"); cProvider != "" {
 		providerId = cProvider
 	}
 


### PR DESCRIPTION
The provider flag name is `provider`, not `providerId`. Fixes #321.