### PR TITLE
Change ValidateImageName function to ignore registry field in the image name.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -485,7 +485,7 @@ func DockerPush(ff *FuncFile) error {
 
 // DockerPush pushes to docker registry.
 func DockerPushV20180708(ff *FuncFileV20180708) error {
-	_, err := ValidateImageName(ff.ImageNameV20180708())
+	err := ValidateImageName(ff.ImageNameV20180708())
 	if err != nil {
 		return err
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -469,7 +469,7 @@ func ExtractEnvConfig(configs []string) map[string]string {
 
 // DockerPush pushes to docker registry.
 func DockerPush(ff *FuncFile) error {
-	_, err := ValidateImageName(ff.ImageName())
+	err := ValidateImageName(ff.ImageName())
 	if err != nil {
 		return err
 	}
@@ -501,19 +501,17 @@ func DockerPushV20180708(ff *FuncFileV20180708) error {
 
 // ValidateImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
 // remember that private registries must be supported here
-func ValidateImageName(n string) (string, error) {
+func ValidateImageName(n string) error {
 	parts := strings.Split(n, "/")
 	if len(parts) < 2 {
-		if viper.GetString("registry") == "" {
-			return "", errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var, pass in --registry or configure your context file")
-		}
-		n = viper.GetString("registry") + "/" + n
+		return errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var, pass in --registry or configure your context file")
+
 	}
 	lastParts := strings.Split(parts[len(parts)-1], ":")
 	if len(lastParts) != 2 {
-		return "", errors.New("image name must have a tag")
+		return errors.New("image name must have a tag")
 	}
-	return n, nil
+	return nil
 }
 
 func appNamePath(img string) (string, string) {

--- a/common/common.go
+++ b/common/common.go
@@ -469,7 +469,7 @@ func ExtractEnvConfig(configs []string) map[string]string {
 
 // DockerPush pushes to docker registry.
 func DockerPush(ff *FuncFile) error {
-	err := ValidateImageName(ff.ImageName())
+	err := ValidateFullImageName(ff.ImageName())
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func DockerPush(ff *FuncFile) error {
 
 // DockerPush pushes to docker registry.
 func DockerPushV20180708(ff *FuncFileV20180708) error {
-	err := ValidateImageName(ff.ImageNameV20180708())
+	err := ValidateFullImageName(ff.ImageNameV20180708())
 	if err != nil {
 		return err
 	}
@@ -499,14 +499,23 @@ func DockerPushV20180708(ff *FuncFileV20180708) error {
 	return nil
 }
 
-// ValidateImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
+// ValidateFullImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
 // remember that private registries must be supported here
-func ValidateImageName(n string) error {
+func ValidateFullImageName(n string) error {
+	fmt.Println("N: ", n)
 	parts := strings.Split(n, "/")
+	fmt.Println("Parts: ", parts)
 	if len(parts) < 2 {
 		return errors.New("image name must have a dockerhub owner or private registry. Be sure to set FN_REGISTRY env var, pass in --registry or configure your context file")
 
 	}
+	return ValidateTagImageName(n)
+}
+
+// ValidateTagImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
+// remember that private registries must be supported here
+func ValidateTagImageName(n string) error {
+	parts := strings.Split(n, "/")
 	lastParts := strings.Split(parts[len(parts)-1], ":")
 	if len(lastParts) != 2 {
 		return errors.New("image name must have a tag")

--- a/common/common.go
+++ b/common/common.go
@@ -502,7 +502,6 @@ func DockerPushV20180708(ff *FuncFileV20180708) error {
 // ValidateFullImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
 // remember that private registries must be supported here
 func ValidateFullImageName(n string) error {
-	fmt.Println("N: ", n)
 	parts := strings.Split(n, "/")
 	fmt.Println("Parts: ", parts)
 	if len(parts) < 2 {
@@ -512,8 +511,7 @@ func ValidateFullImageName(n string) error {
 	return ValidateTagImageName(n)
 }
 
-// ValidateTagImageName validates that the full image name (REGISTRY/name:tag) is allowed for push
-// remember that private registries must be supported here
+// ValidateTagImageName validates that the last part of the image name (name:tag) is allowed for create/update
 func ValidateTagImageName(n string) error {
 	parts := strings.Split(n, "/")
 	lastParts := strings.Split(parts[len(parts)-1], ":")

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -17,7 +17,7 @@ func TestValidateImageName(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			errString := ""
-			if _, err := ValidateImageName(c.name); err != nil {
+			if err := ValidateImageName(c.name); err != nil {
 				errString = err.Error()
 			}
 			if c.expectedErr != errString {

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -249,12 +249,11 @@ func CreateFn(r *clientv2.Fn, appName string, fn *models.Fn) error {
 	}
 
 	fn.AppID = a.ID
-	image, err := common.ValidateImageName(fn.Image)
+	err = common.ValidateImageName(fn.Image)
 	if err != nil {
 		return err
 	}
 
-	fn.Image = image
 	resp, err := r.Fns.CreateFn(&apifns.CreateFnParams{
 		Context: context.Background(),
 		Body:    fn,
@@ -277,7 +276,7 @@ func CreateFn(r *clientv2.Fn, appName string, fn *models.Fn) error {
 
 func PutFn(f *clientv2.Fn, fnID string, fn *models.Fn) error {
 	if fn.Image != "" {
-		_, err := common.ValidateImageName(fn.Image)
+		err := common.ValidateImageName(fn.Image)
 		if err != nil {
 			return err
 		}

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -249,7 +249,7 @@ func CreateFn(r *clientv2.Fn, appName string, fn *models.Fn) error {
 	}
 
 	fn.AppID = a.ID
-	err = common.ValidateImageName(fn.Image)
+	err = common.ValidateTagImageName(fn.Image)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func CreateFn(r *clientv2.Fn, appName string, fn *models.Fn) error {
 
 func PutFn(f *clientv2.Fn, fnID string, fn *models.Fn) error {
 	if fn.Image != "" {
-		err := common.ValidateImageName(fn.Image)
+		err := common.ValidateTagImageName(fn.Image)
 		if err != nil {
 			return err
 		}

--- a/objects/route/routes.go
+++ b/objects/route/routes.go
@@ -299,11 +299,10 @@ func (r *routesCmd) create(c *cli.Context) error {
 
 // PostRoute request
 func PostRoute(r *fnclient.Fn, appName string, rt *fnmodels.Route) error {
-	image, err := common.ValidateImageName(rt.Image)
+	err := common.ValidateImageName(rt.Image)
 	if err != nil {
 		return err
 	}
-	rt.Image = image
 
 	body := &fnmodels.RouteWrapper{
 		Route: rt,
@@ -333,7 +332,7 @@ func PostRoute(r *fnclient.Fn, appName string, rt *fnmodels.Route) error {
 // PatchRoute request
 func PatchRoute(r *fnclient.Fn, appName, routePath string, rt *fnmodels.Route) error {
 	if rt.Image != "" {
-		_, err := common.ValidateImageName(rt.Image)
+		err := common.ValidateImageName(rt.Image)
 		if err != nil {
 			return err
 		}

--- a/objects/route/routes.go
+++ b/objects/route/routes.go
@@ -299,7 +299,7 @@ func (r *routesCmd) create(c *cli.Context) error {
 
 // PostRoute request
 func PostRoute(r *fnclient.Fn, appName string, rt *fnmodels.Route) error {
-	err := common.ValidateImageName(rt.Image)
+	err := common.ValidateTagImageName(rt.Image)
 	if err != nil {
 		return err
 	}
@@ -332,7 +332,7 @@ func PostRoute(r *fnclient.Fn, appName string, rt *fnmodels.Route) error {
 // PatchRoute request
 func PatchRoute(r *fnclient.Fn, appName, routePath string, rt *fnmodels.Route) error {
 	if rt.Image != "" {
-		err := common.ValidateImageName(rt.Image)
+		err := common.ValidateTagImageName(rt.Image)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`registry` does not need to be set when validating the image name. Instead, the user should be warned that registry is missing when it is needed.

Issue [#393](https://github.com/fnproject/cli/issues/393) fn deploy --local now expects registry to be set 