### PR TITLE
Add default format 'http-stream' when creating a function.

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -102,10 +102,6 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Name:  "headers",
 			Usage: "Function response headers",
 		},
-		cli.StringFlag{
-			Name:  "format,f",
-			Usage: "Hot container IO format - default or http",
-		},
 		cli.IntFlag{
 			Name:  "timeout",
 			Usage: "Function timeout (eg. 30)",
@@ -283,10 +279,6 @@ func (a *initFnCmd) init(c *cli.Context) error {
 			a.ff.Entrypoint = c.String("entrypoint")
 		}
 
-		if c.String("format") != "" {
-			a.ff.Format = c.String("format")
-		}
-
 		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ff); err != nil {
 			return err
 		}
@@ -395,9 +387,6 @@ func (a *initFnCmd) generateBoilerplate(path, runtime string) error {
 
 func (a *initFnCmd) bindFn(fn *modelsV2.Fn) {
 	ff := a.ff
-	if fn.Format != "" {
-		ff.Format = fn.Format
-	}
 	if fn.Memory > 0 {
 		ff.Memory = fn.Memory
 	}
@@ -451,10 +440,6 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 			return err
 		}
 		fmt.Printf("Found %v function, assuming %v runtime.\n", helper.Runtime(), helper.Runtime())
-		//need to default this to default format to be backwards compatible. Might want to just not allow this anymore, fail here.
-		if c.String("format") == "" {
-			a.ff.Format = "default"
-		}
 	} else {
 		helper = langs.GetLangHelper(runtime)
 	}
@@ -474,9 +459,7 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 
 		a.ff.Runtime = runtime
 
-		if c.String("format") == "" {
-			a.ff.Format = helper.DefaultFormat()
-		}
+		a.ff.Format = helper.DefaultFormat()
 
 		if c.String("cmd") == "" {
 			cmd, err := helper.Cmd()

--- a/commands/init.go
+++ b/commands/init.go
@@ -440,6 +440,7 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 			return err
 		}
 		fmt.Printf("Found %v function, assuming %v runtime.\n", helper.Runtime(), helper.Runtime())
+		a.ff.Format = "default"
 	} else {
 		helper = langs.GetLangHelper(runtime)
 	}

--- a/config/version.go
+++ b/config/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version of Fn CLI
-var Version = "0.5.17"
+var Version = "0.5.18"
 
 func GetVersion(versionType string) string {
 	base := "https://github.com/fnproject/cli/releases"

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -35,10 +35,6 @@ var FnFlags = []cli.Flag{
 		Name:  "config,c",
 		Usage: "Function configuration",
 	},
-	cli.StringFlag{
-		Name:  "format,f",
-		Usage: "Hot container IO format - can be one of: default, http, json or cloudevent (check FDK docs to see which are supported for the FDK in use.)",
-	},
 	cli.IntFlag{
 		Name:  "timeout",
 		Usage: "Function timeout (eg. 30)",
@@ -151,9 +147,6 @@ func WithFlags(c *cli.Context, fn *models.Fn) {
 	if i := c.String("image"); i != "" {
 		fn.Image = i
 	}
-	if f := c.String("format"); f != "" {
-		fn.Format = f
-	}
 
 	if m := c.Uint64("memory"); m > 0 {
 		fn.Memory = m
@@ -187,10 +180,6 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 		fn.Image = ff.ImageNameV20180708()
 	}
 
-	if ff.Format != "" {
-		fn.Format = ff.Format
-	}
-
 	if ff.Timeout != nil {
 		fn.Timeout = ff.Timeout
 	}
@@ -219,6 +208,7 @@ func (f *fnsCmd) create(c *cli.Context) error {
 	fn := &models.Fn{}
 	fn.Name = fnName
 	fn.Image = c.Args().Get(2)
+	fn.Format = "http-stream"
 
 	WithFlags(c, fn)
 
@@ -227,9 +217,6 @@ func (f *fnsCmd) create(c *cli.Context) error {
 	}
 	if fn.Image == "" {
 		return errors.New("no image specified")
-	}
-	if fn.Format == "" {
-		fn.Format = "http-stream"
 	}
 
 	return CreateFn(f.client, appName, fn)

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -79,7 +79,7 @@ func printFunctions(c *cli.Context, fns []*models.Fn) error {
 			newFns = append(newFns, struct {
 				Name  string `json:"name"`
 				Image string `json:"image"`
-				ID string `json:"id"`
+				ID    string `json:"id"`
 			}{
 				fn.Name,
 				fn.Image,
@@ -227,6 +227,9 @@ func (f *fnsCmd) create(c *cli.Context) error {
 	}
 	if fn.Image == "" {
 		return errors.New("no image specified")
+	}
+	if fn.Format == "" {
+		fn.Format = "http-stream"
 	}
 
 	return CreateFn(f.client, appName, fn)


### PR DESCRIPTION
Fix: [#455 Creating a function does not default to "http-stream" format](https://github.com/fnproject/cli/issues/455)