### PR TITLE
Update init command

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -199,8 +199,6 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 	a.ff.Schema_version = common.LatestYamlVersion
 
-	fmt.Println("Runtime: ", a.ff.Runtime)
-
 	if initImage != "" {
 
 		err = runInitImage(initImage, a)
@@ -421,7 +419,6 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 			a.ff.Format = "default"
 		}
 	} else {
-		fmt.Println("Runtime:", runtime)
 		helper = langs.GetLangHelper(runtime)
 	}
 	if helper == nil {
@@ -436,9 +433,9 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 
 		if runtime == "" {
 			a.ff.Runtime = helper.Runtime()
+		} else {
+			helper.Runtime()
 		}
-
-		a.ff.Runtime = runtime
 
 		if c.String("format") == "" {
 			a.ff.Format = helper.DefaultFormat()

--- a/commands/init.go
+++ b/commands/init.go
@@ -432,10 +432,10 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 		}
 
 		if runtime == "" {
-			a.ff.Runtime = helper.Runtime()
-		} else {
-			helper.Runtime()
+			runtime = helper.Runtime()
 		}
+
+		a.ff.Runtime = runtime
 
 		if c.String("format") == "" {
 			a.ff.Format = helper.DefaultFormat()

--- a/commands/init.go
+++ b/commands/init.go
@@ -39,7 +39,7 @@ import (
 
 type initFnCmd struct {
 	force   bool
-	trigger bool
+	trigger string
 	wd      string
 	ff      *common.FuncFileV20180708
 }
@@ -81,7 +81,7 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Usage:       "Specify the working directory to initialise a function, must be the full path.",
 			Destination: &a.wd,
 		},
-		cli.BoolFlag{
+		cli.StringFlag{
 			Name:        "trigger",
 			Usage:       "Specify the trigger type.",
 			Destination: &a.trigger,
@@ -130,11 +130,11 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 	a.ff.Name = c.Args().First()
 
-	if a.trigger {
+	if a.trigger != "" {
 		trig := make([]common.Trigger, 1)
 		trig[0] = common.Trigger{
 			a.ff.Name + "-trigger",
-			"http",
+			a.trigger,
 			"/" + a.ff.Name + "-trigger",
 		}
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -38,10 +38,10 @@ import (
 )
 
 type initFnCmd struct {
-	force   bool
-	trigger string
-	wd      string
-	ff      *common.FuncFileV20180708
+	force       bool
+	triggerType string
+	wd          string
+	ff          *common.FuncFileV20180708
 }
 
 func initFlags(a *initFnCmd) []cli.Flag {
@@ -84,7 +84,7 @@ func initFlags(a *initFnCmd) []cli.Flag {
 		cli.StringFlag{
 			Name:        "trigger",
 			Usage:       "Specify the trigger type.",
-			Destination: &a.trigger,
+			Destination: &a.triggerType,
 		},
 	}
 
@@ -130,11 +130,11 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 	a.ff.Name = c.Args().First()
 
-	if a.trigger != "" {
+	if a.triggerType != "" {
 		trig := make([]common.Trigger, 1)
 		trig[0] = common.Trigger{
 			a.ff.Name + "-trigger",
-			a.trigger,
+			a.triggerType,
 			"/" + a.ff.Name + "-trigger",
 		}
 

--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	MigrateSuccessMessage = "Successfully migrated func.yaml and created a back up func.yaml.bak"
+	MigrateSuccessMessage = "Successfully migrated func.yaml and created a back up func.yaml.bak."
 	MigrateFailureMessage = "you have an up to date func.yaml file and do not need to migrate."
 )
 

--- a/commands/migrate.go
+++ b/commands/migrate.go
@@ -15,6 +15,11 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const (
+	MigrateSuccessMessage = "Successfully migrated func.yaml and created a back up func.yaml.bak"
+	MigrateFailureMessage = "you have an up to date func.yaml file and do not need to migrate."
+)
+
 type migrateFnCmd struct {
 	newFF *common.FuncFileV20180708
 }
@@ -41,7 +46,7 @@ func (m *migrateFnCmd) migrate(c *cli.Context) error {
 
 	version := common.GetFuncYamlVersion(oldFF)
 	if version == common.LatestYamlVersion {
-		return errors.New("you have an up to date func.yaml file and do not need to migrate.")
+		return errors.New(MigrateFailureMessage)
 	}
 
 	err = backUpYamlFile(oldFF)
@@ -64,7 +69,7 @@ func (m *migrateFnCmd) migrate(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println("Successfully migrated func.yaml and created a back up func.yaml.bak")
+	fmt.Println(MigrateSuccessMessage)
 	return nil
 }
 

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -17,7 +17,7 @@ func TestValidateImageName(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			errString := ""
-			if err := ValidateImageName(c.name); err != nil {
+			if err := ValidateFullImageName(c.name); err != nil {
 				errString = err.Error()
 			}
 			if c.expectedErr != errString {

--- a/init_test.go
+++ b/init_test.go
@@ -1,48 +1,46 @@
 package main
 
 import (
-	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/fnproject/cli/commands"
 	"github.com/fnproject/cli/common"
-	"github.com/fnproject/cli/langs"
-	"github.com/urfave/cli"
+	"github.com/fnproject/cli/testharness"
 	yaml "gopkg.in/yaml.v2"
 )
 
 func TestInit(t *testing.T) {
+	h := testharness.Create(t)
+	defer h.Cleanup()
 
 	testname := "test-init"
 	testdir, err := ioutil.TempDir("", testname)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to make tmp test directory: err: %v", err)
 	}
-	defer os.RemoveAll(testdir)
 
+	defer os.RemoveAll(testdir)
 	err = os.Chdir(testdir)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to cd to tmp test directory: err: %v", err)
 	}
 
-	helper := &langs.GoLangHelper{}
-	helper.GenerateBoilerplate(testdir)
-
-	app := newFn()
-	err = app.Command("init").Run(cli.NewContext(app, &flag.FlagSet{}, nil))
-	if err != nil {
-		t.Fatalf("ERROR: Failed run `init` command: err: %v", err)
-	}
+	funcName := h.NewFuncName()
+	h.Fn("init", "--runtime", "go").AssertSuccess()
+	fmt.Println("ffName: ", funcName)
 
 	ffname := "func.yaml"
 	b, err := ioutil.ReadFile(ffname)
 	if err != nil {
 		t.Fatalf("Could not open %s for parsing. Error: %v", ffname, err)
 	}
-	ff := &common.FuncFile{}
+	ff := &common.FuncFileV20180708{}
 	err = yaml.Unmarshal(b, ff)
+
+	fmt.Println("FF.Runtime: ", ff.Runtime)
 	if err != nil {
 		t.Fatalf("Could not parse %s. Error: %v", ffname, err)
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -1,46 +1,48 @@
 package main
 
 import (
-	"fmt"
+	"flag"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/fnproject/cli/commands"
 	"github.com/fnproject/cli/common"
-	"github.com/fnproject/cli/testharness"
+	"github.com/fnproject/cli/langs"
+	"github.com/urfave/cli"
 	yaml "gopkg.in/yaml.v2"
 )
 
 func TestInit(t *testing.T) {
-	h := testharness.Create(t)
-	defer h.Cleanup()
 
 	testname := "test-init"
 	testdir, err := ioutil.TempDir("", testname)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to make tmp test directory: err: %v", err)
 	}
-
 	defer os.RemoveAll(testdir)
+
 	err = os.Chdir(testdir)
 	if err != nil {
 		t.Fatalf("ERROR: Failed to cd to tmp test directory: err: %v", err)
 	}
 
-	funcName := h.NewFuncName()
-	h.Fn("init", "--runtime", "go").AssertSuccess()
-	fmt.Println("ffName: ", funcName)
+	helper := &langs.GoLangHelper{}
+	helper.GenerateBoilerplate(testdir)
+
+	app := newFn()
+	err = app.Command("init").Run(cli.NewContext(app, &flag.FlagSet{}, nil))
+	if err != nil {
+		t.Fatalf("ERROR: Failed run `init` command: err: %v", err)
+	}
 
 	ffname := "func.yaml"
 	b, err := ioutil.ReadFile(ffname)
 	if err != nil {
 		t.Fatalf("Could not open %s for parsing. Error: %v", ffname, err)
 	}
-	ff := &common.FuncFileV20180708{}
+	ff := &common.FuncFile{}
 	err = yaml.Unmarshal(b, ff)
-
-	fmt.Println("FF.Runtime: ", ff.Runtime)
 	if err != nil {
 		t.Fatalf("Could not parse %s. Error: %v", ffname, err)
 	}

--- a/test/cli_migrate_test.go
+++ b/test/cli_migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fnproject/cli/commands"
 	"github.com/fnproject/cli/testharness"
 )
 

--- a/test/cli_migrate_test.go
+++ b/test/cli_migrate_test.go
@@ -9,23 +9,17 @@ import (
 )
 
 func TestMigrateFuncYaml(t *testing.T) {
-	t.Parallel()
-
 	for _, rt := range Runtimes {
-		t.Run(fmt.Sprintf("%s migrating runtime", rt.runtime), func(t *testing.T) {
-			t.Parallel()
+		t.Run(fmt.Sprintf("%s migrating V1 func file with runtime", rt.runtime), func(t *testing.T) {
 			h := testharness.Create(t)
 			defer h.Cleanup()
 
 			funcName := h.NewFuncName()
-			h.Fn("init", "--runtime", "java", funcName).AssertSuccess()
-
+			h.MkDir(funcName)
 			h.Cd(funcName)
-			h.Fn("build").AssertSuccess()
 
-			h.FnWithInput("", "run").AssertSuccess()
-
-			h.Fn("migrate").AssertSuccess().AssertStdoutContains("Successfully migrated func.yaml and created a back up func.yaml.bak")
+			h.CreateFuncfile(funcName, rt.runtime)
+			h.Fn("migrate").AssertSuccess().AssertStdoutContains(commands.MigrateSuccessMessage)
 
 			funcYaml := h.GetFile("func.yaml")
 			if !strings.Contains(funcYaml, "schema_version") {
@@ -39,10 +33,6 @@ func TestMigrateFuncYaml(t *testing.T) {
 			if yamlFile.Triggers[0].Type != "http" {
 				t.Fatalf("Exepected type to be 'http' in %s", yamlFile.Triggers[0].Type)
 			}
-
-			h.Fn("build").AssertSuccess()
-
-			h.FnWithInput("", "run").AssertSuccess()
 		})
 	}
 }

--- a/testharness/harness.go
+++ b/testharness/harness.go
@@ -528,3 +528,14 @@ func (cr *CmdResult) AssertStdoutMissingJSONPath(query []string) {
 		log.Fatalf("Found path %v in json body %v when it was supposed to be missing", query, cr.Stdout)
 	}
 }
+
+func (h *CLIHarness) CreateFuncfile(funcName, runtime string) *CLIHarness {
+	funcYaml := `version: 0.0.1
+name: ` + funcName + `
+runtime: ` + runtime + `
+entrypoint: ./func
+format: json
+`
+	h.WithFile("func.yaml", funcYaml, 0644)
+	return h
+}


### PR DESCRIPTION
Remove the creation of v1 func files with the init command:

`fn init --runtime go my-func` will create a v2 funcfile without trigger:
```
schema_version: 20180708
name: hello2
version: 0.0.1
entrypoint: ./func
format: json
``` 
`fn init --runtime go  --trigger my-func` will create a v2 funcfile with `http` trigger:
```
schema_version: 20180708
name: hello3
version: 0.0.1
entrypoint: ./func
format: json
triggers:
- name: hello3-trigger
  type: http
  source: /hello3-trigger
```