### PR TITLE
Clojure FDK

### DIFF
--- a/langs/base.go
+++ b/langs/base.go
@@ -21,6 +21,7 @@ func init() {
 	registerHelper(&RubyLangHelper{})
 	registerHelper(&RustLangHelper{})
 	registerHelper(&KotlinLangHelper{})
+	registerHelper(&ClojureLangHelper{version: "1.9.0"})
 
 }
 

--- a/langs/clojure.go
+++ b/langs/clojure.go
@@ -1,0 +1,249 @@
+package langs
+
+import (
+    "bytes"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "os"
+    "path/filepath"
+)
+
+// ClojureLangHelper provides a set of helper methods for the lifecycle of Clojure Maven projects
+type ClojureLangHelper struct {
+    BaseHelper
+    latestFdkVersion string
+    version          string
+}
+
+func (h *ClojureLangHelper) Handles(lang string) bool {
+    for _, s := range h.LangStrings() {
+        if lang == s {
+            return true
+        }
+    }
+    return false
+}
+func (h *ClojureLangHelper) Runtime() string {
+    return h.LangStrings()[0]
+}
+
+func (lh *ClojureLangHelper) LangStrings() []string {
+    return []string{"clojure"}
+
+}
+func (lh *ClojureLangHelper) Extensions() []string {
+    return []string{".clj"}
+}
+
+func (lh *ClojureLangHelper) BuildFromImage() (string, error) {
+    return "clojure:lein", nil
+}
+
+// RunFromImage returns the Docker image used to run the Clojure function.
+func (lh *ClojureLangHelper) RunFromImage() (string, error) {
+    return "openjdk:9-jre", nil
+}
+
+// HasBoilerplate returns whether the Java runtime has boilerplate that can be generated.
+func (lh *ClojureLangHelper) HasBoilerplate() bool { return true }
+
+// Clojure defaults to CloudEvents
+func (lh *ClojureLangHelper) DefaultFormat() string { return "cloudevent" }
+
+// GenerateBoilerplate will generate function boilerplate for a Java runtime.
+// The default boilerplate is for a Maven project.
+func (lh *ClojureLangHelper) GenerateBoilerplate(path string) error {
+    pathToProjectFile := filepath.Join(path, "project.clj")
+    if exists(pathToProjectFile) {
+        return ErrBoilerplateExists
+    }
+
+    apiVersion, err := lh.getFDKAPIVersion()
+    if err != nil {
+        return err
+    }
+
+    if err := ioutil.WriteFile(pathToProjectFile,
+        []byte(clojureProjFileContent(lh.version, apiVersion)),
+        os.FileMode(0644)); err != nil {
+        return err
+    }
+
+    pathToTestJson := filepath.Join(path, "test.json")
+    if exists(pathToTestJson) {
+        return ErrBoilerplateExists
+    }
+    if err := ioutil.WriteFile(pathToTestJson,
+        []byte(fnTestBoilerplate),
+        os.FileMode(0644)); err != nil {
+        return err
+    }
+
+    mkDirAndWriteFile := func(dir, filename, content string) error {
+        fullPath := filepath.Join(path, dir)
+        if err = os.MkdirAll(fullPath, os.FileMode(0755)); err != nil {
+            return err
+        }
+
+        fullFilePath := filepath.Join(fullPath, filename)
+        return ioutil.WriteFile(fullFilePath, []byte(content), os.FileMode(0644))
+    }
+
+    err = mkDirAndWriteFile("src/example", "core.clj", helloClojureSrcBoilerplate)
+    if err != nil {
+        return err
+    }
+
+    return mkDirAndWriteFile("test/example", "core_test.clj", helloClojureTestBoilerplate)
+}
+
+func (lh *ClojureLangHelper) Entrypoint() (string, error) {
+    return "java -jar /function/app/example.jar", nil
+}
+
+// DockerfileCopyCmds returns the Docker COPY command to copy the compiled Clojure standalone jar.
+func (lh *ClojureLangHelper) DockerfileCopyCmds() []string {
+    return []string{
+        `COPY --from=build-stage /function/target/com.example.fn-1.0.0-standalone.jar /function/app/example.jar`,
+    }
+}
+
+// DockerfileBuildCmds returns the build stage steps to compile the Maven function project.
+func (lh *ClojureLangHelper) DockerfileBuildCmds() []string {
+    return []string{
+        `ADD project.clj /function/project.clj`,
+        `ADD src /function/src`,
+        `RUN ["lein", "uberjar"]`,
+    }
+}
+
+// HasPreBuild returns whether the Leiningen runtime has a pre-build step.
+func (lh *ClojureLangHelper) HasPreBuild() bool { return true }
+
+// PreBuild ensures that the expected the function is based is a maven project.
+func (lh *ClojureLangHelper) PreBuild() error {
+    wd, err := os.Getwd()
+    if err != nil {
+        return err
+    }
+
+    if !exists(filepath.Join(wd, "project.clj")) {
+        return errors.New("Could not find project.clj - are you sure this is a Leiningen project?")
+    }
+
+    return nil
+}
+
+func clojureProjFileContent(clojureVersion string, FDKVersion string) string {
+    return fmt.Sprintf(clojureProjFile, clojureVersion, FDKVersion)
+}
+
+func (lh *ClojureLangHelper) getFDKAPIVersion() (string, error) {
+
+    if lh.latestFdkVersion != "" {
+        return lh.latestFdkVersion, nil
+    }
+
+    const versionURL = "https://clojars.org/api/artifacts/unpause/fdk-clj"
+    const versionEnv = "FN_CLOJURE_FDK_VERSION"
+    fetchError := fmt.Errorf("Failed to fetch latest Clojure FDK version from %v. Check your network settings or manually override the version by setting %s", versionURL, versionEnv)
+
+    type parsedResponse struct {
+        Version string `json:"latest_version"`
+    }
+    version := os.Getenv(versionEnv)
+    if version != "" {
+        return version, nil
+    }
+    resp, err := http.Get(versionURL)
+    if err != nil || resp.StatusCode != 200 {
+        return "", fetchError
+    }
+
+    buf := bytes.Buffer{}
+    _, err = buf.ReadFrom(resp.Body)
+    if err != nil {
+        return "", fetchError
+    }
+
+    var parsedResp parsedResponse
+    err = json.Unmarshal(buf.Bytes(), &parsedResp)
+    if err != nil {
+        fmt.Print(err)
+        return "", fetchError
+    }
+
+    lh.latestFdkVersion = parsedResp.Version
+    return lh.latestFdkVersion, nil
+}
+
+func (lh *ClojureLangHelper) FixImagesOnInit() bool {
+    return true
+}
+
+const (
+    clojureProjFile = `(defproject com.example.fn "1.0.0"
+  :description "Clojure FDK for Fn"
+  :url "https://github.com/fnproject"
+  :license {:name "Apache License Version 2.0"
+        :url "http://www.apache.org/licenses/LICENSE-2.0.txt"}
+  :dependencies [[org.clojure/clojure "%s"]
+                [unpause/fdk-clj "%s"]
+                [org.clojure/test.check "0.9.0"]]
+  :main example.core
+  :jvm-opts ["-Duser.timezone=UTC"]
+  :profiles {:uberjar { :aot :all }}
+  :test-paths ["test"])
+`
+
+    helloClojureSrcBoilerplate = `
+(ns example.core 
+  (:require [fdk-clj.core :as fdk]) 
+  (:gen-class))
+
+(defn handler [ctx data]
+  { :message (str "Hello " (get data :name "World")) })
+
+(defn -main [& args] (fdk/handle handler))
+`
+
+    helloClojureTestBoilerplate = `
+(ns example.core-test
+  (:refer-clojure :exclude [extend second])
+  (:require [clojure.test :refer :all]
+            [example.core :refer :all]))
+
+(deftest handler-test
+  (is (= (handler nil { :name "Johnny" }) { :message "Hello Johnny" }))
+  (is (= (handler nil nil) {:message "Hello World"})))
+`
+    fnTestBoilerplate = `{
+    "tests": [
+        {
+            "input": {
+                "body": {
+                    "name": "Johnny"
+                }
+            },
+            "output": {
+                "body": {
+                    "message": "Hello Johnny"
+                }
+            }
+        },
+        {
+            "input": {
+                "body": ""
+            },
+            "output": {
+                "body": {
+                    "message": "Hello World"
+                }
+            }
+        }
+    ]
+}`
+)

