### PR TITLE
Bugfix/appnotfound

### DIFF
--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -340,18 +340,16 @@ func (n NameNotFoundError) Error() string {
 func GetAppByName(client *fnclient.Fn, appName string) (*modelsv2.App, error) {
 	appsResp, err := client.Apps.ListApps(&apiapps.ListAppsParams{
 		Context: context.Background(),
+		Name:    &appName,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	var app *modelsv2.App
-	for i := 0; i < len(appsResp.Payload.Items); i++ {
-		if appsResp.Payload.Items[i].Name == appName {
-			app = appsResp.Payload.Items[i]
-		}
-	}
-	if app == nil {
+	if len(appsResp.Payload.Items) > 0 {
+		app = appsResp.Payload.Items[0]
+	} else {
 		return nil, NameNotFoundError{appName}
 	}
 

--- a/test/cli_crud_test.go
+++ b/test/cli_crud_test.go
@@ -23,6 +23,10 @@ func TestFnAppUpdateCycle(t *testing.T) {
 	h.Fn("create", "app", appName).AssertSuccess()
 	h.Fn("create", "app", appName).AssertFailed()
 	h.Fn("list", "apps", appName).AssertSuccess().AssertStdoutContains(appName)
+	// Test looking up app by name when multiple pages worth of apps exist
+	for i := 0; i < 50; i++ {
+		h.Fn("create", "app", fmt.Sprintf("%s%d", appName, i)).AssertSuccess()
+	}
 	h.Fn("inspect", "app", appName).AssertSuccess().AssertStdoutContains(fmt.Sprintf(`"name": "%s"`, appName))
 	h.Fn("config", "app", appName, "fooConfig", "barval").AssertSuccess()
 	h.Fn("get", "config", "app", appName, "fooConfig").AssertSuccess().AssertStdoutContains("barval")


### PR DESCRIPTION
Fix #478 - app lookup via GetAppByName now uses 'name' filter in API app list, avoiding issue of pagination entirely. Added test to check for previous failure scenario where an app could not be found if multiple pages of apps exist.