### PR TITLE
Add path option to build command

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
@@ -53,6 +55,19 @@ func (b *buildcmd) flags() []cli.Flag {
 // build will take the found valid function and build it
 func (b *buildcmd) build(c *cli.Context) error {
 	dir := common.GetDir(c)
+
+	path := c.Args().First()
+	if path != "" {
+		fmt.Printf("Building function at: /%s\n", path)
+		dir = filepath.Join(dir, path)
+	}
+
+	err := os.Chdir(dir)
+	if err != nil {
+		return err
+	}
+	defer os.Chdir(dir)
+
 	ffV, err := common.ReadInFuncFile()
 	if err != nil {
 		return err


### PR DESCRIPTION
[#343](https://github.com/fnproject/cli/issues/343) fn build usage is inconsistent with other command as it only works in the function directory