### PR TITLE
init-images

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -223,7 +223,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 		// Merge the func.yaml from the initImage with a.ff
 		//     write out the new func file
-		var initFf, err = common.ParseFuncfile("func.yaml")
+		var initFf, err = common.ParseFuncfile("func.init.yaml")
 		if err != nil {
 			return errors.New("init-image did not produce a valid func.yaml fragment")
 		}

--- a/commands/init.go
+++ b/commands/init.go
@@ -207,14 +207,37 @@ func (a *initFnCmd) init(c *cli.Context) error {
 			return errors.New("init-image did not produce a valid func.init.yaml")
 		}
 
-		// Copy fields provided by init-image
-		// TODO: also allow CLI args to override here?
-		a.ff.Runtime = initFf.Runtime
-		a.ff.Cmd = initFf.Cmd
+		// Build up a combined func.yaml (in a.ff) from the init-image and defaults and route and cli-args
+		//     The following fields are already in a.ff:
+		//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
+		//     Add the following from the init-image:
+		//         build, build_image, cmd, content_type, entrypoint, expects, format, headers, run_image, runtime, tests
+		a.ff.Build = initFf.Build
 		a.ff.BuildImage = initFf.BuildImage
-		a.ff.RunImage = initFf.RunImage
+		a.ff.Cmd = initFf.Cmd
+		a.ff.ContentType = initFf.ContentType
+		a.ff.Entrypoint = initFf.Entrypoint
+		a.ff.Expects = initFf.Expects
 		a.ff.Format = initFf.Format
+		a.ff.Headers = initFf.Headers
+		a.ff.RunImage = initFf.RunImage
+		a.ff.Runtime = initFf.Runtime
+		a.ff.Tests = initFf.Tests
 
+		// Then CLI args can override some init-image options (TODO: remove this with #383)
+		if c.String("cmd") != "" {
+			a.ff.Cmd = c.String("cmd")
+		}
+
+		if c.String("entrypoint") != "" {
+			a.ff.Entrypoint = c.String("entrypoint")
+		}
+
+		if c.String("format") != "" {
+			a.ff.Format = c.String("format")
+		}
+
+		// Done - write it out to func.yaml
 		if err := common.EncodeFuncfileYAML("func.yaml", a.ff); err != nil {
 			return err
 		}
@@ -402,13 +425,33 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 			return errors.New("init-image did not produce a valid func.init.yaml")
 		}
 
-		// Copy fields provided by init-image
-		// TODO: also allow CLI args to override here?
-		a.ffV20180707.Runtime = initFf.Runtime
-		a.ffV20180707.Cmd = initFf.Cmd
+		// Build up a combined func.yaml (in a.ff) from the init-image and defaults and route and cli-args
+		//     The following fields are already in a.ff:
+		//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
+		//     Add the following from the init-image:
+		//         build, build_image, cmd, content_type, entrypoint, expects, format, headers, run_image, runtime
+		a.ffV20180707.Build = initFf.Build
 		a.ffV20180707.Build_image = initFf.BuildImage
-		a.ffV20180707.Run_image = initFf.RunImage
+		a.ffV20180707.Cmd = initFf.Cmd
+		a.ffV20180707.Content_type = initFf.ContentType
+		a.ffV20180707.Entrypoint = initFf.Entrypoint
+		a.ffV20180707.Expects = initFf.Expects
 		a.ffV20180707.Format = initFf.Format
