### PR TITLE
remove environment expansion from config

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -390,12 +390,7 @@ func (p *deploycmd) updateFunction(c *cli.Context, appName string, ff *common.Fu
 
 	return nil
 }
-func expandEnvConfig(configs map[string]string) map[string]string {
-	for k, v := range configs {
-		configs[k] = os.ExpandEnv(v)
-	}
-	return configs
-}
+
 
 func (p *deploycmd) updateAppConfig(appf *common.AppFile) error {
 	app, err := apps.GetAppByName(p.clientV2, appf.Name)

--- a/common/common.go
+++ b/common/common.go
@@ -457,13 +457,13 @@ func stringToSlice(in string) string {
 	return buffer.String()
 }
 
-// ExtractEnvConfig extract env vars from configuration.
-func ExtractEnvConfig(configs []string) map[string]string {
+// ExtractConfig parses key-value configuration into a map
+func ExtractConfig(configs []string) map[string]string {
 	c := make(map[string]string)
 	for _, v := range configs {
 		kv := strings.SplitN(v, "=", 2)
 		if len(kv) == 2 {
-			c[kv[0]] = os.ExpandEnv(kv[1])
+			c[kv[0]] =kv[1]
 		}
 	}
 	return c

--- a/common/common.go
+++ b/common/common.go
@@ -463,7 +463,7 @@ func ExtractConfig(configs []string) map[string]string {
 	for _, v := range configs {
 		kv := strings.SplitN(v, "=", 2)
 		if len(kv) == 2 {
-			c[kv[0]] =kv[1]
+			c[kv[0]] = kv[1]
 		}
 	}
 	return c

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -96,7 +96,7 @@ func appWithFlags(c *cli.Context, app *modelsv2.App) {
 		app.SyslogURL = c.String("syslog-url")
 	}
 	if len(c.StringSlice("config")) > 0 {
-		app.Config = common.ExtractEnvConfig(c.StringSlice("config"))
+		app.Config = common.ExtractConfig(c.StringSlice("config"))
 	}
 	if len(c.StringSlice("annotation")) > 0 {
 		app.Annotations = common.ExtractAnnotations(c)

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -159,7 +159,7 @@ func WithFlags(c *cli.Context, fn *models.Fn) {
 		fn.Memory = m
 	}
 
-	fn.Config = common.ExtractEnvConfig(c.StringSlice("config"))
+	fn.Config = common.ExtractConfig(c.StringSlice("config"))
 
 	if len(c.StringSlice("annotation")) > 0 {
 		fn.Annotations = common.ExtractAnnotations(c)


### PR DESCRIPTION
The current EnvExpand stuff removes/mutates  config values that naturally contain dollars - this is completely unexpected and has caused a few issues with config values being re-written. 

I propose to just remove that and make the config the config - if you want to env expansion that's what shells are for. 