### PR TITLE
Incorrect usage text "fn update fn --help"

### DIFF
--- a/objects/fn/commands.go
+++ b/objects/fn/commands.go
@@ -137,7 +137,7 @@ func Update() cli.Command {
 			f.client = f.provider.APIClientv2()
 			return nil
 		},
-		ArgsUsage: "<app-name>",
+		ArgsUsage: "<app-name> <function-name>",
 		Action:    f.update,
 		Flags:     updateFnFlags,
 	}


### PR DESCRIPTION
Usage text for `fn update fn --help` is missing the function name argument

Fixes https://github.com/fnproject/cli/issues/465