### PR TITLE
remove headers field from func.yaml

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -98,10 +98,6 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Name:  "config,c",
 			Usage: "Function configuration",
 		},
-		cli.StringSliceFlag{
-			Name:  "headers",
-			Usage: "Function response headers",
-		},
 		cli.StringFlag{
 			Name:  "format,f",
 			Usage: "Hot container IO format - default or http",

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -75,7 +75,6 @@ type FuncFile struct {
 	Timeout     *int32                 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Path        string                 `yaml:"path,omitempty" json:"path,omitempty"`
 	Config      map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
-	Headers     map[string][]string    `yaml:"headers,omitempty" json:"headers,omitempty"`
 	IDLETimeout *int32                 `yaml:"idle_timeout,omitempty" json:"idle_timeout,omitempty"`
 	Annotations map[string]interface{} `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 


### PR DESCRIPTION
these were taken out when the routes API went the way of the dodo