### PR TITLE
Fix deploy --all command when using V20180707 func.yaml

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -69,7 +69,7 @@ func (b *buildcmd) build(c *cli.Context) error {
 	}
 	defer os.Chdir(dir)
 
-	ffV, err := common.ReadInFuncFile()
+	ffV, err := common.ReadInFuncFile("")
 	if err != nil {
 		return err
 	}

--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -34,7 +34,7 @@ func MigrateCommand() cli.Command {
 
 func (m *migrateFnCmd) migrate(c *cli.Context) error {
 	var err error
-	oldFF, err := common.ReadInFuncFile()
+	oldFF, err := common.ReadInFuncFile("")
 	if err != nil {
 		return err
 	}

--- a/commands/push.go
+++ b/commands/push.go
@@ -49,7 +49,7 @@ func (p *pushcmd) flags() []cli.Flag {
 // push the container, and finally it will update function's route. Optionally,
 // the route can be overriden inside the functions file.
 func (p *pushcmd) push(c *cli.Context) error {
-	ffV, err := common.ReadInFuncFile()
+	ffV, err := common.ReadInFuncFile("")
 	version := common.GetFuncYamlVersion(ffV)
 	if version == common.LatestYamlVersion {
 		_, ff, err := common.LoadFuncFileV20180707(".")

--- a/commands/test.go
+++ b/commands/test.go
@@ -91,47 +91,47 @@ func (t *testcmd) test(c *cli.Context) error {
 func (t *testcmd) testAll(c *cli.Context, wd string) error {
 	testCount := 0
 	errorCount := 0
-	err := common.WalkFuncs(wd, func(path string, ff *common.FuncFile, err error) error {
-		if err != nil { // probably some issue with funcfile parsing, can decide to handle this differently if we'd like
-			return err
-		}
-		dir := filepath.Dir(path)
-		if dir == wd {
-			// TODO: needed for tests?
-			// setRootFuncInfo(ff, appName)
-		} else {
-			// change dirs
-			err = os.Chdir(dir)
-			if err != nil {
-				return err
-			}
-			p2 := strings.TrimPrefix(dir, wd)
-			if ff.Name == "" {
-				ff.Name = strings.Replace(p2, "/", "-", -1)
-				if strings.HasPrefix(ff.Name, "-") {
-					ff.Name = ff.Name[1:]
-				}
-				// todo: should we prefix appname too?
-			}
-			if ff.Path == "" {
-				ff.Path = p2
-			}
-		}
-		tc, ec, err := t.testSingle(c, dir)
-		if err != nil {
-			fmt.Printf("Test error on %s: %v\n", path, err)
-			// TOOD: store these logs and print them at the end?
-		}
-		testCount += tc
-		errorCount += ec
-		now := time.Now()
-		os.Chtimes(path, now, now)
-		// funcFound = true
-		return nil
-	})
-	if err != nil {
-		return err
-	}
+	// err := common.WalkFuncs(wd, func(path string, ff *common.FuncFile, err error) error {
+	// 	if err != nil { // probably some issue with funcfile parsing, can decide to handle this differently if we'd like
+	// 		return err
+	// 	}
+	// 	dir := filepath.Dir(path)
+	// 	if dir == wd {
+	// 		// TODO: needed for tests?
+	// 		// setRootFuncInfo(ff, appName)
+	// 	} else {
+	// 		// change dirs
+	// 		err = os.Chdir(dir)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 		p2 := strings.TrimPrefix(dir, wd)
+	// 		if ff.Name == "" {
+	// 			ff.Name = strings.Replace(p2, "/", "-", -1)
+	// 			if strings.HasPrefix(ff.Name, "-") {
+	// 				ff.Name = ff.Name[1:]
+	// 			}
+	// 			// todo: should we prefix appname too?
+	// 		}
+	// 		if ff.Path == "" {
+	// 			ff.Path = p2
+	// 		}
+	// 	}
+	// 	tc, ec, err := t.testSingle(c, dir)
+	// 	if err != nil {
+	// 		fmt.Printf("Test error on %s: %v\n", path, err)
+	// 		// TOOD: store these logs and print them at the end?
+	// 	}
+	// 	testCount += tc
+	// 	errorCount += ec
+	// 	now := time.Now()
+	// 	os.Chtimes(path, now, now)
+	// 	// funcFound = true
+	// 	return nil
+	// })
+	// if err != nil {
+	// 	return err
+	// }
 	errmsg := "0 FAILED"
 	if errorCount > 0 {
 		errmsg = color.RedString(fmt.Sprintf("%v FAILED", errorCount))

--- a/common/bump.go
+++ b/common/bump.go
@@ -85,7 +85,7 @@ func (b *bumpcmd) bump(c *cli.Context) error {
 
 	dir = GetDir(c)
 
-	ff, err := ReadInFuncFile()
+	ff, err := ReadInFuncFile("")
 	version := GetFuncYamlVersion(ff)
 	if version == LatestYamlVersion {
 		_, err = bumpItWdV20180707(dir, t)

--- a/common/common.go
+++ b/common/common.go
@@ -548,12 +548,16 @@ func ExtractAnnotations(c *cli.Context) map[string]interface{} {
 	return annotations
 }
 
-func ReadInFuncFile() (map[string]interface{}, error) {
-	wd := GetWd()
-
-	fpath, err := FindFuncfile(wd)
-	if err != nil {
-		return nil, err
+func ReadInFuncFile(path string) (map[string]interface{}, error) {
+	var fpath string
+	if path != "" {
+		fpath = path
+	} else {
+		var err error
+		fpath, err = FindFuncfile(GetWd())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	b, err := ioutil.ReadFile(fpath)

--- a/run/run.go
+++ b/run/run.go
@@ -227,7 +227,7 @@ func getEnvValue(n string, envVars []string) string {
 }
 
 func (r *runCmd) run(c *cli.Context) error {
-	ffV, err := common.ReadInFuncFile()
+	ffV, err := common.ReadInFuncFile("")
 	version := common.GetFuncYamlVersion(ffV)
 
 	if version == common.LatestYamlVersion {


### PR DESCRIPTION
[#395](https://github.com/fnproject/cli/issues/395) Fn deploy --all overwrites the trigger information in func.yaml files.

Update the walker function to identify the version of the func.yaml to then be used within deploy.go to determine how the funcfile is deployed.