### PR TITLE
Adds --endpoint to  inspect (the current JSON endpoints can't be extracted as paths because they contain dots) Adds --endpoint (taking a direct URL) to invoke

### DIFF
--- a/objects/fn/commands.go
+++ b/objects/fn/commands.go
@@ -113,6 +113,12 @@ func Inspect() cli.Command {
 			f.client = f.provider.APIClientv2()
 			return nil
 		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "endpoint",
+				Usage: "Output the function invoke endpoint if set",
+			},
+		},
 		ArgsUsage: "<app-name> <function-name> [property.[key]]",
 		Action:    f.inspect,
 	}

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -448,6 +448,7 @@ func (f *fnsCmd) inspect(c *cli.Context) error {
 	fnName := WithoutSlash(c.Args().Get(1))
 	prop := c.Args().Get(2)
 
+
 	app, err := app.GetAppByName(f.client, appName)
 	if err != nil {
 		return err
@@ -455,6 +456,15 @@ func (f *fnsCmd) inspect(c *cli.Context) error {
 	fn, err := GetFnByName(f.client, app.ID, fnName)
 	if err != nil {
 		return err
+	}
+
+	if c.Bool("endpoint") {
+		 endpoint,ok:= fn.Annotations["fnproject.io/fn/invokeEndpoint"].(string)
+		 if !ok {
+		 	return errors.New("missing or invalid endpoint on function")
+		 }
+		 fmt.Println(endpoint)
+		 return nil
 	}
 
 	enc := json.NewEncoder(os.Stdout)
@@ -478,7 +488,7 @@ func (f *fnsCmd) inspect(c *cli.Context) error {
 	jq := jsonq.NewQuery(inspect)
 	field, err := jq.Interface(strings.Split(prop, ".")...)
 	if err != nil {
-		return errors.New("failed to inspect that fnName's field")
+		return errors.New("failed to inspect that function's field")
 	}
 	enc.Encode(field)
 

--- a/objects/trigger/commands.go
+++ b/objects/trigger/commands.go
@@ -129,6 +129,12 @@ func Inspect() cli.Command {
 		Aliases:     []string{"t", "tr"},
 		Description: "This command gets one of all trigger properties.",
 		Usage:       "Retrieve one or all trigger properties",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "endpoint",
+				Usage: "Output the trigger HTTP endpoint if set",
+			},
+		},
 		Before: func(ctx *cli.Context) error {
 			var err error
 			t.provider, err = client.CurrentProvider()

--- a/objects/trigger/triggers.go
+++ b/objects/trigger/triggers.go
@@ -255,6 +255,15 @@ func (t *triggersCmd) inspect(c *cli.Context) error {
 		return err
 	}
 
+	if c.Bool("endpoint") {
+		endpoint,ok := trigger.Annotations["fnproject.io/trigger/httpEndpoint"].(string)
+		if !ok  {
+			return errors.New("missing or invalid http endpoint on trigger")
+		}
+		fmt.Println(endpoint)
+		return nil
+	}
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "\t")
 

--- a/test/cli_invoke_test.go
+++ b/test/cli_invoke_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"github.com/fnproject/cli/testharness"
 	"testing"
+	"strings"
 )
 
 func TestFnInvokeInvalidImage(t *testing.T) {
@@ -27,4 +28,21 @@ func TestFnInvokeValidImage(t *testing.T) {
 	h.Fn("create", "app", appName1).AssertSuccess()
 	h.Fn("create", "function", appName1, funcName1, "fnproject/hello:latest").AssertSuccess()
 	h.Fn("invoke", appName1, funcName1).AssertSuccess()
+}
+
+func TestFnInvokeViaDirectUrl(t *testing.T) {
+	t.Parallel()
+
+	h := testharness.Create(t)
+	defer h.Cleanup()
+	appName1 := h.NewAppName()
+	funcName1 := h.NewFuncName(appName1)
+	h.Fn("create", "app", appName1).AssertSuccess()
+	h.Fn("create", "function", appName1, funcName1, "fnproject/hello:latest").AssertSuccess()
+
+	res := h.Fn("inspect", "function", appName1, funcName1, "--endpoint").AssertSuccess()
+
+	url := strings.TrimSpace(res.Stdout)
+
+	h.Fn("invoke", "--endpoint", url).AssertSuccess()
 }


### PR DESCRIPTION
There are two changes here: 

* I wanted to be able to run an invoke directly against a URL (without the API operations) largely for perf/timing analysis - I've added `fn invoke --endpoint http://function-endpoint/` to do this - this will also work against triggers 
* To make this possible i needed a way of computationally getting the endpoint in a script - the current `fn inspect object <property-path>` does not work on the invoke annotations as they contain dots, so I've added a special case to `fn inspect trigger` and `fn inspect function` (`--endpoint`) that just prints the respective annotations. 