### PR TITLE
Make BuildFunc context-free

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -97,7 +97,7 @@ func (b *buildcmd) build(c *cli.Context) error {
 		}
 
 		buildArgs := c.StringSlice("build-arg")
-		ff, err = common.BuildFunc(c, fpath, ff, buildArgs, b.noCache)
+		ff, err = common.BuildFunc(c.GlobalBool("verbose"), fpath, ff, buildArgs, b.noCache)
 		if err != nil {
 			return err
 		}

--- a/commands/build.go
+++ b/commands/build.go
@@ -82,7 +82,7 @@ func (b *buildcmd) build(c *cli.Context) error {
 		}
 
 		buildArgs := c.StringSlice("build-arg")
-		ff, err = common.BuildFuncV20180708(c, fpath, ff, buildArgs, b.noCache)
+		ff, err = common.BuildFuncV20180708(c.GlobalBool("verbose"), fpath, ff, buildArgs, b.noCache)
 		if err != nil {
 			return err
 		}

--- a/commands/build_server.go
+++ b/commands/build_server.go
@@ -98,7 +98,7 @@ func (b *BuildServerCmd) buildServer(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = common.RunBuild(c, dir, c.String("tag"), "Dockerfile", nil, b.noCache)
+	err = common.RunBuild(c.GlobalBool("verbose"), dir, c.String("tag"), "Dockerfile", nil, b.noCache)
 	if err != nil {
 		return err
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -323,7 +323,7 @@ func (p *deploycmd) deployFunc(c *cli.Context, appName, baseDir, funcfilePath st
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFunc(c, funcfilePath, funcfile, buildArgs, p.noCache)
+	_, err = common.BuildFunc(c.GlobalBool("verbose"), funcfilePath, funcfile, buildArgs, p.noCache)
 	if err != nil {
 		return err
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -358,7 +358,7 @@ func (p *deploycmd) deployFuncV20180708(c *cli.Context, appName, baseDir, funcfi
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFuncV20180708(c, funcfilePath, funcfile, buildArgs, p.noCache)
+	_, err = common.BuildFuncV20180708(c.GlobalBool("verbose"), funcfilePath, funcfile, buildArgs, p.noCache)
 	if err != nil {
 		return err
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -155,7 +155,7 @@ func dockerBuild(c *cli.Context, fpath string, ff *FuncFile, buildArgs []string,
 			}
 		}
 	}
-	err = RunBuild(c, dir, ff.ImageName(), dockerfile, buildArgs, noCache)
+	err = RunBuild(c.GlobalBool("verbose"), dir, ff.ImageName(), dockerfile, buildArgs, noCache)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func dockerBuildV20180708(c *cli.Context, fpath string, ff *FuncFileV20180708, b
 			}
 		}
 	}
-	err = RunBuild(c, dir, ff.ImageNameV20180708(), dockerfile, buildArgs, noCache)
+	err = RunBuild(c.GlobalBool("verbose"), dir, ff.ImageNameV20180708(), dockerfile, buildArgs, noCache)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func dockerBuildV20180708(c *cli.Context, fpath string, ff *FuncFileV20180708, b
 }
 
 // RunBuild runs function from func.yaml/json/yml.
-func RunBuild(c *cli.Context, dir, imageName, dockerfile string, buildArgs []string, noCache bool) error {
+func RunBuild(verbose bool, dir, imageName, dockerfile string, buildArgs []string, noCache bool) error {
 	cancel := make(chan os.Signal, 3)
 	signal.Notify(cancel, os.Interrupt) // and others perhaps
 	defer signal.Stop(cancel)
@@ -226,7 +226,7 @@ func RunBuild(c *cli.Context, dir, imageName, dockerfile string, buildArgs []str
 
 	quit := make(chan struct{})
 	fmt.Fprintf(os.Stderr, "Building image %v ", imageName)
-	if c.GlobalBool("verbose") {
+	if verbose {
 		fmt.Println()
 		buildOut = os.Stdout
 		buildErr = os.Stderr

--- a/common/common.go
+++ b/common/common.go
@@ -56,7 +56,7 @@ func GetDir(c *cli.Context) string {
 }
 
 // BuildFunc bumps version and builds function.
-func BuildFunc(c *cli.Context, fpath string, funcfile *FuncFile, buildArg []string, noCache bool) (*FuncFile, error) {
+func BuildFunc(verbose bool, fpath string, funcfile *FuncFile, buildArg []string, noCache bool) (*FuncFile, error) {
 	var err error
 	if funcfile.Version == "" {
 		funcfile, err = BumpIt(fpath, Patch)
@@ -69,7 +69,7 @@ func BuildFunc(c *cli.Context, fpath string, funcfile *FuncFile, buildArg []stri
 		return nil, err
 	}
 
-	if err := dockerBuild(c.GlobalBool("verbose"), fpath, funcfile, buildArg, noCache); err != nil {
+	if err := dockerBuild(verbose, fpath, funcfile, buildArg, noCache); err != nil {
 		return nil, err
 	}
 

--- a/common/common.go
+++ b/common/common.go
@@ -69,7 +69,7 @@ func BuildFunc(c *cli.Context, fpath string, funcfile *FuncFile, buildArg []stri
 		return nil, err
 	}
 
-	if err := dockerBuild(c, fpath, funcfile, buildArg, noCache); err != nil {
+	if err := dockerBuild(c.GlobalBool("verbose"), fpath, funcfile, buildArg, noCache); err != nil {
 		return nil, err
 	}
 
@@ -77,7 +77,7 @@ func BuildFunc(c *cli.Context, fpath string, funcfile *FuncFile, buildArg []stri
 }
 
 // BuildFunc bumps version and builds function.
-func BuildFuncV20180708(c *cli.Context, fpath string, funcfile *FuncFileV20180708, buildArg []string, noCache bool) (*FuncFileV20180708, error) {
+func BuildFuncV20180708(verbose bool, fpath string, funcfile *FuncFileV20180708, buildArg []string, noCache bool) (*FuncFileV20180708, error) {
 	var err error
 
 	if funcfile.Version == "" {
@@ -91,7 +91,7 @@ func BuildFuncV20180708(c *cli.Context, fpath string, funcfile *FuncFileV2018070
 		return nil, err
 	}
 
-	if err := dockerBuildV20180708(c, fpath, funcfile, buildArg, noCache); err != nil {
+	if err := dockerBuildV20180708(verbose, fpath, funcfile, buildArg, noCache); err != nil {
 		return nil, err
 	}
 
@@ -125,7 +125,7 @@ func PrintContextualInfo() {
 	fmt.Println("Current Context: ", currentContext)
 }
 
-func dockerBuild(c *cli.Context, fpath string, ff *FuncFile, buildArgs []string, noCache bool) error {
+func dockerBuild(verbose bool, fpath string, ff *FuncFile, buildArgs []string, noCache bool) error {
 	err := dockerVersionCheck()
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func dockerBuild(c *cli.Context, fpath string, ff *FuncFile, buildArgs []string,
 			}
 		}
 	}
-	err = RunBuild(c.GlobalBool("verbose"), dir, ff.ImageName(), dockerfile, buildArgs, noCache)
+	err = RunBuild(verbose, dir, ff.ImageName(), dockerfile, buildArgs, noCache)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func dockerBuild(c *cli.Context, fpath string, ff *FuncFile, buildArgs []string,
 	return nil
 }
 
-func dockerBuildV20180708(c *cli.Context, fpath string, ff *FuncFileV20180708, buildArgs []string, noCache bool) error {
+func dockerBuildV20180708(verbose bool, fpath string, ff *FuncFileV20180708, buildArgs []string, noCache bool) error {
 	err := dockerVersionCheck()
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func dockerBuildV20180708(c *cli.Context, fpath string, ff *FuncFileV20180708, b
 			}
 		}
 	}
-	err = RunBuild(c.GlobalBool("verbose"), dir, ff.ImageNameV20180708(), dockerfile, buildArgs, noCache)
+	err = RunBuild(verbose, dir, ff.ImageNameV20180708(), dockerfile, buildArgs, noCache)
 	if err != nil {
 		return err
 	}

--- a/config/version.go
+++ b/config/version.go
@@ -11,7 +11,6 @@ import (
 // Version of Fn CLI
 var Version = "0.4.154"
 
-
 func GetVersion(versionType string) string {
 	base := "https://github.com/fnproject/cli/releases"
 	url := ""

--- a/run/run.go
+++ b/run/run.go
@@ -146,7 +146,7 @@ func PreRun(c *cli.Context) (string, *common.FuncFile, []string, error) {
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFunc(c, fpath, ff, buildArgs, c.Bool("no-cache"))
+	_, err = common.BuildFunc(c.GlobalBool("verbose"), fpath, ff, buildArgs, c.Bool("no-cache"))
 	if err != nil {
 		return fpath, nil, nil, err
 	}

--- a/run/run.go
+++ b/run/run.go
@@ -207,7 +207,7 @@ func PreRunV20180708(c *cli.Context) (string, *common.FuncFileV20180708, []strin
 	}
 
 	buildArgs := c.StringSlice("build-arg")
-	_, err = common.BuildFuncV20180708(c, fpath, ff, buildArgs, c.Bool("no-cache"))
+	_, err = common.BuildFuncV20180708(c.GlobalBool("verbose"), fpath, ff, buildArgs, c.Bool("no-cache"))
 	if err != nil {
 		return fpath, nil, nil, err
 	}


### PR DESCRIPTION
It's not a secret that we've put a lot of efforts to CLI to make it what it is right now.
At this moment, CLI contains a lot of useful logic that may be reused while developing another tool which may require the same set of features.

The problem is we pass down the CLI context even if that is used for 1 flag value (consider here `--verbose`) which makes the whole CLI's internal logic not reusable what forces developers to solve the same problems.

In this change, I was trying to get rid of the CLI context by substituting one with parameter(s) that is required by the particular method (consider here a logic behind `fn deploy`).
