### PR TITLE
Fn init now respects the --name arg

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -349,6 +349,10 @@ func ValidateFuncName(name string) error {
 func (a *initFnCmd) BuildFuncFile(c *cli.Context, path string) error {
 	var err error
 
+	if c.String("name") != "" {
+		a.ff.Name = strings.ToLower(c.String("name"))
+	}
+
 	if a.ff.Name == "" {
 		// then defaults to current directory for name, the name must be lowercase
 		a.ff.Name = strings.ToLower(filepath.Base(path))
@@ -444,6 +448,10 @@ func (a *initFnCmd) BuildFuncFile(c *cli.Context, path string) error {
 
 func (a *initFnCmd) BuildFuncFileV20180707(c *cli.Context, path string) error {
 	var err error
+
+	if c.String("name") != "" {
+		a.ffV20180707.Name = strings.ToLower(c.String("name"))
+	}
 
 	if a.ffV20180707.Name == "" {
 		// then defaults to current directory for name, the name must be lowercase

--- a/test/cli_init_test.go
+++ b/test/cli_init_test.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/fnproject/cli/testharness"
+)
+
+func TestSettingFuncName(t *testing.T) {
+	t.Run("`fn init --name` should set the name in func.yaml", func(t *testing.T) {
+		t.Parallel()
+		h := testharness.Create(t)
+		defer h.Cleanup()
+
+		funcName := h.NewFuncName()
+		dirName := funcName + "_dir"
+		h.Fn("init", "--runtime", "java", "--name", funcName, dirName).AssertSuccess()
+
+		h.Cd(dirName)
+
+		yamlFile := h.GetYamlFile("func.yaml")
+		if yamlFile.Name != funcName {
+			t.Fatalf("Name was not set to %s in func.yaml", funcName)
+		}
+	})
+}


### PR DESCRIPTION
  Previously the --name arg was ignored and the name of the
directory was being used as the name in all cases.

Fixes: #385