### PR TITLE
Base config file loaded even if explicit context given

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,13 +117,15 @@ func LoadConfiguration(c *cli.Context) error {
 	// Find home directory.
 	home := GetHomeDir()
 	context := ""
-	if context = c.String(EnvFnContext); context == "" {
-		viper.AddConfigPath(filepath.Join(home, rootConfigPathName))
-		viper.SetConfigName(configName)
 
-		if err := viper.ReadInConfig(); err != nil {
-			return err
-		}
+	viper.AddConfigPath(filepath.Join(home, rootConfigPathName))
+	viper.SetConfigName(configName)
+
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	if context = c.String(EnvFnContext); context == "" {
 		context = viper.GetString(CurrentContext)
 	}
 


### PR DESCRIPTION
Currently when specifying a context in the command, via --context, the
welcome message is always shown. This is because when the flag is
supplied the base config file is not loaded, and it is this that
contains the cli-version field, which is then used to see if the
welcome message should be displayed.

This change makes it so the base config file is loaded, but only uses
the context contained within, if the cmd arg has not be specified.