### PR TITLE
[poc] do not merge!

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -528,10 +528,9 @@ func appNamePath(img string) (string, string) {
 	return img[:sep], img[sep : sep+tag]
 }
 
-// ExtractAnnotations extract annotations from command flags.
-func ExtractAnnotations(c *cli.Context) map[string]interface{} {
+func ExtractAnnotations(ann []string) map[string]interface{} {
 	annotations := make(map[string]interface{})
-	for _, s := range c.StringSlice("annotation") {
+	for _, s := range ann {
 		parts := strings.Split(s, "=")
 		if len(parts) == 2 {
 			var v interface{}


### PR DESCRIPTION
the idea is to get rid of `cli.Context` wherever that is possible in order to get a reusable importable code.

the problem is that most of the function relies on `cli.Context`, this context is used for CLI flags only, so instead of passing a context down, we may retrieve necessary flag values to then pass them instead.

2nd thing is CLI command structs like:
```go
type initFnCmd struct {
	force       bool
	triggerType string
	wd          string
	ff          *common.FuncFile
	ffV20180707 *common.FuncFileV20180707
}
```
most of the methods implemented on this struct are using func file, nothing else, so, in order to make code reusable we need to do two things (true way and an alternative):
 - extract core logic of those methods and make it reusable
 - make those methods structure-independent (i.e., if a method needs a reference to any of structure attributes - pass them as parameters, but not through a struct pointer reference).

I'm talking about specific method like:
```go
func bindRoute(ff *common.FuncFile, fn *models.Route)

func bindFn(ff *common.FuncFileV20180707, fn *modelsV2.Fn)
```
etc