### PR TITLE
Edit init --help text to use functions/triggers flags

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -91,7 +91,7 @@ func initFlags(a *initFnCmd) []cli.Flag {
 		},
 	}
 
-	return append(fgs, route.RouteFlags...)
+	return append(fgs, function.FnFlags...)
 }
 
 func langsList() string {

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -30,27 +30,27 @@ type fnsCmd struct {
 var FnFlags = []cli.Flag{
 	cli.Uint64Flag{
 		Name:  "memory,m",
-		Usage: "memory in MiB",
+		Usage: "Memory in MiB",
 	},
 	cli.StringSliceFlag{
 		Name:  "config,c",
-		Usage: "fn configuration",
+		Usage: "Function configuration",
 	},
 	cli.StringFlag{
 		Name:  "format,f",
-		Usage: "hot container IO format - can be one of: default, http, json or cloudevent (check FDK docs to see which are supported for the FDK in use.)",
+		Usage: "Hot container IO format - can be one of: default, http, json or cloudevent (check FDK docs to see which are supported for the FDK in use.)",
 	},
 	cli.IntFlag{
 		Name:  "timeout",
-		Usage: "fn timeout (eg. 30)",
+		Usage: "Function timeout (eg. 30)",
 	},
 	cli.IntFlag{
 		Name:  "idle-timeout",
-		Usage: "fn idle timeout (eg. 30)",
+		Usage: "Function idle timeout (eg. 30)",
 	},
 	cli.StringSliceFlag{
 		Name:  "annotation",
-		Usage: "fn annotation (can be specified multiple times)",
+		Usage: "Function annotation (can be specified multiple times)",
 	},
 }
 var updateFnFlags = FnFlags


### PR DESCRIPTION
Replace the --help text on the init command with functions/triggers flags rather than routes. 
See issue [#396 fn init Help Text Refers to Route Features](https://github.com/fnproject/cli/issues/396)

```
  --memory value, -m value       Memory in MiB (default: 0)
  --config value, -c value       Function configuration
  --format value, -f value       Hot container IO format - can be one of: default, http, json or cloudevent (check FDK docs to see which are supported for the FDK in use.)
  --timeout value                Function timeout (eg. 30) (default: 0)
  --idle-timeout value           Function idle timeout (eg. 30) (default: 0)
  --annotation value             Function annotation (can be specified multiple times)
```