### PR TITLE
Adding debug logging for call request/response #344

### DIFF
--- a/client/call_fn.go
+++ b/client/call_fn.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"strings"
 
 	"github.com/fnproject/fn_go/provider"
+	"github.com/go-openapi/runtime/logger"
 )
 
 const (
@@ -86,7 +88,24 @@ func CallFN(provider provider.Provider, appName string, route string, content io
 	transport := provider.WrapCallTransport(http.DefaultTransport)
 	httpClient := http.Client{Transport: transport}
 
+	if logger.DebugEnabled() {
+		b, err := httputil.DumpRequestOut(req, content != nil)
+		if err != nil {
+			return err
+		}
+		fmt.Printf(string(b) + "\n")
+	}
+
 	resp, err := httpClient.Do(req)
+
+	if logger.DebugEnabled() {
+		b, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return err
+		}
+		fmt.Printf(string(b) + "\n")
+	}
+
 	if err != nil {
 		return fmt.Errorf("Error running route: %s", err)
 	}


### PR DESCRIPTION
The Call api endpoint isn't included in the Swagger
definition, so we hand build a http client. This doesn't include the
debug creation as that is performed by the Swagger Runtime code.

This change copies the logging approach from the Runtime code, adding
a context check for 'verbose' mode as well.