### PR TITLE
Allow fn config to be updated

### DIFF
--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -165,9 +165,9 @@ func WithFlags(c *cli.Context, fn *models.Fn) {
 	if m := c.Uint64("memory"); m > 0 {
 		fn.Memory = m
 	}
-	if len(fn.Config) == 0 {
-		fn.Config = common.ExtractEnvConfig(c.StringSlice("config"))
-	}
+	
+	fn.Config = common.ExtractEnvConfig(c.StringSlice("config"))
+	
 	if len(c.StringSlice("annotation")) > 0 {
 		fn.Annotations = common.ExtractAnnotations(c)
 	}


### PR DESCRIPTION
Currently, the code only allows setting the configuration on a fn, if the configuration is already empty. This ends up preventing the config of an already existing fn being updated, as the fn is pulled down from the server with config present.

Here we remove the check so that the fn's configuration is set to any that has been provided as args. The server side will merge these new values when they are sent up, removing any keys that are set to an empty value.