+		a.ffV20180707.Run_image = initFf.RunImage
+		a.ffV20180707.Runtime = initFf.Runtime
+
+		// Then CLI args can override some init-image options (TODO: remove this with #383)
+		if c.String("cmd") != "" {
+			a.ffV20180707.Cmd = c.String("cmd")
+		}
+
+		if c.String("entrypoint") != "" {
+			a.ffV20180707.Entrypoint = c.String("entrypoint")
+		}
+
+		if c.String("format") != "" {
+			a.ffV20180707.Format = c.String("format")
+		}
 
 		if err := common.EncodeFuncFileV20180707YAML("func.yaml", a.ffV20180707); err != nil {
 			return err

--- a/test/cli_init_test.go
+++ b/test/cli_init_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/fnproject/cli/testharness"
@@ -22,5 +23,63 @@ func TestSettingFuncName(t *testing.T) {
 		if yamlFile.Name != funcName {
 			t.Fatalf("Name was not set to %s in func.yaml", funcName)
 		}
+	})
+}
+
+func TestInitImage(t *testing.T) {
+
+	// NB this test creates a function with `rn init --runtime` then creates an init-image from that
+	// This will not be necessary when there are init-images publicly available to pull during this test
+
+	t.Run("`fn init --init-image=<...>` should produce a working function template", func(t *testing.T) {
+		h := testharness.Create(t)
+		var err error
+
+		// Create the init-image
+		origFuncName := h.NewFuncName()
+		h.Fn("init", "--runtime", "go", origFuncName)
+		h.Cd(origFuncName)
+
+		origYaml := h.GetYamlFile("func.yaml")
+		origYaml.Name = ""
+		origYaml.Version = ""
+		h.WriteYamlFile("func.init.yaml", origYaml)
+
+		err = h.Exec("tar", "-cf", "go.tar", "func.go", "func.init.yaml", "Gopkg.toml")
+		if err != nil {
+			fmt.Println(err)
+			t.Fatal("Failed to create tarball for init-image")
+		}
+
+		const initDockerFile = `FROM alpine:latest
+                                        COPY go.tar /
+                                        CMD ["cat", "/go.tar"]
+                                        `
+		h.WithFile("Dockerfile", initDockerFile, 0600)
+
+		err = h.Exec("docker", "build", "-t", origFuncName+"-init", ".")
+		if err != nil {
+			fmt.Println(err)
+			t.Fatal("Failed to create init-image")
+		}
+
+		// Hooray we have an init-image!!
+		// Lets use it
+		h.Cd("")
+		newFuncName := h.NewFuncName()
+
+		h.Fn("init", "--init-image", origFuncName+"-init", newFuncName)
+		h.Cd(newFuncName)
+		h.Fn("run").AssertSuccess()
+
+		newYaml := h.GetYamlFile("func.yaml")
+		if newYaml.Name != newFuncName {
+			t.Fatalf("generated function name is %s not %s", newYaml.Name, newFuncName)
+		}
+
+		if newYaml.Version != "0.0.1" {
+			t.Fatalf("generated function version is %s not 0.0.1", newYaml.Version)
+		}
+
 	})
 }

--- a/testharness/harness.go
+++ b/testharness/harness.go
@@ -436,6 +436,16 @@ func (h *CLIHarness) MkDir(dir string) {
 
 }
 
+func (h *CLIHarness) Exec(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = h.cwd
+	err := cmd.Run()
+	//	out, err := cmd.CombinedOutput()
+	//	fmt.Printf("STDOUT: %s", out)
+	//	fmt.Printf("STDERR: %s", err)
+	return err
+}
+
 //FileAppend appends val to  an existing file
 func (h *CLIHarness) FileAppend(file string, val string) {
 	filePath := h.relativeToCwd(file)
@@ -462,7 +472,10 @@ func (h *CLIHarness) GetFile(s string) string {
 		h.t.Fatalf("File %s is not readable %v", s, err)
 	}
 	return string(v)
+}
 
+func (h *CLIHarness) RemoveFile(s string) error {
+	return os.Remove(h.relativeToCwd(s))
 }
 
 func (h *CLIHarness) GetYamlFile(s string) common.FuncFileV20180707 {
@@ -474,8 +487,15 @@ func (h *CLIHarness) GetYamlFile(s string) common.FuncFileV20180707 {
 	err = yaml.Unmarshal(b, &ff)
 
 	return ff
+}
+
+func (h *CLIHarness) WriteYamlFile(s string, ff common.FuncFileV20180707) {
+
+	ffContent, _ := yaml.Marshal(ff)
+	h.WithFile(s, string(ffContent), 0600)
 
 }
+
 func (cr *CmdResult) AssertStdoutContainsJSON(query []string, value interface{}) {
 	routeObj := map[string]interface{}{}
 	err := json.Unmarshal([]byte(cr.Stdout), &routeObj)


### PR DESCRIPTION
This command:

```
  fn init --image=mjg123/java-init:latest
```

Will `docker run` that image, un-tarring the output with `archive/tar`.

The expected result is that a template of the function will be created, along
with a `func.init.yaml` which is missing various field (notably `Name` and `Version`).  The missing fields are then added by the cli, so that the function is ready to `fn run`.