### PR TITLE
Python multistage support

### DIFF
--- a/langs/base.go
+++ b/langs/base.go
@@ -18,6 +18,7 @@ func init() {
 	registerHelper(&NodeLangHelper{})
 	registerHelper(&PhpLangHelper{})
 	registerHelper(&PythonLangHelper{Version: "3.6"})
+	registerHelper(&PythonLangHelper{Version: "3.7"})
 	registerHelper(&RubyLangHelper{})
 	registerHelper(&RustLangHelper{})
 	registerHelper(&KotlinLangHelper{})

--- a/langs/python.go
+++ b/langs/python.go
@@ -59,11 +59,11 @@ func (h *PythonLangHelper) Extensions() []string {
 }
 
 func (h *PythonLangHelper) BuildFromImage() (string, error) {
-	return fmt.Sprintf("python:%s-slim-stretch", h.Version), nil
+	return fmt.Sprintf("fnproject/python:%s", h.Version), nil
 }
 
 func (h *PythonLangHelper) RunFromImage() (string, error) {
-	return fmt.Sprintf("python:%s-slim-stretch", h.Version), nil
+	return fmt.Sprintf("fnproject/python:%s", h.Version), nil
 }
 
 func (h *PythonLangHelper) Entrypoint() (string, error) {
@@ -75,8 +75,7 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 	r = append(r, "ADD . /function/")
 	if exists("requirements.txt") {
 		r = append(r, `
-RUN apt-get update && apt-get install --no-install-recommends -qy build-essential gcc &&\
-    pip3 install --no-cache --no-cache-dir -r requirements.txt &&\
+RUN pip3 install --no-cache --no-cache-dir -r requirements.txt &&\
     apt-get remove -y --purge build-essential gcc && apt-get autoremove -y &&\
     rm -rf /var/lib/apt/lists/ &&\
     apt clean all &&\

--- a/langs/python.go
+++ b/langs/python.go
@@ -76,9 +76,6 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 	if exists("requirements.txt") {
 		r = append(r, `
 RUN pip3 install --target /python/  --no-cache --no-cache-dir -r requirements.txt &&\
-    apt-get remove -y --purge build-essential gcc && apt-get autoremove -y &&\
-    rm -rf /var/lib/apt/lists/ &&\
-    apt clean all &&\
     rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv`)
 	}
 	return r


### PR DESCRIPTION
dev
===
New managed base image is `fnproject/python:3.6-dev`.
OS: `Debian`
Base image: `python:3.6-slim-stretch`
Installed packages: `build-essential gcc`

New managed base image is `fnproject/python:3.7-dev`.
OS: `Debian`
Base image: `python:3.7-slim-stretch`
Installed packages: `build-essential gcc`

runtime
======
New managed base image is `fnproject/python:3.6`.
New managed base image is `fnproject/python:3.7`.