### PR TITLE
Generate boilerplate from the existing func file

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -173,13 +173,15 @@ func (a *initFnCmd) init(c *cli.Context) error {
 			if ff != nil {
 				return errors.New("Function file already exists, aborting")
 			}
+		} else {
+			a.ff = ff
+			fileExt = filepath.Ext(ffPath)
+			if a.ff.Runtime != "" {
+				runtime = a.ff.Runtime
+			}
 		}
-		a.ff = ff
-		fileExt = filepath.Ext(ffPath)
 	}
-	if a.ff.Runtime != "" {
-		runtime = a.ff.Runtime
-	}
+
 	err = a.BuildFuncFile(c, runtime, dir) // TODO: Return LangHelper here, then don't need to refind the helper in generateBoilerplate() below
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR to allow developers generate the boilerplate from existing `func` files.

How it works:

Developer has a func file:
```bash
$ ls -la
total 8
drwxr-xr-x   3 denismakogon  staff   96 Aug 10 12:15 .
drwxr-xr-x  20 denismakogon  staff  640 Aug  8 13:23 ..
-rw-r--r--   1 denismakogon  staff  139 Aug 10 12:12 func.yml
```

Generating boilerplate:
```bash
$ fn init --from-func-file
Runtime: go
Function boilerplate generated.
func.yml  created.
```

Boilerplate generated:
```bash
ls -la
total 32
drwxr-xr-x   6 denismakogon  staff  192 Aug 10 12:16 .
drwxr-xr-x  20 denismakogon  staff  640 Aug  8 13:23 ..
-rw-r--r--   1 denismakogon  staff  127 Aug 10 12:16 Gopkg.toml
-rw-r--r--   1 denismakogon  staff  469 Aug 10 12:16 func.go
-rw-r--r--   1 denismakogon  staff  139 Aug 10 12:16 func.yml
-rw-r--r--   1 denismakogon  staff  505 Aug 10 12:16 test.json
```

No impact on current UX:
```bash
fn init --runtime go
Runtime: go
Function boilerplate generated.
func.yaml  created.
```

```bash
$ fn init

Fn: Function file already exists, aborting

See 'fn <command> --help' for more information. Client version: 0.4.135

```

Closes: #371