### PR TITLE
Support annotations in app files

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -321,7 +321,8 @@ func (p *deploycmd) updateAppConfig(appf *common.AppFile) error {
 	param.App = appf.Name
 	param.Body = &models.AppWrapper{
 		App: &models.App{
-			Config: appf.Config,
+			Config:      appf.Config,
+			Annotations: appf.Annotations,
 		},
 	}
 
@@ -330,8 +331,9 @@ func (p *deploycmd) updateAppConfig(appf *common.AppFile) error {
 		postParams := clientApps.NewPostAppsParams() //XXX switch to put when v2.0 Fn
 		postParams.Body = &models.AppWrapper{
 			App: &models.App{
-				Name:   appf.Name,
-				Config: appf.Config,
+				Name:        appf.Name,
+				Config:      appf.Config,
+				Annotations: appf.Annotations,
 			},
 		}
 

--- a/common/appfile.go
+++ b/common/appfile.go
@@ -25,7 +25,8 @@ var (
 type AppFile struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 	// TODO: Config here is not yet used
-	Config map[string]string `yaml:"config,omitempty" json:"config,omitempty"`
+	Config      map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
 
 func findAppfile(path string) (string, error) {


### PR DESCRIPTION
This allows annotations to be specified in the `app.yaml` in the same way as they are specified in `func.yaml`.

```yaml
name: myfunction
annotations:
    exampleAnnotation: value
```