### PR TITLE
initial support for java 11

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -90,17 +90,9 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Name:  "memory,m",
 			Usage: "Memory in MiB",
 		},
-		cli.StringFlag{
-			Name:  "type,t",
-			Usage: "Function type - sync or async",
-		},
 		cli.StringSliceFlag{
 			Name:  "config,c",
 			Usage: "Function configuration",
-		},
-		cli.StringFlag{
-			Name:  "format,f",
-			Usage: "Hot container IO format - default or http",
 		},
 		cli.IntFlag{
 			Name:  "timeout",

--- a/langs/base.go
+++ b/langs/base.go
@@ -13,6 +13,7 @@ func init() {
 	registerHelper(&GoLangHelper{})
 	registerHelper(&JavaLangHelper{version: "1.8"})
 	registerHelper(&JavaLangHelper{version: "9"})
+	registerHelper(&JavaLangHelper{version: "11"})
 	registerHelper(&NodeLangHelper{})
 	registerHelper(&PythonLangHelper{Version: "3.6"})
 	registerHelper(&PythonLangHelper{Version: "3.7"})

--- a/langs/java.go
+++ b/langs/java.go
@@ -37,8 +37,10 @@ func (h *JavaLangHelper) Runtime() string {
 func (lh *JavaLangHelper) LangStrings() []string {
 	if lh.version == "1.8" {
 		return []string{"java8"}
+	} else if lh.version == "9" {
+		return []string{"java9", "java"}
 	}
-	return []string{"java9", "java"}
+	return []string{"java11"}
 
 }
 func (lh *JavaLangHelper) Extensions() []string {
@@ -57,6 +59,8 @@ func (lh *JavaLangHelper) BuildFromImage() (string, error) {
 		return fmt.Sprintf("fnproject/fn-java-fdk-build:%s", fdkVersion), nil
 	} else if lh.version == "9" {
 		return fmt.Sprintf("fnproject/fn-java-fdk-build:jdk9-%s", fdkVersion), nil
+	} else if lh.version == "11" {
+		return fmt.Sprintf("fnproject/fn-java-fdk-build:jdk11-%s", fdkVersion), nil
 	} else {
 		return "", fmt.Errorf("unsupported java version %s", lh.version)
 	}
@@ -72,6 +76,8 @@ func (lh *JavaLangHelper) RunFromImage() (string, error) {
 		return fmt.Sprintf("fnproject/fn-java-fdk:%s", fdkVersion), nil
 	} else if lh.version == "9" {
 		return fmt.Sprintf("fnproject/fn-java-fdk:jdk9-%s", fdkVersion), nil
+	} else if lh.version == "11" {
+		return fmt.Sprintf("fnproject/fn-java-fdk:jdk11-%s", fdkVersion), nil
 	} else {
 		return "", fmt.Errorf("unsupported java version %s", lh.version)
 	}

--- a/langs/java.go
+++ b/langs/java.go
@@ -77,7 +77,7 @@ func (lh *JavaLangHelper) RunFromImage() (string, error) {
 	} else if lh.version == "9" {
 		return fmt.Sprintf("fnproject/fn-java-fdk:jdk9-%s", fdkVersion), nil
 	} else if lh.version == "11" {
-		return fmt.Sprintf("fnproject/fn-java-fdk:jdk11-%s", fdkVersion), nil
+		return fmt.Sprintf("fnproject/fn-java-fdk:jre11-%s", fdkVersion), nil
 	} else {
 		return "", fmt.Errorf("unsupported java version %s", lh.version)
 	}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func newFn() *cli.App {
 		cli.StringFlag{
 			Name:  "context",
 			Usage: "Use --context to select context configuration file",
+			EnvVar: "FN_CONTEXT",
 		},
 		cli.StringFlag{
 			Name:  "registry",

--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -15,6 +15,7 @@ var Runtimes = []struct {
 	{"java", ""},
 	{"java8", ""},
 	{"java9", ""},
+	{"java11", ""},
 	{"kotlin", `{"name": "John"}`}, //  no arg fn run is broken https://github.com/fnproject/cli/issues/262
 	{"node", ""},
 	{"ruby", ""},


### PR DESCRIPTION
This adds initial support for building and running java 11 functions 

the default "java" remains java9 for now 