### PR TITLE
Allow syslog-url to be unset (CLI part)

### DIFF
--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -92,7 +92,7 @@ func (a *appsCmd) list(c *cli.Context) error {
 }
 
 func appWithFlags(c *cli.Context, app *modelsv2.App) {
-	if len(c.String("syslog-url")) > 0 {
+	if c.IsSet("syslog-url") {
 		app.SyslogURL = c.String("syslog-url")
 	}
 	if len(c.StringSlice("config")) > 0 {


### PR DESCRIPTION
The existing check was checking for the syslog-url option being an empty string rather than the option being set. 
This prevented the possibility of setting the syslog URL to an actual empty string (i.e. unsetting it).