--- a/langs/clojure.go
+++ b/langs/clojure.go
@@ -92,22 +92,22 @@ func (lh *ClojureLangHelper) GenerateBoilerplate(path string) error {
         return ioutil.WriteFile(fullFilePath, []byte(content), os.FileMode(0644))
     }
 
-    err = mkDirAndWriteFile("src/example", "core.clj", helloClojureSrcBoilerplate)
+    err = mkDirAndWriteFile("src/func", "core.clj", helloClojureSrcBoilerplate)
     if err != nil {
         return err
     }
 
-    return mkDirAndWriteFile("test/example", "core_test.clj", helloClojureTestBoilerplate)
+    return mkDirAndWriteFile("test/func", "core_test.clj", helloClojureTestBoilerplate)
 }
 
 func (lh *ClojureLangHelper) Entrypoint() (string, error) {
-    return "java -jar /function/app/example.jar", nil
+    return "java -jar /function/app/func.jar", nil
 }
 
 // DockerfileCopyCmds returns the Docker COPY command to copy the compiled Clojure standalone jar.
 func (lh *ClojureLangHelper) DockerfileCopyCmds() []string {
     return []string{
-        `COPY --from=build-stage /function/target/com.example.fn-1.0.0-standalone.jar /function/app/example.jar`,
+        `COPY --from=build-stage /function/target/com.fdk.func-1.0.0-standalone.jar /function/app/func.jar`,
     }
 }
 
