### PR TITLE
Fixes a discrepancy in schema version naming

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -76,18 +76,18 @@ func (b *buildcmd) build(c *cli.Context) error {
 
 	switch common.GetFuncYamlVersion(ffV) {
 	case common.LatestYamlVersion:
-		fpath, ff, err := common.FindAndParseFuncFileV20180707(dir)
+		fpath, ff, err := common.FindAndParseFuncFileV20180708(dir)
 		if err != nil {
 			return err
 		}
 
 		buildArgs := c.StringSlice("build-arg")
-		ff, err = common.BuildFuncV20180707(c, fpath, ff, buildArgs, b.noCache)
+		ff, err = common.BuildFuncV20180708(c, fpath, ff, buildArgs, b.noCache)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("Function %v built successfully.\n", ff.ImageNameV20180707())
+		fmt.Printf("Function %v built successfully.\n", ff.ImageNameV20180708())
 		return nil
 
 	default:

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -183,13 +183,13 @@ func (p *deploycmd) deploySingle(c *cli.Context, appName string, appf *common.Ap
 
 	switch common.GetFuncYamlVersion(ffV) {
 	case common.LatestYamlVersion:
-		fpath, ff, err := common.FindAndParseFuncFileV20180707(dir)
+		fpath, ff, err := common.FindAndParseFuncFileV20180708(dir)
 		if err != nil {
 			return err
 		}
 		if appf != nil {
 			if dir == wd {
-				setFuncInfoV20180707(ff, appf.Name)
+				setFuncInfoV20180708(ff, appf.Name)
 			}
 		}
 
@@ -200,7 +200,7 @@ func (p *deploycmd) deploySingle(c *cli.Context, appName string, appf *common.Ap
 			}
 		}
 
-		return p.deployFuncV20180707(c, appName, wd, fpath, ff)
+		return p.deployFuncV20180708(c, appName, wd, fpath, ff)
 	default:
 		fpath, ff, err := common.FindAndParseFuncfile(dir)
 		if err != nil {
@@ -337,7 +337,7 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 	return p.updateRoute(c, appName, funcfile)
 }
 
-func (p *deploycmd) deployFuncV20180707(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *common.FuncFileV20180707) error {
+func (p *deploycmd) deployFuncV20180708(c *cli.Context, appName, baseDir, funcfilePath string, funcfile *common.FuncFileV20180708) error {
 	if appName == "" {
 		return errors.New("App name must be provided, try `--app APP_NAME`")
 	}
@@ -349,7 +349,7 @@ func (p *deploycmd) deployFuncV20180707(c *cli.Context, appName, baseDir, funcfi
 
 	var err error
 	if !p.noBump {
-		funcfile2, err := common.BumpItV20180707(funcfilePath, common.Patch)
+		funcfile2, err := common.BumpItV20180708(funcfilePath, common.Patch)
 		if err != nil {
 			return err
 		}
@@ -358,13 +358,13 @@ func (p *deploycmd) deployFuncV20180707(c *cli.Context, appName, baseDir, funcfi
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFuncV20180707(c, funcfilePath, funcfile, buildArgs, p.noCache)
+	_, err = common.BuildFuncV20180708(c, funcfilePath, funcfile, buildArgs, p.noCache)
 	if err != nil {
 		return err
 	}
 
 	if !p.local {
-		if err := common.DockerPushV20180707(funcfile); err != nil {
+		if err := common.DockerPushV20180708(funcfile); err != nil {
 			return err
 		}
 	}
@@ -383,7 +383,7 @@ func setRootFuncInfo(ff *common.FuncFile, appName string) {
 	}
 }
 
-func setFuncInfoV20180707(ff *common.FuncFileV20180707, appName string) {
+func setFuncInfoV20180708(ff *common.FuncFileV20180708, appName string) {
 	if ff.Name == "" {
 		fmt.Println("Setting name")
 		ff.Name = fmt.Sprintf("%s-root", appName)
@@ -399,10 +399,10 @@ func (p *deploycmd) updateRoute(c *cli.Context, appName string, ff *common.FuncF
 	return route.PutRoute(p.client, appName, ff.Path, rt)
 }
 
-func (p *deploycmd) updateFunction(c *cli.Context, appName string, ff *common.FuncFileV20180707) error {
-	fmt.Printf("Updating function %s using image %s...\n", ff.Name, ff.ImageNameV20180707())
+func (p *deploycmd) updateFunction(c *cli.Context, appName string, ff *common.FuncFileV20180708) error {
+	fmt.Printf("Updating function %s using image %s...\n", ff.Name, ff.ImageNameV20180708())
 	fn := &modelsV2.Fn{}
-	if err := function.WithFuncFileV20180707(ff, fn); err != nil {
+	if err := function.WithFuncFileV20180708(ff, fn); err != nil {
 		return fmt.Errorf("Error getting route with funcfile: %s", err)
 	}
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -44,7 +44,7 @@ type initFnCmd struct {
 	triggerType string
 	wd          string
 	ff          *common.FuncFile
-	ffV20180707 *common.FuncFileV20180707
+	ffV20180708 *common.FuncFileV20180708
 }
 
 func initFlags(a *initFnCmd) []cli.Flag {
@@ -104,7 +104,7 @@ func langsList() string {
 
 // InitCommand returns init cli.command
 func InitCommand() cli.Command {
-	a := &initFnCmd{ff: &common.FuncFile{}, ffV20180707: &common.FuncFileV20180707{}}
+	a := &initFnCmd{ff: &common.FuncFile{}, ffV20180708: &common.FuncFileV20180708{}}
 
 	return cli.Command{
 		Name:        "init",
@@ -341,16 +341,16 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 		dir = a.wd
 	}
 
-	a.ffV20180707.Name = c.Args().First()
+	a.ffV20180708.Name = c.Args().First()
 
 	if a.triggerType == "http" {
 		trig := make([]common.Trigger, 1)
 		trig[0] = common.Trigger{
-			a.ffV20180707.Name + "-trigger",
+			a.ffV20180708.Name + "-trigger",
 			a.triggerType,
-			"/" + a.ffV20180707.Name + "-trigger",
+			"/" + a.ffV20180708.Name + "-trigger",
 		}
-		a.ffV20180707.Triggers = trig
+		a.ffV20180708.Triggers = trig
 	}
 
 	runtime := c.String("runtime")
@@ -362,7 +362,7 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 
 	runtimeSpecified := runtime != ""
 
-	a.ffV20180707.Schema_version = common.LatestYamlVersion
+	a.ffV20180708.Schema_version = common.LatestYamlVersion
 	if runtimeSpecified {
 		// go no further if the specified runtime is not supported
 		if runtime != common.FuncfileDockerRuntime && langs.GetLangHelper(runtime) == nil {
@@ -404,12 +404,12 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 			return errors.New("Function file already exists, aborting")
 		}
 	}
-	err = a.BuildFuncFileV20180707(c, dir) // TODO: Return LangHelper here, then don't need to refind the helper in generateBoilerplate() below
+	err = a.BuildFuncFileV20180708(c, dir) // TODO: Return LangHelper here, then don't need to refind the helper in generateBoilerplate() below
 	if err != nil {
 		return err
 	}
 
-	a.ffV20180707.Schema_version = common.LatestYamlVersion
+	a.ffV20180708.Schema_version = common.LatestYamlVersion
 
 	if initImage != "" {
 
@@ -430,30 +430,30 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 		//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
 		//     Add the following from the init-image:
 		//         build, build_image, cmd, content_type, entrypoint, expects, format, headers, run_image, runtime
-		a.ffV20180707.Build = initFf.Build
-		a.ffV20180707.Build_image = initFf.BuildImage
-		a.ffV20180707.Cmd = initFf.Cmd
-		a.ffV20180707.Content_type = initFf.ContentType
-		a.ffV20180707.Entrypoint = initFf.Entrypoint
-		a.ffV20180707.Expects = initFf.Expects
-		a.ffV20180707.Format = initFf.Format
-		a.ffV20180707.Run_image = initFf.RunImage
-		a.ffV20180707.Runtime = initFf.Runtime
+		a.ffV20180708.Build = initFf.Build
+		a.ffV20180708.Build_image = initFf.BuildImage
+		a.ffV20180708.Cmd = initFf.Cmd
+		a.ffV20180708.Content_type = initFf.ContentType
+		a.ffV20180708.Entrypoint = initFf.Entrypoint
+		a.ffV20180708.Expects = initFf.Expects
+		a.ffV20180708.Format = initFf.Format
+		a.ffV20180708.Run_image = initFf.RunImage
+		a.ffV20180708.Runtime = initFf.Runtime
 
 		// Then CLI args can override some init-image options (TODO: remove this with #383)
 		if c.String("cmd") != "" {
-			a.ffV20180707.Cmd = c.String("cmd")
+			a.ffV20180708.Cmd = c.String("cmd")
 		}
 
 		if c.String("entrypoint") != "" {
-			a.ffV20180707.Entrypoint = c.String("entrypoint")
+			a.ffV20180708.Entrypoint = c.String("entrypoint")
 		}
 
 		if c.String("format") != "" {
-			a.ffV20180707.Format = c.String("format")
+			a.ffV20180708.Format = c.String("format")
 		}
 
-		if err := common.EncodeFuncFileV20180707YAML("func.yaml", a.ffV20180707); err != nil {
+		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ffV20180708); err != nil {
 			return err
 		}
 
@@ -469,7 +469,7 @@ func (a *initFnCmd) initV2(c *cli.Context, fn modelsV2.Fn) error {
 			}
 		}
 
-		if err := common.EncodeFuncFileV20180707YAML("func.yaml", a.ffV20180707); err != nil {
+		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ffV20180708); err != nil {
 			return err
 		}
 	}
@@ -510,7 +510,7 @@ func (a *initFnCmd) bindRoute(fn *models.Route) {
 }
 
 func (a *initFnCmd) bindFn(fn *modelsV2.Fn) {
-	ff := a.ffV20180707
+	ff := a.ffV20180708
 	if fn.Format != "" {
 		ff.Format = fn.Format
 	}
@@ -645,20 +645,20 @@ func (a *initFnCmd) BuildFuncFile(c *cli.Context, path string) error {
 	return nil
 }
 
-func (a *initFnCmd) BuildFuncFileV20180707(c *cli.Context, path string) error {
+func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 	var err error
 
 	if c.String("name") != "" {
-		a.ffV20180707.Name = strings.ToLower(c.String("name"))
+		a.ffV20180708.Name = strings.ToLower(c.String("name"))
 	}
 
-	if a.ffV20180707.Name == "" {
+	if a.ffV20180708.Name == "" {
 		// then defaults to current directory for name, the name must be lowercase
-		a.ffV20180707.Name = strings.ToLower(filepath.Base(path))
+		a.ffV20180708.Name = strings.ToLower(filepath.Base(path))
 	}
 
-	a.ffV20180707.Version = c.String("version")
-	if err = ValidateFuncName(a.ffV20180707.Name); err != nil {
+	a.ffV20180708.Version = c.String("version")
+	if err = ValidateFuncName(a.ffV20180708.Name); err != nil {
 		return err
 	}
 
@@ -686,7 +686,7 @@ func (a *initFnCmd) BuildFuncFileV20180707(c *cli.Context, path string) error {
 		fmt.Printf("Found %v function, assuming %v runtime.\n", helper.Runtime(), helper.Runtime())
 		//need to default this to default format to be backwards compatible. Might want to just not allow this anymore, fail here.
 		if c.String("format") == "" {
-			a.ffV20180707.Format = "default"
+			a.ffV20180708.Format = "default"
 		}
 	} else {
 		fmt.Println("Runtime:", runtime)
@@ -696,20 +696,20 @@ func (a *initFnCmd) BuildFuncFileV20180707(c *cli.Context, path string) error {
 		fmt.Printf("Init does not support the %s runtime, you'll have to create your own Dockerfile for this function.\n", runtime)
 	} else {
 		if c.String("entrypoint") == "" {
-			a.ffV20180707.Entrypoint, err = helper.Entrypoint()
+			a.ffV20180708.Entrypoint, err = helper.Entrypoint()
 			if err != nil {
 				return err
 			}
 		}
 
 		if runtime == "" {
-			a.ffV20180707.Runtime = helper.Runtime()
+			a.ffV20180708.Runtime = helper.Runtime()
 		}
 
-		a.ffV20180707.Runtime = runtime
+		a.ffV20180708.Runtime = runtime
 
 		if c.String("format") == "" {
-			a.ffV20180707.Format = helper.DefaultFormat()
+			a.ffV20180708.Format = helper.DefaultFormat()
 		}
 
 		if c.String("cmd") == "" {
@@ -717,31 +717,31 @@ func (a *initFnCmd) BuildFuncFileV20180707(c *cli.Context, path string) error {
 			if err != nil {
 				return err
 			}
-			a.ffV20180707.Cmd = cmd
+			a.ffV20180708.Cmd = cmd
 		}
 
 		if helper.FixImagesOnInit() {
-			if a.ffV20180707.Build_image == "" {
+			if a.ffV20180708.Build_image == "" {
 				buildImage, err := helper.BuildFromImage()
 				if err != nil {
 					return err
 				}
-				a.ffV20180707.Build_image = buildImage
+				a.ffV20180708.Build_image = buildImage
 			}
 			if helper.IsMultiStage() {
-				if a.ffV20180707.Run_image == "" {
+				if a.ffV20180708.Run_image == "" {
 					runImage, err := helper.RunFromImage()
 					if err != nil {
 						return err
 					}
-					a.ffV20180707.Run_image = runImage
+					a.ffV20180708.Run_image = runImage
 				}
 			}
 		}
 	}
 
-	if a.ffV20180707.Entrypoint == "" && a.ffV20180707.Cmd == "" {
-		return fmt.Errorf("Could not detect entrypoint or cmd for %v, use --entrypoint and/or --cmd to set them explicitly", a.ffV20180707.Runtime)
+	if a.ffV20180708.Entrypoint == "" && a.ffV20180708.Cmd == "" {
+		return fmt.Errorf("Could not detect entrypoint or cmd for %v, use --entrypoint and/or --cmd to set them explicitly", a.ffV20180708.Runtime)
 	}
 
 	return nil

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -75,7 +75,7 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 	if c.String("content-type") != "" {
 		contentType = c.String("content-type")
 	} else {
-		_, ff, err := common.FindAndParseFuncFileV20180707(wd)
+		_, ff, err := common.FindAndParseFuncFileV20180708(wd)
 		if err == nil && ff.Content_type != "" {
 			contentType = ff.Content_type
 		}

--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -16,11 +16,11 @@ import (
 )
 
 type migrateFnCmd struct {
-	newFF *common.FuncFileV20180707
+	newFF *common.FuncFileV20180708
 }
 
 func MigrateCommand() cli.Command {
-	m := &migrateFnCmd{newFF: &common.FuncFileV20180707{}}
+	m := &migrateFnCmd{newFF: &common.FuncFileV20180708{}}
 
 	return cli.Command{
 		Name:        "migrate",
@@ -127,7 +127,7 @@ func vaidateFuncFileSchema(b []byte) error {
 	}
 	defer os.Remove("temp.json")
 
-	err = common.ValidateFileAgainstSchema("temp.json", common.V20180707Schema)
+	err = common.ValidateFileAgainstSchema("temp.json", common.V20180708Schema)
 	if err != nil {
 		return err
 	}

--- a/commands/push.go
+++ b/commands/push.go
@@ -52,7 +52,7 @@ func (p *pushcmd) push(c *cli.Context) error {
 	ffV, err := common.ReadInFuncFile()
 	version := common.GetFuncYamlVersion(ffV)
 	if version == common.LatestYamlVersion {
-		_, ff, err := common.LoadFuncFileV20180707(".")
+		_, ff, err := common.LoadFuncFileV20180708(".")
 		if err != nil {
 			if _, ok := err.(*common.NotFoundError); ok {
 				return errors.New("Image name is missing or no function file found")
@@ -60,13 +60,13 @@ func (p *pushcmd) push(c *cli.Context) error {
 			return err
 		}
 
-		fmt.Println("pushing", ff.ImageNameV20180707())
+		fmt.Println("pushing", ff.ImageNameV20180708())
 
-		if err := common.DockerPushV20180707(ff); err != nil {
+		if err := common.DockerPushV20180708(ff); err != nil {
 			return err
 		}
 
-		fmt.Printf("Function %v pushed successfully to Docker Hub.\n", ff.ImageNameV20180707())
+		fmt.Printf("Function %v pushed successfully to Docker Hub.\n", ff.ImageNameV20180708())
 		return nil
 	}
 

--- a/common/bump.go
+++ b/common/bump.go
@@ -88,7 +88,7 @@ func (b *bumpcmd) bump(c *cli.Context) error {
 	ff, err := ReadInFuncFile()
 	version := GetFuncYamlVersion(ff)
 	if version == LatestYamlVersion {
-		_, err = bumpItWdV20180707(dir, t)
+		_, err = bumpItWdV20180708(dir, t)
 	} else {
 		_, err = bumpItWd(dir, t)
 	}
@@ -165,37 +165,37 @@ func cleanImageName(name string) string {
 	return strings.Join(slashParts, "/")
 }
 
-// --------- FuncFileV20180707 -------------
+// --------- FuncFileV20180708 -------------
 
-func bumpItWdV20180707(wd string, vtype VType) (*FuncFileV20180707, error) {
+func bumpItWdV20180708(wd string, vtype VType) (*FuncFileV20180708, error) {
 	fn, err := FindFuncfile(wd)
 	if err != nil {
 		return nil, err
 	}
-	return BumpItV20180707(fn, vtype)
+	return BumpItV20180708(fn, vtype)
 }
 
 // BumpIt returns updated funcfile
-func BumpItV20180707(fpath string, vtype VType) (*FuncFileV20180707, error) {
+func BumpItV20180708(fpath string, vtype VType) (*FuncFileV20180708, error) {
 	// fmt.Println("Bumping version in func file at: ", fpath)
-	funcfile, err := ParseFuncFileV20180707(fpath)
+	funcfile, err := ParseFuncFileV20180708(fpath)
 	if err != nil {
 		return nil, err
 	}
 
-	funcfile, err = bumpVersionV20180707(funcfile, vtype)
+	funcfile, err = bumpVersionV20180708(funcfile, vtype)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := storeFuncFileV20180707(fpath, funcfile); err != nil {
+	if err := storeFuncFileV20180708(fpath, funcfile); err != nil {
 		return nil, err
 	}
 	fmt.Println("Bumped to version", funcfile.Version)
 	return funcfile, nil
 }
 
-func bumpVersionV20180707(funcfile *FuncFileV20180707, t VType) (*FuncFileV20180707, error) {
+func bumpVersionV20180708(funcfile *FuncFileV20180708, t VType) (*FuncFileV20180708, error) {
 	funcfile.Name = cleanImageName(funcfile.Name)
 	if funcfile.Version == "" {
 		funcfile.Version = InitialVersion

--- a/common/common.go
+++ b/common/common.go
@@ -77,11 +77,11 @@ func BuildFunc(c *cli.Context, fpath string, funcfile *FuncFile, buildArg []stri
 }
 
 // BuildFunc bumps version and builds function.
-func BuildFuncV20180707(c *cli.Context, fpath string, funcfile *FuncFileV20180707, buildArg []string, noCache bool) (*FuncFileV20180707, error) {
+func BuildFuncV20180708(c *cli.Context, fpath string, funcfile *FuncFileV20180708, buildArg []string, noCache bool) (*FuncFileV20180708, error) {
 	var err error
 
 	if funcfile.Version == "" {
-		funcfile, err = BumpItV20180707(fpath, Patch)
+		funcfile, err = BumpItV20180708(fpath, Patch)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func BuildFuncV20180707(c *cli.Context, fpath string, funcfile *FuncFileV2018070
 		return nil, err
 	}
 
-	if err := dockerBuildV20180707(c, fpath, funcfile, buildArg, noCache); err != nil {
+	if err := dockerBuildV20180708(c, fpath, funcfile, buildArg, noCache); err != nil {
 		return nil, err
 	}
 
@@ -169,7 +169,7 @@ func dockerBuild(c *cli.Context, fpath string, ff *FuncFile, buildArgs []string,
 	return nil
 }
 
-func dockerBuildV20180707(c *cli.Context, fpath string, ff *FuncFileV20180707, buildArgs []string, noCache bool) error {
+func dockerBuildV20180708(c *cli.Context, fpath string, ff *FuncFileV20180708, buildArgs []string, noCache bool) error {
 	err := dockerVersionCheck()
 	if err != nil {
 		return err
@@ -187,7 +187,7 @@ func dockerBuildV20180707(c *cli.Context, fpath string, ff *FuncFileV20180707, b
 		if helper == nil {
 			return fmt.Errorf("Cannot build, no language helper found for %v", ff.Runtime)
 		}
-		dockerfile, err = writeTmpDockerfileV20180707(helper, dir, ff)
+		dockerfile, err = writeTmpDockerfileV20180708(helper, dir, ff)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func dockerBuildV20180707(c *cli.Context, fpath string, ff *FuncFileV20180707, b
 			}
 		}
 	}
-	err = RunBuild(c, dir, ff.ImageNameV20180707(), dockerfile, buildArgs, noCache)
+	err = RunBuild(c, dir, ff.ImageNameV20180708(), dockerfile, buildArgs, noCache)
 	if err != nil {
 		return err
 	}
@@ -375,7 +375,7 @@ func writeTmpDockerfile(helper langs.LangHelper, dir string, ff *FuncFile) (stri
 	return fd.Name(), err
 }
 
-func writeTmpDockerfileV20180707(helper langs.LangHelper, dir string, ff *FuncFileV20180707) (string, error) {
+func writeTmpDockerfileV20180708(helper langs.LangHelper, dir string, ff *FuncFileV20180708) (string, error) {
 	if ff.Entrypoint == "" && ff.Cmd == "" {
 		return "", errors.New("entrypoint and cmd are missing, you must provide one or the other")
 	}
@@ -484,13 +484,13 @@ func DockerPush(ff *FuncFile) error {
 }
 
 // DockerPush pushes to docker registry.
-func DockerPushV20180707(ff *FuncFileV20180707) error {
-	_, err := ValidateImageName(ff.ImageNameV20180707())
+func DockerPushV20180708(ff *FuncFileV20180708) error {
+	_, err := ValidateImageName(ff.ImageNameV20180708())
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Pushing %v to docker registry...", ff.ImageNameV20180707())
-	cmd := exec.Command("docker", "push", ff.ImageNameV20180707())
+	fmt.Printf("Pushing %v to docker registry...", ff.ImageNameV20180708())
+	cmd := exec.Command("docker", "push", ff.ImageNameV20180708())
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -83,8 +83,8 @@ type FuncFile struct {
 	Expects Expects `yaml:"expects,omitempty" json:"expects,omitempty"`
 }
 
-// FuncFileV20180707 defines the latest internal structure of a func.yaml/json/yml
-type FuncFileV20180707 struct {
+// FuncFileV20180708 defines the latest internal structure of a func.yaml/json/yml
+type FuncFileV20180708 struct {
 	Schema_version int `yaml:"schema_version,omitempty" json:"schema_version,omitempty"`
 
 	Name         string `yaml:"name,omitempty" json:"name,omitempty"`
@@ -110,7 +110,7 @@ type FuncFileV20180707 struct {
 	Triggers []Trigger `yaml:"triggers,omitempty" json:"triggers,omitempty"`
 }
 
-// Trigger represents a trigger for a FuncFileV20180707
+// Trigger represents a trigger for a FuncFileV20180708
 type Trigger struct {
 	Name   string `yaml:"name,omitempty" json:"name,omitempty"`
 	Type   string `yaml:"type,omitempty" json:"type,omitempty"`
@@ -258,59 +258,59 @@ func IsFuncFile(path string, info os.FileInfo) bool {
 	return false
 }
 
-// --------- FuncFileV20180707 -------------
+// --------- FuncFileV20180708 -------------
 
-func FindAndParseFuncFileV20180707(path string) (fpath string, ff *FuncFileV20180707, err error) {
+func FindAndParseFuncFileV20180708(path string) (fpath string, ff *FuncFileV20180708, err error) {
 	fpath, err = FindFuncfile(path)
 	if err != nil {
 		return "", nil, err
 	}
-	ff, err = ParseFuncFileV20180707(fpath)
+	ff, err = ParseFuncFileV20180708(fpath)
 	if err != nil {
 		return "", nil, err
 	}
 	return fpath, ff, err
 }
 
-func LoadFuncFileV20180707(path string) (string, *FuncFileV20180707, error) {
-	return FindAndParseFuncFileV20180707(path)
+func LoadFuncFileV20180708(path string) (string, *FuncFileV20180708, error) {
+	return FindAndParseFuncFileV20180708(path)
 }
 
-func ParseFuncFileV20180707(path string) (*FuncFileV20180707, error) {
+func ParseFuncFileV20180708(path string) (*FuncFileV20180708, error) {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
-		return decodeFuncFileV20180707JSON(path)
+		return decodeFuncFileV20180708JSON(path)
 	case ".yaml", ".yml":
-		return decodeFuncFileV20180707YAML(path)
+		return decodeFuncFileV20180708YAML(path)
 	}
 	return nil, errUnexpectedFileFormat
 }
 
-func decodeFuncFileV20180707JSON(path string) (*FuncFileV20180707, error) {
+func decodeFuncFileV20180708JSON(path string) (*FuncFileV20180708, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &FuncFileV20180707{}
+	ff := &FuncFileV20180708{}
 	// ff.Route = &fnmodels.Route{}
 	err = json.NewDecoder(f).Decode(ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func decodeFuncFileV20180707YAML(path string) (*FuncFileV20180707, error) {
+func decodeFuncFileV20180708YAML(path string) (*FuncFileV20180708, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
-	ff := &FuncFileV20180707{}
+	ff := &FuncFileV20180708{}
 	err = yaml.Unmarshal(b, ff)
 	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
-func encodeFuncFileV20180707JSON(path string, ff *FuncFileV20180707) error {
+func encodeFuncFileV20180708JSON(path string, ff *FuncFileV20180708) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("could not open %s for encoding. Error: %v", path, err)
@@ -319,7 +319,7 @@ func encodeFuncFileV20180707JSON(path string, ff *FuncFileV20180707) error {
 }
 
 // EncodeFuncfileYAML encodes function file.
-func EncodeFuncFileV20180707YAML(path string, ff *FuncFileV20180707) error {
+func EncodeFuncFileV20180708YAML(path string, ff *FuncFileV20180708) error {
 	b, err := yaml.Marshal(ff)
 	if err != nil {
 		return fmt.Errorf("could not encode function file. Error: %v", err)
@@ -327,19 +327,19 @@ func EncodeFuncFileV20180707YAML(path string, ff *FuncFileV20180707) error {
 	return ioutil.WriteFile(path, b, os.FileMode(0644))
 }
 
-func storeFuncFileV20180707(path string, ff *FuncFileV20180707) error {
+func storeFuncFileV20180708(path string, ff *FuncFileV20180708) error {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
-		return encodeFuncFileV20180707JSON(path, ff)
+		return encodeFuncFileV20180708JSON(path, ff)
 	case ".yaml", ".yml":
-		return EncodeFuncFileV20180707YAML(path, ff)
+		return EncodeFuncFileV20180708YAML(path, ff)
 	}
 	return errUnexpectedFileFormat
 }
 
 // ImageName returns the name of a funcfile image
-func (ff *FuncFileV20180707) ImageNameV20180707() string {
+func (ff *FuncFileV20180708) ImageNameV20180708() string {
 	fname := ff.Name
 	if !strings.Contains(fname, "/") {
 

--- a/common/schema.go
+++ b/common/schema.go
@@ -10,8 +10,8 @@ import (
 
 const LatestYamlVersion = 20180708
 
-const V20180707Schema = `{
-    "title": "V20180707 func file schema",
+const V20180708Schema = `{
+    "title": "V20180708 func file schema",
     "type": "object",
     "properties": {
         "name": {

--- a/common/walker.go
+++ b/common/walker.go
@@ -9,7 +9,7 @@ import (
 
 // WalkFuncsFunc good name huh?
 type walkFuncsFunc func(path string, ff *FuncFile, err error) error
-type walkFuncsFuncV20180707 func(path string, ff *FuncFileV20180707, err error) error
+type walkFuncsFuncV20180708 func(path string, ff *FuncFileV20180708, err error) error
 
 // WalkFuncs is similar to filepath.Walk except only returns func.yaml's (so on per function)
 func WalkFuncs(root string, walkFn walkFuncsFunc) error {
@@ -42,7 +42,7 @@ func WalkFuncs(root string, walkFn walkFuncsFunc) error {
 }
 
 // WalkFuncs is similar to filepath.Walk except only returns func.yaml's (so on per function)
-func WalkFuncsV20180707(root string, walkFn walkFuncsFunc) error {
+func WalkFuncsV20180708(root string, walkFn walkFuncsFunc) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			// logging this so we can figure out any common issues

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -184,16 +184,16 @@ func FnWithFlags(c *cli.Context, fn *models.Fn) {
 }
 
 // WithFuncFile used when creating a function from a funcfile
-func WithFuncFileV20180707(ff *common.FuncFileV20180707, fn *models.Fn) error {
+func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 	var err error
 	if ff == nil {
-		_, ff, err = common.LoadFuncFileV20180707(".")
+		_, ff, err = common.LoadFuncFileV20180708(".")
 		if err != nil {
 			return err
 		}
 	}
-	if ff.ImageNameV20180707() != "" { // args take precedence
-		fn.Image = ff.ImageNameV20180707()
+	if ff.ImageNameV20180708() != "" { // args take precedence
+		fn.Image = ff.ImageNameV20180708()
 	}
 
 	if ff.Format != "" {

--- a/run/run.go
+++ b/run/run.go
@@ -153,9 +153,9 @@ func PreRun(c *cli.Context) (string, *common.FuncFile, []string, error) {
 	return fpath, ff, envVars, nil
 }
 
-func PreRunV20180707(c *cli.Context) (string, *common.FuncFileV20180707, []string, error) {
+func PreRunV20180708(c *cli.Context) (string, *common.FuncFileV20180708, []string, error) {
 	var dir string
-	var ff *common.FuncFileV20180707
+	var ff *common.FuncFileV20180708
 	var fpath string
 
 	dir = common.GetWd()
@@ -177,7 +177,7 @@ func PreRunV20180707(c *cli.Context) (string, *common.FuncFileV20180707, []strin
 	}
 	defer os.Chdir(dir) // todo: wrap this so we can log the error if changing back fails
 
-	fpath, ff, err = common.FindAndParseFuncFileV20180707(dir)
+	fpath, ff, err = common.FindAndParseFuncFileV20180708(dir)
 	if err != nil {
 		return fpath, nil, nil, err
 	}
@@ -207,7 +207,7 @@ func PreRunV20180707(c *cli.Context) (string, *common.FuncFileV20180707, []strin
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFuncV20180707(c, fpath, ff, buildArgs, c.Bool("no-cache"))
+	_, err = common.BuildFuncV20180708(c, fpath, ff, buildArgs, c.Bool("no-cache"))
 	if err != nil {
 		return fpath, nil, nil, err
 	}
@@ -231,7 +231,7 @@ func (r *runCmd) run(c *cli.Context) error {
 	version := common.GetFuncYamlVersion(ffV)
 
 	if version == common.LatestYamlVersion {
-		_, ff, envVars, err := PreRunV20180707(c)
+		_, ff, envVars, err := PreRunV20180708(c)
 		if err != nil {
 			return err
 		}
@@ -241,7 +241,7 @@ func (r *runCmd) run(c *cli.Context) error {
 			ff.Memory = c.Uint64("memory")
 		}
 
-		return RunFFV20180707(ff, Stdin(), os.Stdout, os.Stderr, c.String("method"), envVars, c.StringSlice("link"), c.String("format"), c.Int("runs"), c.String("content-type"))
+		return RunFFV20180708(ff, Stdin(), os.Stdout, os.Stderr, c.String("method"), envVars, c.StringSlice("link"), c.String("format"), c.Int("runs"), c.String("content-type"))
 	}
 
 	_, ff, envVars, err := PreRun(c)
@@ -369,7 +369,7 @@ func RunFF(ff *common.FuncFile, stdin io.Reader, stdout, stderr io.Writer, metho
 }
 
 // TODO: share all this stuff with the Docker driver in server or better yet, actually use the Docker driver
-func RunFFV20180707(ff *common.FuncFileV20180707, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int, contentType string) error {
+func RunFFV20180708(ff *common.FuncFileV20180708, stdin io.Reader, stdout, stderr io.Writer, method string, envVars []string, links []string, format string, runs int, contentType string) error {
 	sh := []string{"docker", "run", "--rm", "-i", fmt.Sprintf("--memory=%dm", ff.Memory)}
 
 	var env []string    // env for the shelled out docker run command
@@ -470,7 +470,7 @@ func RunFFV20180707(ff *common.FuncFileV20180707, stdin io.Reader, stdout, stder
 		sh = append(sh, "-e", e)
 	}
 
-	sh = append(sh, ff.ImageNameV20180707())
+	sh = append(sh, ff.ImageNameV20180708())
 	cmd := exec.Command(sh[0], sh[1:]...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout

--- a/testharness/harness.go
+++ b/testharness/harness.go
@@ -478,18 +478,18 @@ func (h *CLIHarness) RemoveFile(s string) error {
 	return os.Remove(h.relativeToCwd(s))
 }
 
-func (h *CLIHarness) GetYamlFile(s string) common.FuncFileV20180707 {
+func (h *CLIHarness) GetYamlFile(s string) common.FuncFileV20180708 {
 	b, err := ioutil.ReadFile(h.relativeToCwd(s))
 	if err != nil {
 		h.t.Fatalf("could not open func file for parsing. Error: %v", err)
 	}
-	var ff common.FuncFileV20180707
+	var ff common.FuncFileV20180708
 	err = yaml.Unmarshal(b, &ff)
 
 	return ff
 }
 
-func (h *CLIHarness) WriteYamlFile(s string, ff common.FuncFileV20180707) {
+func (h *CLIHarness) WriteYamlFile(s string, ff common.FuncFileV20180708) {
 
 	ffContent, _ := yaml.Marshal(ff)
 	h.WithFile(s, string(ffContent), 0600)


### PR DESCRIPTION
The actual schema version expected in the code is 20180708, but
somehow all the naming in the code base is 20180707.

This commit brings the two into agreement on 20180708.