### PR TITLE
Use named parameters for ruby BP

### DIFF
--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -91,7 +91,7 @@ func (h *RubyLangHelper) GenerateBoilerplate(path string) error {
 const (
 	rubySrcBoilerplate = `require 'fdk'
 
-def myhandler(context, input)
+def myhandler(context:, input:)
 	STDERR.puts "call_id: " + context.call_id
 	name = "World"
 	if input != nil


### PR DESCRIPTION
Sorry should have spotted this when we made the last change to ruby FDK - will go away with proper init images. 