### PR TITLE
Add surefire config workaround for classloader bug in JDK8_181

### DIFF
--- a/langs/java.go
+++ b/langs/java.go
@@ -308,6 +308,14 @@ const (
                     <target>%s</target>
                 </configuration>
             </plugin>
+            <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-surefire-plugin</artifactId>
+                 <version>2.22.1</version>
+                 <configuration>
+                     <useSystemClassLoader>false</useSystemClassLoader>
+                 </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This is the workaround for the Surefire plugin that fails on new build images based on the latest Debian OpenJDK 8-u181-derived Maven images.  I see this as a temporary fix until the Debian OpenJDK image moves to a later JDK8 build, but in the meantime think this is probably needed otherwise we can't build the FDK Java pipeline.

I *could* break this out so it's only included in the pom.xml when `java8` is specified but would like to see if it works with `java9` before doing that.