### PR TITLE
add defaultexts to fn build-server

### DIFF
--- a/commands/build_server.go
+++ b/commands/build_server.go
@@ -142,7 +142,8 @@ import (
 	"context"
 
 	"github.com/fnproject/fn/api/server"
-	
+	_ “github.com/fnproject/fn/api/server/defaultexts”
+
 	{{- range .Extensions }}
 		_ "{{ .Name }}"
 	{{- end}}


### PR DESCRIPTION
while users may want to build without these eventually, build server generates
the initial version mostly, and should include defaultexts so that users may
use the runtime configurable defaults for db / logs / drivers. it's easy
enough for users to remove these and replace piece meal if they'd like to, but
starting with them seems ideal as it's a point of confusion for users getting
started with extensions (we probably need better docs, too)