### PR TITLE
Add <function-name> args to logs and calls help text.

### DIFF
--- a/objects/call/commands.go
+++ b/objects/call/commands.go
@@ -32,8 +32,8 @@ func List() cli.Command {
 	c := callsCmd{}
 	return cli.Command{
 		Name:        "calls",
-		Usage:       "List all calls for the specific app (route is optional)",
-		Description: "This command provides a list of defined calls for a specific application.",
+		Usage:       "List all calls for a specific function",
+		Description: "This command provides a list of defined calls for a specific function.",
 		Aliases:     []string{"call", "cl"},
 		Category:    "MANAGEMENT COMMAND",
 		Before: func(cxt *cli.Context) error {
@@ -44,7 +44,7 @@ func List() cli.Command {
 			c.client = provider.APIClientv2()
 			return nil
 		},
-		ArgsUsage: "<app-name>",
+		ArgsUsage: "<app-name> <function-name>",
 		Action:    c.list,
 		Flags: []cli.Flag{
 			cli.StringFlag{

--- a/objects/log/commands.go
+++ b/objects/log/commands.go
@@ -22,7 +22,7 @@ func Get() cli.Command {
 			l.client = provider.APIClientv2()
 			return nil
 		},
-		ArgsUsage: "<app-name> <call-id>",
+		ArgsUsage: "<app-name> <function-name> <call-id>",
 		Action:    l.get,
 	}
 }


### PR DESCRIPTION
Fix for 1 and 3 [#430 Cannot get logs for a function invocation](https://github.com/fnproject/cli/issues/430).