### PR TITLE
Add --delete flag to update context command

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -208,7 +208,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		a.triggerType = strings.ToLower(a.triggerType)
 		ok := validateTriggerType(a.triggerType)
 		if !ok {
-			return fmt.Errorf("Init does not support the trigger type '%s'.\n", a.triggerType, " Permitted values are 'http'.")
+			return fmt.Errorf("Init does not support the trigger type '%s'.\n Permitted values are 'http'.", a.triggerType)
 		}
 
 		trig := make([]common.Trigger, 1)

--- a/objects/context/commands.go
+++ b/objects/context/commands.go
@@ -10,7 +10,7 @@ func Create() cli.Command {
 		ArgsUsage:   "<context>",
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command creates a new context for a created application.",
-		Action:      create,
+		Action:      createCtx,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "provider",
@@ -35,7 +35,7 @@ func List() cli.Command {
 		Aliases:     []string{"context", "ctx"},
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command returns a list of contexts.",
-		Action:      list,
+		Action:      listCtx,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "output",
@@ -54,7 +54,7 @@ func Delete() cli.Command {
 		ArgsUsage:   "<context>",
 		Description: "This command deletes a context.",
 		Category:    "MANAGEMENT COMMAND",
-		Action:      delete,
+		Action:      deleteCtx,
 	}
 }
 
@@ -64,7 +64,7 @@ func Inspect() cli.Command {
 		Usage:    "Inspect the contents of a context, if no context is specified the current-context will be used.",
 		Aliases:  []string{"ctx"},
 		Category: "MANAGEMENT COMMAND",
-		Action:   inspect,
+		Action:   inspectCtx,
 	}
 }
 
@@ -74,10 +74,16 @@ func Update() cli.Command {
 		Name:        "context",
 		Usage:       "Update context files",
 		Aliases:     []string{"ctx"},
-		ArgsUsage:   "<key> <value>",
+		ArgsUsage:   "<key> [value]",
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command updates the current context file.",
-		Action:      ctxMap.update,
+		Action:      ctxMap.updateCtx,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "delete",
+				Usage: "Delete key=value pair from context file.",
+			},
+		},
 	}
 }
 
@@ -89,7 +95,7 @@ func Use() cli.Command {
 		ArgsUsage:   "<context>",
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command uses context for future invocations.",
-		Action:      use,
+		Action:      useCtx,
 	}
 }
 
@@ -100,6 +106,6 @@ func Unset() cli.Command {
 		Aliases:     []string{"ctx"},
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command unsets the current context in use.",
-		Action:      unset,
+		Action:      unsetCtx,
 	}
 }

--- a/test/cli_config_test.go
+++ b/test/cli_config_test.go
@@ -12,12 +12,16 @@ func TestContextCrud(t *testing.T) {
 	defer h.Cleanup()
 
 	h.Fn("list", "context").AssertSuccess().AssertStdoutContains("default")
-	h.Fn("create", "context", "--api-url", "alskjalskdjasd/v2", "mycontext").AssertFailed()
+	h.Fn("create", "context", "--api-url", "alskjalskdjasd/v2", "mycontext").AssertFailed().AssertStderrContains("Invalid Fn API URL: does not contain ://")
 	h.Fn("create", "context", "--api-url", "http://alskjalskdjasd", "mycontext").AssertSuccess()
 	h.Fn("use", "context", "mycontext").AssertSuccess()
 	h.Fn("update", "context", "api-url", "alskjalskdjaff/v2").AssertFailed()
+	h.Fn("update", "context", "api-url").AssertFailed().AssertStderrContains("Please specify a value")
 	h.Fn("update", "context", "api-url", "http://alskjalskdjaf").AssertSuccess()
-	h.Fn("delete", "context", "mycontext").AssertFailed()
+	h.Fn("update", "context", "--delete").AssertFailed().AssertStderrContains("Update context files using fn update context requires the missing argument '<key>'")
+	h.Fn("update", "context", "api-u", "--delete").AssertFailed().AssertStderrContains("Context file does not contain key: api-u")
+	h.Fn("update", "context", "api-url", "--delete").AssertSuccess().AssertStdoutContains("Current context deleted api-url")
+	h.Fn("delete", "context", "mycontext").AssertFailed().AssertStderrContains("Cannot delete the current context: mycontext")
 	h.Fn("unset", "context", "mycontext").AssertSuccess()
 	h.Fn("delete", "context", "mycontext").AssertSuccess()
 }


### PR DESCRIPTION
When updating the current context, the '--delete' flag will indicate users want to remove the key/value pair from the current context file.

Fix: [#407 `fn update context` should support deleting context entries](https://github.com/fnproject/cli/issues/407)