@@ -185,7 +185,7 @@ func (lh *ClojureLangHelper) FixImagesOnInit() bool {
 }
 
 const (
-    clojureProjFile = `(defproject com.example.fn "1.0.0"
+    clojureProjFile = `(defproject com.fdk.func "1.0.0"
   :description "Clojure FDK for Fn"
   :url "https://github.com/fnproject"
   :license {:name "Apache License Version 2.0"
@@ -193,14 +193,14 @@ const (
   :dependencies [[org.clojure/clojure "%s"]
                 [unpause/fdk-clj "%s"]
                 [org.clojure/test.check "0.9.0"]]
-  :main example.core
+  :main func.core
   :jvm-opts ["-Duser.timezone=UTC"]
   :profiles {:uberjar { :aot :all }}
   :test-paths ["test"])
 `
 
     helloClojureSrcBoilerplate = `
-(ns example.core 
+(ns func.core 
   (:require [fdk-clj.core :as fdk]) 
   (:gen-class))
 
@@ -211,10 +211,10 @@ const (
 `
 
     helloClojureTestBoilerplate = `
-(ns example.core-test
+(ns func.core-test
   (:refer-clojure :exclude [extend second])
   (:require [clojure.test :refer :all]
-            [example.core :refer :all]))
+            [func.core :refer :all]))
 
 (deftest handler-test
   (is (= (handler nil { :name "Johnny" }) { :message "Hello Johnny" }))

--- a/langs/clojure.go
+++ b/langs/clojure.go
@@ -11,7 +11,7 @@ import (
     "path/filepath"
 )
 
-// ClojureLangHelper provides a set of helper methods for the lifecycle of Clojure Maven projects
+// ClojureLangHelper provides a set of helper methods for the lifecycle of Clojure Leiningen projects
 type ClojureLangHelper struct {
     BaseHelper
     latestFdkVersion string
@@ -54,7 +54,7 @@ func (lh *ClojureLangHelper) HasBoilerplate() bool { return true }
 func (lh *ClojureLangHelper) DefaultFormat() string { return "cloudevent" }
 
 // GenerateBoilerplate will generate function boilerplate for a Java runtime.
-// The default boilerplate is for a Maven project.
+// The default boilerplate is for a Leiningen project.
 func (lh *ClojureLangHelper) GenerateBoilerplate(path string) error {
     pathToProjectFile := filepath.Join(path, "project.clj")
     if exists(pathToProjectFile) {
@@ -111,7 +111,7 @@ func (lh *ClojureLangHelper) DockerfileCopyCmds() []string {
     }
 }
 
-// DockerfileBuildCmds returns the build stage steps to compile the Maven function project.
+// DockerfileBuildCmds returns the build stage steps to compile the Leiningen function project.
 func (lh *ClojureLangHelper) DockerfileBuildCmds() []string {
     return []string{
         `ADD project.clj /function/project.clj`,
@@ -123,7 +123,7 @@ func (lh *ClojureLangHelper) DockerfileBuildCmds() []string {
 // HasPreBuild returns whether the Leiningen runtime has a pre-build step.
 func (lh *ClojureLangHelper) HasPreBuild() bool { return true }
 
-// PreBuild ensures that the expected the function is based is a maven project.
+// PreBuild ensures that the expected the function is based is a leiningen project.
 func (lh *ClojureLangHelper) PreBuild() error {
     wd, err := os.Getwd()
     if err != nil {

--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -12,6 +12,7 @@ var Runtimes = []struct {
 	generatesTests bool
 	callInput      string
 }{
+	{"clojure", true, `{"name": "John"}`}
 	{"go", true, ""},
 	{"java", false, ""},
 	{"java8", false, ""},

--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -12,7 +12,7 @@ var Runtimes = []struct {
 	generatesTests bool
 	callInput      string
 }{
-	{"clojure", true, `{"name": "John"}`}
+	{"clojure", true, `{"name": "John"}`},
 	{"go", true, ""},
 	{"java", false, ""},
 	{"java8", false, ""},


### PR DESCRIPTION
Hello,  I have created a Clojure FDK from code I've been working on for my project.  The FDK itself can be found at https://github.com/unpause-live/fdk-clj.  It currently supports CloudEvents and JSON format and passes Fn Test.

In this PR is a Clojure language helper which will, as with the other languages, prepare some example boilerplate.   The supplied tests in the boilerplate pass as well.

In the current example I have it building with `clojure:lein` and running with `openjdk:9-jre`, however functions could also be built using Graal's `native-image` and run from `SCRATCH`.