### PR TITLE
Include Auto Completions

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
@@ -19,12 +20,13 @@ func ConfigCommand(command string) cli.Command {
 	}
 
 	return cli.Command{
-		Name:        "config",
-		ShortName:   "config",
-		Usage:       "Manage configurations for apps and functions",
-		Aliases:     []string{"cf"},
-		ArgsUsage:   "<subcommand>",
-		Description: "This command unsets the configuration of created objects ('app' or 'function').",
-		Subcommands: cmds,
+		Name:         "config",
+		ShortName:    "config",
+		Usage:        "Manage configurations for apps and functions",
+		Aliases:      []string{"cf"},
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command unsets the configuration of created objects ('app' or 'function').",
+		Subcommands:  cmds,
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/configure.go
+++ b/commands/configure.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -14,5 +16,10 @@ func ConfigureCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command sets a configuaration key for an 'app' or 'function'.",
 		Subcommands: GetCommands(ConfigCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(ConfigCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/configure.go
+++ b/commands/configure.go
@@ -1,25 +1,20 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // ConfigureCommand returns configure cli.command
 func ConfigureCommand() cli.Command {
 	return cli.Command{
-		Name:        "config",
-		Aliases:     []string{"cf"},
-		Usage:       "\tSet configuration for an object",
-		Category:    "MANAGEMENT COMMANDS",
-		ArgsUsage:   "<subcommand>",
-		Description: "This command sets a configuaration key for an 'app' or 'function'.",
-		Subcommands: GetCommands(ConfigCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(ConfigCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "config",
+		Aliases:      []string{"cf"},
+		Usage:        "\tSet configuration for an object",
+		Category:     "MANAGEMENT COMMANDS",
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command sets a configuaration key for an 'app' or 'function'.",
+		Subcommands:  GetCommands(ConfigCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/create.go
+++ b/commands/create.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func CreateCommand() cli.Command {
 		ArgsUsage:   "<object-type>",
 		Category:    "MANAGEMENT COMMANDS",
 		Subcommands: GetCommands(CreateCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(CreateCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/create.go
+++ b/commands/create.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // CreateCommand returns create cli.command
 func CreateCommand() cli.Command {
 	return cli.Command{
-		Name:        "create",
-		Aliases:     []string{"c"},
-		Usage:       "\tCreate a new object",
-		Description: "This command creates a new object ('app', 'context', 'function', or 'trigger').",
-		Hidden:      false,
-		ArgsUsage:   "<object-type>",
-		Category:    "MANAGEMENT COMMANDS",
-		Subcommands: GetCommands(CreateCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(CreateCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "create",
+		Aliases:      []string{"c"},
+		Usage:        "\tCreate a new object",
+		Description:  "This command creates a new object ('app', 'context', 'function', or 'trigger').",
+		Hidden:       false,
+		ArgsUsage:    "<object-type>",
+		Category:     "MANAGEMENT COMMANDS",
+		Subcommands:  GetCommands(CreateCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func DeleteCommand() cli.Command {
 		Hidden:      false,
 		ArgsUsage:   "<subcommand>",
 		Subcommands: GetCommands(DeleteCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(DeleteCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // DeleteCommand returns delete cli.command
 func DeleteCommand() cli.Command {
 	return cli.Command{
-		Name:        "delete",
-		Aliases:     []string{"d"},
-		Usage:       "\tDelete an object",
-		Category:    "MANAGEMENT COMMANDS",
-		Description: "This command deletes a created object ('app', 'context', 'function' or 'trigger').",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Subcommands: GetCommands(DeleteCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(DeleteCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "delete",
+		Aliases:      []string{"d"},
+		Usage:        "\tDelete an object",
+		Category:     "MANAGEMENT COMMANDS",
+		Description:  "This command deletes a created object ('app', 'context', 'function' or 'trigger').",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Subcommands:  GetCommands(DeleteCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/get.go
+++ b/commands/get.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func GetCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command gets a 'call', 'configuration' or 'log' to retrieve information for an object ('app' or 'function').",
 		Subcommands: GetCommands(GetCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(GetCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/get.go
+++ b/commands/get.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // GetCommand returns get cli.command
 func GetCommand() cli.Command {
 	return cli.Command{
-		Name:        "get",
-		Aliases:     []string{"g"},
-		Usage:       "\tGet an object to retrieve its information",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command gets a 'call', 'configuration' or 'log' to retrieve information for an object ('app' or 'function').",
-		Subcommands: GetCommands(GetCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(GetCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "get",
+		Aliases:      []string{"g"},
+		Usage:        "\tGet an object to retrieve its information",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command gets a 'call', 'configuration' or 'log' to retrieve information for an object ('app' or 'function').",
+		Subcommands:  GetCommands(GetCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -1,27 +1,22 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // InspectCommand returns inspect cli.command
 func InspectCommand() cli.Command {
 	return cli.Command{
-		Name:        "inspect",
-		UsageText:   "inspect",
-		Aliases:     []string{"i"},
-		Usage:       "\tRetrieve properties of an object",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command allows to inspect the properties of an object ('app', 'context', function' or 'trigger').",
-		Subcommands: GetCommands(InspectCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(InspectCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "inspect",
+		UsageText:    "inspect",
+		Aliases:      []string{"i"},
+		Usage:        "\tRetrieve properties of an object",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command allows to inspect the properties of an object ('app', 'context', function' or 'trigger').",
+		Subcommands:  GetCommands(InspectCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -16,5 +18,10 @@ func InspectCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command allows to inspect the properties of an object ('app', 'context', function' or 'trigger').",
 		Subcommands: GetCommands(InspectCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(InspectCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -65,18 +65,17 @@ func InvokeCommand() cli.Command {
 		Description: "This command explicitly invokes a function.",
 		Action:      cl.Invoke,
 		BashComplete: func(ctx *cli.Context) {
-			//TODO: Expand to include <app-name> <function-name>
-			provider, err := client.CurrentProvider()
-			if err != nil {
-				return
+			args := ctx.Args()
+			if len(args) == 0 {
+				app.BashCompleteApps(ctx)
 			}
-			resp, err := app.GetApps(ctx, provider.APIClientv2())
-			if err != nil {
-				return
+			//convert to using arg[0] to get available functions.
+			var msg string
+			for _, a := range args {
+				msg = msg + "-" + a
 			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
-			}
+			fmt.Println(msg)
+
 		},
 	}
 }

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"errors"
+
 	"github.com/fnproject/cli/client"
 	"github.com/fnproject/cli/common"
 	"github.com/fnproject/cli/objects/app"
@@ -11,7 +13,6 @@ import (
 	"github.com/fnproject/fn_go/clientv2"
 	"github.com/fnproject/fn_go/provider"
 	"github.com/urfave/cli"
-	"errors"
 )
 
 // FnInvokeEndpointAnnotation is the annotation that exposes the fn invoke endpoint as defined in models/fn.go
@@ -63,6 +64,20 @@ func InvokeCommand() cli.Command {
 		Category:    "DEVELOPMENT COMMANDS",
 		Description: "This command explicitly invokes a function.",
 		Action:      cl.Invoke,
+		BashComplete: func(ctx *cli.Context) {
+			//TODO: Expand to include <app-name> <function-name>
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			resp, err := app.GetApps(ctx, provider.APIClientv2())
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -64,18 +64,13 @@ func InvokeCommand() cli.Command {
 		Category:    "DEVELOPMENT COMMANDS",
 		Description: "This command explicitly invokes a function.",
 		Action:      cl.Invoke,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
-			if len(args) == 0 {
-				app.BashCompleteApps(ctx)
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
 			}
-			//convert to using arg[0] to get available functions.
-			var msg string
-			for _, a := range args {
-				msg = msg + "-" + a
-			}
-			fmt.Println(msg)
-
 		},
 	}
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func ListCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command returns a list of created objects ('app', 'call', 'context', 'function' or 'trigger') or configurations.",
 		Subcommands: GetCommands(ListCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(ListCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // ListCommand returns list cli.command
 func ListCommand() cli.Command {
 	return cli.Command{
-		Name:        "list",
-		Aliases:     []string{"ls"},
-		Usage:       "\tReturn a list of created objects",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command returns a list of created objects ('app', 'call', 'context', 'function' or 'trigger') or configurations.",
-		Subcommands: GetCommands(ListCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(ListCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "list",
+		Aliases:      []string{"ls"},
+		Usage:        "\tReturn a list of created objects",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command returns a list of created objects ('app', 'call', 'context', 'function' or 'trigger') or configurations.",
+		Subcommands:  GetCommands(ListCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/unset.go
+++ b/commands/unset.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // UnsetCommand returns unset cli.command
 func UnsetCommand() cli.Command {
 	return cli.Command{
-		Name:        "unset",
-		Aliases:     []string{"un"},
-		Usage:       "\tUnset elements of a created object",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command unsets elements ('configurations') for a created object ('app', 'function' or 'context').",
-		Subcommands: GetCommands(UnsetCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(UnsetCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "unset",
+		Aliases:      []string{"un"},
+		Usage:        "\tUnset elements of a created object",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command unsets elements ('configurations') for a created object ('app', 'function' or 'context').",
+		Subcommands:  GetCommands(UnsetCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/unset.go
+++ b/commands/unset.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func UnsetCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command unsets elements ('configurations') for a created object ('app', 'function' or 'context').",
 		Subcommands: GetCommands(UnsetCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(UnsetCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/update.go
+++ b/commands/update.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // UpdateCommand returns update cli.command
 func UpdateCommand() cli.Command {
 	return cli.Command{
-		Name:        "update",
-		Aliases:     []string{"up"},
-		Usage:       "\tUpdate a created object",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command updates an object ('app', 'context', 'function', 'server' or 'trigger').",
-		Subcommands: GetCommands(UpdateCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(UpdateCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "update",
+		Aliases:      []string{"up"},
+		Usage:        "\tUpdate a created object",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command updates an object ('app', 'context', 'function', 'server' or 'trigger').",
+		Subcommands:  GetCommands(UpdateCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/commands/update.go
+++ b/commands/update.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func UpdateCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command updates an object ('app', 'context', 'function', 'server' or 'trigger').",
 		Subcommands: GetCommands(UpdateCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(UpdateCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/use.go
+++ b/commands/use.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli"
 )
 
@@ -15,5 +17,10 @@ func UseCommand() cli.Command {
 		ArgsUsage:   "<subcommand>",
 		Description: "This command uses a selected object ('context') for further invocations.",
 		Subcommands: GetCommands(UseCmds),
+		BashComplete: func(ctx *cli.Context) {
+			for _, c := range GetCommands(UseCmds) {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }

--- a/commands/use.go
+++ b/commands/use.go
@@ -1,26 +1,21 @@
 package commands
 
 import (
-	"fmt"
-
+	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
 
 // UseCommand returns use cli.command
 func UseCommand() cli.Command {
 	return cli.Command{
-		Name:        "use",
-		Aliases:     []string{"u"},
-		Usage:       "\tSelect context for further commands",
-		Category:    "MANAGEMENT COMMANDS",
-		Hidden:      false,
-		ArgsUsage:   "<subcommand>",
-		Description: "This command uses a selected object ('context') for further invocations.",
-		Subcommands: GetCommands(UseCmds),
-		BashComplete: func(ctx *cli.Context) {
-			for _, c := range GetCommands(UseCmds) {
-				fmt.Println(c.Name)
-			}
-		},
+		Name:         "use",
+		Aliases:      []string{"u"},
+		Usage:        "\tSelect context for further commands",
+		Category:     "MANAGEMENT COMMANDS",
+		Hidden:       false,
+		ArgsUsage:    "<subcommand>",
+		Description:  "This command uses a selected object ('context') for further invocations.",
+		Subcommands:  GetCommands(UseCmds),
+		BashComplete: common.DefaultBashComplete,
 	}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -34,6 +34,19 @@ const (
 	MinRequiredDockerVersion = "17.5.0"
 )
 
+// DefaultBashComplete prints the list of all sub commands
+// of the current command (without alias names)
+func DefaultBashComplete(c *cli.Context) {
+	for _, command := range c.App.Commands {
+		if command.Hidden {
+			continue
+		}
+		if command.Name != "help" {
+			fmt.Println(command.Name)
+		}
+	}
+}
+
 // GetWd returns working directory.
 func GetWd() string {
 	wd, err := os.Getwd()

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ func newFn() *cli.App {
 			Usage: "Use --verbose to enable verbose mode for debugging",
 		},
 		cli.StringFlag{
-			Name:  "context",
-			Usage: "Use --context to select context configuration file",
+			Name:   "context",
+			Usage:  "Use --context to select context configuration file",
 			EnvVar: "FN_CONTEXT",
 		},
 		cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/fnproject/cli/commands"
+	"github.com/fnproject/cli/common"
 	"github.com/fnproject/cli/common/color"
 	"github.com/fnproject/cli/config"
 	"github.com/spf13/viper"
@@ -24,6 +25,7 @@ func newFn() *cli.App {
 	app.Authors = []cli.Author{{Name: "Fn Project"}}
 	app.Description = "Fn Command Line Tool"
 	app.EnableBashCompletion = true
+	app.BashComplete = common.DefaultBashComplete
 	app.Before = func(c *cli.Context) error {
 		err := config.LoadConfiguration(c)
 		if err != nil {

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -57,7 +57,7 @@ func printApps(c *cli.Context, apps []*modelsv2.App) error {
 }
 
 func (a *appsCmd) list(c *cli.Context) error {
-	resApps, err := a.getApps(c)
+	resApps, err := GetApps(c, a.client)
 	if err != nil {
 		return err
 	}
@@ -68,11 +68,12 @@ func (a *appsCmd) list(c *cli.Context) error {
 	return nil
 }
 
-func (a *appsCmd) getApps(c *cli.Context) ([]*modelsv2.App, error) {
+// GetApps returns an array of apps in the given context and client
+func GetApps(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.App, error) {
 	params := &apiapps.ListAppsParams{Context: context.Background()}
 	var resApps []*modelsv2.App
 	for {
-		resp, err := a.client.Apps.ListApps(params)
+		resp, err := client.Apps.ListApps(params)
 		if err != nil {
 			return nil, err
 		}

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -62,30 +62,10 @@ func (a *appsCmd) list(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-
-	if err := printApps(c, resApps); err != nil {
-		return err
-	}
-	return nil
+	return printApps(c, resApps)
 }
 
-// BashCompleteApps can be called from a BashComplete function
-// to provide app completion suggestions
-func BashCompleteApps(ctx *cli.Context) {
-	provider, err := client.CurrentProvider()
-	if err != nil {
-		return
-	}
-	resp, err := getApps(ctx, provider.APIClientv2())
-	if err != nil {
-		return
-	}
-	for _, r := range resp {
-		fmt.Println(r.Name)
-	}
-}
-
-// getApps returns an array of apps in the given context and client
+// getApps returns an array of all apps in the given context and client
 func getApps(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.App, error) {
 	params := &apiapps.ListAppsParams{Context: context.Background()}
 	var resApps []*modelsv2.App
@@ -115,6 +95,24 @@ func getApps(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.App, error) {
 		return nil, nil
 	}
 	return resApps, nil
+}
+
+// BashCompleteApps can be called from a BashComplete function
+// to provide app completion suggestions (Does not check if the
+// current context already contains an app name as an argument.
+// This should be checked before calling this)
+func BashCompleteApps(c *cli.Context) {
+	provider, err := client.CurrentProvider()
+	if err != nil {
+		return
+	}
+	resp, err := getApps(c, provider.APIClientv2())
+	if err != nil {
+		return
+	}
+	for _, r := range resp {
+		fmt.Println(r.Name)
+	}
 }
 
 func appWithFlags(c *cli.Context, app *modelsv2.App) {

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/fnproject/cli/client"
 	"github.com/fnproject/cli/common"
 	fnclient "github.com/fnproject/fn_go/clientv2"
 	apiapps "github.com/fnproject/fn_go/clientv2/apps"
@@ -57,7 +58,7 @@ func printApps(c *cli.Context, apps []*modelsv2.App) error {
 }
 
 func (a *appsCmd) list(c *cli.Context) error {
-	resApps, err := GetApps(c, a.client)
+	resApps, err := getApps(c, a.client)
 	if err != nil {
 		return err
 	}
@@ -68,8 +69,24 @@ func (a *appsCmd) list(c *cli.Context) error {
 	return nil
 }
 
-// GetApps returns an array of apps in the given context and client
-func GetApps(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.App, error) {
+// BashCompleteApps can be called from a BashComplete function
+// to provide app completion suggestions
+func BashCompleteApps(ctx *cli.Context) {
+	provider, err := client.CurrentProvider()
+	if err != nil {
+		return
+	}
+	resp, err := getApps(ctx, provider.APIClientv2())
+	if err != nil {
+		return
+	}
+	for _, r := range resp {
+		fmt.Println(r.Name)
+	}
+}
+
+// getApps returns an array of apps in the given context and client
+func getApps(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.App, error) {
 	params := &apiapps.ListAppsParams{Context: context.Background()}
 	var resApps []*modelsv2.App
 	for {

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -16,7 +16,7 @@ func Create() cli.Command {
 		Category: "MANAGEMENT COMMAND",
 		Description: "This command creates a new application.\n	Fn supports grouping functions into a set that defines an application (or API), making it easy to organize and deploy.\n	Applications define a namespace to organize functions and can contain configuration values that are shared across all functions in that application.",
 		Aliases: []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -52,7 +52,7 @@ func List() cli.Command {
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command provides a list of defined applications.",
 		Aliases:     []string{"app", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -89,7 +89,7 @@ func Delete() cli.Command {
 		Description: "This command deletes a created application.",
 		ArgsUsage:   "<app_name>",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -98,10 +98,10 @@ func Delete() cli.Command {
 			return nil
 		},
 		Action: a.delete,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			if len(args) == 0 {
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 				return
 			}
 		},
@@ -117,7 +117,7 @@ func Inspect() cli.Command {
 		Description: "This command inspects properties of an application.",
 		Category:    "MANAGEMENT COMMAND",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -127,10 +127,10 @@ func Inspect() cli.Command {
 		},
 		ArgsUsage: "<app-name> [property.[key]]",
 		Action:    a.inspect,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			if len(args) == 0 {
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 				return
 			}
 		},
@@ -146,7 +146,7 @@ func Update() cli.Command {
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command updates a created application.",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -170,10 +170,10 @@ func Update() cli.Command {
 				Usage: "Syslog URL to send application logs to",
 			},
 		},
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			if len(args) == 0 {
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 				return
 			}
 		},
@@ -189,7 +189,7 @@ func SetConfig() cli.Command {
 		Description: "This command sets configurations for an application.",
 		Category:    "MANAGEMENT COMMAND",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -199,10 +199,10 @@ func SetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key> <value>",
 		Action:    a.setConfig,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			if len(args) == 0 {
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 				return
 			}
 		},
@@ -218,7 +218,7 @@ func ListConfig() cli.Command {
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command lists the configuration of an application.",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -228,10 +228,10 @@ func ListConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name>",
 		Action:    a.listConfig,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			if len(args) == 0 {
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 				return
 			}
 		},
@@ -247,7 +247,7 @@ func GetConfig() cli.Command {
 		Description: "This command gets the configuration of an application.",
 		Category:    "MANAGEMENT COMMAND",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -257,11 +257,11 @@ func GetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.getConfig,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			switch len(args) {
 			case 0:
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 			case 1:
 				provider, err := client.CurrentProvider()
 				if err != nil {
@@ -290,7 +290,7 @@ func UnsetConfig() cli.Command {
 		Description: "This command removes a configuration for an application.",
 		Category:    "MANAGEMENT COMMAND",
 		Aliases:     []string{"apps", "a"},
-		Before: func(cxt *cli.Context) error {
+		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
@@ -300,11 +300,11 @@ func UnsetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.unsetConfig,
-		BashComplete: func(ctx *cli.Context) {
-			args := ctx.Args()
+		BashComplete: func(c *cli.Context) {
+			args := c.Args()
 			switch len(args) {
 			case 0:
-				BashCompleteApps(ctx)
+				BashCompleteApps(c)
 			case 1:
 				provider, err := client.CurrentProvider()
 				if err != nil {

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -104,7 +104,7 @@ func Delete() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -140,7 +140,7 @@ func Inspect() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -190,7 +190,7 @@ func Update() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -226,7 +226,7 @@ func SetConfig() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -262,7 +262,7 @@ func ListConfig() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -298,7 +298,7 @@ func GetConfig() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}
@@ -334,7 +334,7 @@ func UnsetConfig() cli.Command {
 				return
 			}
 			a.client = provider.APIClientv2()
-			resp, err := a.getApps(ctx)
+			resp, err := GetApps(ctx, a.client)
 			if err != nil {
 				return
 			}

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/fnproject/cli/client"
@@ -102,7 +103,6 @@ func Delete() cli.Command {
 			args := c.Args()
 			if len(args) == 0 {
 				BashCompleteApps(c)
-				return
 			}
 		},
 	}
@@ -128,10 +128,30 @@ func Inspect() cli.Command {
 		ArgsUsage: "<app-name> [property.[key]]",
 		Action:    a.inspect,
 		BashComplete: func(c *cli.Context) {
-			args := c.Args()
-			if len(args) == 0 {
+			switch len(c.Args()) {
+			case 0:
 				BashCompleteApps(c)
-				return
+			case 1:
+				provider, err := client.CurrentProvider()
+				if err != nil {
+					return
+				}
+				app, err := GetAppByName(provider.APIClientv2(), c.Args()[0])
+				if err != nil {
+					return
+				}
+				data, err := json.Marshal(app)
+				if err != nil {
+					return
+				}
+				var inspect map[string]interface{}
+				err = json.Unmarshal(data, &inspect)
+				if err != nil {
+					return
+				}
+				for key := range inspect {
+					fmt.Println(key)
+				}
 			}
 		},
 	}
@@ -174,7 +194,6 @@ func Update() cli.Command {
 			args := c.Args()
 			if len(args) == 0 {
 				BashCompleteApps(c)
-				return
 			}
 		},
 	}
@@ -203,7 +222,6 @@ func SetConfig() cli.Command {
 			args := c.Args()
 			if len(args) == 0 {
 				BashCompleteApps(c)
-				return
 			}
 		},
 	}
@@ -232,7 +250,6 @@ func ListConfig() cli.Command {
 			args := c.Args()
 			if len(args) == 0 {
 				BashCompleteApps(c)
-				return
 			}
 		},
 	}
@@ -258,8 +275,7 @@ func GetConfig() cli.Command {
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.getConfig,
 		BashComplete: func(c *cli.Context) {
-			args := c.Args()
-			switch len(args) {
+			switch len(c.Args()) {
 			case 0:
 				BashCompleteApps(c)
 			case 1:
@@ -267,15 +283,13 @@ func GetConfig() cli.Command {
 				if err != nil {
 					return
 				}
-				app, err := GetAppByName(provider.APIClientv2(), args[0])
+				app, err := GetAppByName(provider.APIClientv2(), c.Args()[0])
 				if err != nil {
 					return
 				}
 				for key := range app.Config {
 					fmt.Println(key)
 				}
-			default:
-				return
 			}
 		},
 	}
@@ -309,15 +323,13 @@ func UnsetConfig() cli.Command {
 				if err != nil {
 					return
 				}
-				app, err := GetAppByName(provider.APIClientv2(), c.Args().Get(1))
+				app, err := GetAppByName(provider.APIClientv2(), c.Args()[0])
 				if err != nil {
 					return
 				}
 				for key := range app.Config {
 					fmt.Println(key)
 				}
-			default:
-				return
 			}
 		},
 	}

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/fnproject/cli/client"
 	"github.com/urfave/cli"
 )
@@ -48,7 +50,7 @@ func List() cli.Command {
 		Name:        "apps",
 		Usage:       "List all created applications",
 		Category:    "MANAGEMENT COMMAND",
-		Description: "This command provides a list of defined application.",
+		Description: "This command provides a list of defined applications.",
 		Aliases:     []string{"app", "a"},
 		Before: func(cxt *cli.Context) error {
 			provider, err := client.CurrentProvider()
@@ -96,6 +98,20 @@ func Delete() cli.Command {
 			return nil
 		},
 		Action: a.delete,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -118,6 +134,20 @@ func Inspect() cli.Command {
 		},
 		ArgsUsage: "<app-name> [property.[key]]",
 		Action:    a.inspect,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -154,6 +184,20 @@ func Update() cli.Command {
 				Usage: "Syslog URL to send application logs to",
 			},
 		},
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -176,6 +220,20 @@ func SetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key> <value>",
 		Action:    a.setConfig,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -198,6 +256,20 @@ func ListConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name>",
 		Action:    a.listConfig,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -220,6 +292,20 @@ func GetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.getConfig,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }
 
@@ -242,5 +328,19 @@ func UnsetConfig() cli.Command {
 		},
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.unsetConfig,
+		BashComplete: func(ctx *cli.Context) {
+			provider, err := client.CurrentProvider()
+			if err != nil {
+				return
+			}
+			a.client = provider.APIClientv2()
+			resp, err := a.getApps(ctx)
+			if err != nil {
+				return
+			}
+			for _, r := range resp {
+				fmt.Println(r.Name)
+			}
+		},
 	}
 }

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -99,17 +99,10 @@ func Delete() cli.Command {
 		},
 		Action: a.delete,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			if len(args) == 0 {
+				BashCompleteApps(ctx)
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -135,17 +128,10 @@ func Inspect() cli.Command {
 		ArgsUsage: "<app-name> [property.[key]]",
 		Action:    a.inspect,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			if len(args) == 0 {
+				BashCompleteApps(ctx)
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -185,17 +171,10 @@ func Update() cli.Command {
 			},
 		},
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			if len(args) == 0 {
+				BashCompleteApps(ctx)
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -221,17 +200,10 @@ func SetConfig() cli.Command {
 		ArgsUsage: "<app-name> <key> <value>",
 		Action:    a.setConfig,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			if len(args) == 0 {
+				BashCompleteApps(ctx)
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -257,17 +229,10 @@ func ListConfig() cli.Command {
 		ArgsUsage: "<app-name>",
 		Action:    a.listConfig,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			if len(args) == 0 {
+				BashCompleteApps(ctx)
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -293,17 +258,24 @@ func GetConfig() cli.Command {
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.getConfig,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			switch len(args) {
+			case 0:
+				BashCompleteApps(ctx)
+			case 1:
+				provider, err := client.CurrentProvider()
+				if err != nil {
+					return
+				}
+				app, err := GetAppByName(provider.APIClientv2(), args[0])
+				if err != nil {
+					return
+				}
+				for key := range app.Config {
+					fmt.Println(key)
+				}
+			default:
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}
@@ -329,17 +301,24 @@ func UnsetConfig() cli.Command {
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.unsetConfig,
 		BashComplete: func(ctx *cli.Context) {
-			provider, err := client.CurrentProvider()
-			if err != nil {
+			args := ctx.Args()
+			switch len(args) {
+			case 0:
+				BashCompleteApps(ctx)
+			case 1:
+				provider, err := client.CurrentProvider()
+				if err != nil {
+					return
+				}
+				app, err := GetAppByName(provider.APIClientv2(), args[0])
+				if err != nil {
+					return
+				}
+				for key := range app.Config {
+					fmt.Println(key)
+				}
+			default:
 				return
-			}
-			a.client = provider.APIClientv2()
-			resp, err := GetApps(ctx, a.client)
-			if err != nil {
-				return
-			}
-			for _, r := range resp {
-				fmt.Println(r.Name)
 			}
 		},
 	}

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -301,8 +301,7 @@ func UnsetConfig() cli.Command {
 		ArgsUsage: "<app-name> <key>",
 		Action:    a.unsetConfig,
 		BashComplete: func(c *cli.Context) {
-			args := c.Args()
-			switch len(args) {
+			switch len(c.Args()) {
 			case 0:
 				BashCompleteApps(c)
 			case 1:
@@ -310,7 +309,7 @@ func UnsetConfig() cli.Command {
 				if err != nil {
 					return
 				}
-				app, err := GetAppByName(provider.APIClientv2(), args[0])
+				app, err := GetAppByName(provider.APIClientv2(), c.Args().Get(1))
 				if err != nil {
 					return
 				}

--- a/objects/context/commands.go
+++ b/objects/context/commands.go
@@ -68,7 +68,9 @@ func Delete() cli.Command {
 				return
 			}
 			for _, c := range contexts {
-				fmt.Println(c.Name)
+				if c.Name != "default" {
+					fmt.Println(c.Name)
+				}
 			}
 		},
 	}
@@ -82,6 +84,15 @@ func Inspect() cli.Command {
 		Aliases:  []string{"ctx"},
 		Category: "MANAGEMENT COMMAND",
 		Action:   inspectCtx,
+		BashComplete: func(ctx *cli.Context) {
+			contexts, err := getAvailableContexts()
+			if err != nil {
+				return
+			}
+			for _, c := range contexts {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }
 

--- a/objects/context/commands.go
+++ b/objects/context/commands.go
@@ -1,7 +1,12 @@
 package context
 
-import "github.com/urfave/cli"
+import (
+	"fmt"
 
+	"github.com/urfave/cli"
+)
+
+// Create context command
 func Create() cli.Command {
 	return cli.Command{
 		Name:        "context",
@@ -28,6 +33,7 @@ func Create() cli.Command {
 	}
 }
 
+// List contexts command
 func List() cli.Command {
 	return cli.Command{
 		Name:        "contexts",
@@ -46,6 +52,7 @@ func List() cli.Command {
 	}
 }
 
+// Delete context command
 func Delete() cli.Command {
 	return cli.Command{
 		Name:        "context",
@@ -55,9 +62,19 @@ func Delete() cli.Command {
 		Description: "This command deletes a context.",
 		Category:    "MANAGEMENT COMMAND",
 		Action:      deleteCtx,
+		BashComplete: func(ctx *cli.Context) {
+			contexts, err := getAvailableContexts()
+			if err != nil {
+				return
+			}
+			for _, c := range contexts {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }
 
+// Inspect context command
 func Inspect() cli.Command {
 	return cli.Command{
 		Name:     "context",
@@ -68,6 +85,7 @@ func Inspect() cli.Command {
 	}
 }
 
+// Update context command
 func Update() cli.Command {
 	ctxMap := ContextMap{}
 	return cli.Command{
@@ -87,6 +105,7 @@ func Update() cli.Command {
 	}
 }
 
+// Use context command
 func Use() cli.Command {
 	return cli.Command{
 		Name:        "context",
@@ -96,9 +115,19 @@ func Use() cli.Command {
 		Category:    "MANAGEMENT COMMAND",
 		Description: "This command uses context for future invocations.",
 		Action:      useCtx,
+		BashComplete: func(ctx *cli.Context) {
+			contexts, err := getAvailableContexts()
+			if err != nil {
+				return
+			}
+			for _, c := range contexts {
+				fmt.Println(c.Name)
+			}
+		},
 	}
 }
 
+// Unset context command
 func Unset() cli.Command {
 	return cli.Command{
 		Name:        "context",

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	client "github.com/fnproject/cli/client"
 	"github.com/fnproject/cli/common"
 	"github.com/fnproject/cli/objects/app"
 	fnclient "github.com/fnproject/fn_go/clientv2"
@@ -153,10 +154,21 @@ func getFns(c *cli.Context, client *fnclient.Fn) ([]*modelsv2.Fn, error) {
 	return resFns, nil
 }
 
+// BashCompleteFns can be called from a BashComplete function
+// to provide function completion suggestions (Assumes the
+// current context already contains an app name as an argument.
+// This should be confirmed before calling this)
 func BashCompleteFns(c *cli.Context) {
-	appName := c.Args().Get(0)
-	if appName != "" {
+	provider, err := client.CurrentProvider()
+	if err != nil {
 		return
+	}
+	resp, err := getFns(c, provider.APIClientv2())
+	if err != nil {
+		return
+	}
+	for _, f := range resp {
+		fmt.Println(f.Name)
 	}
 }
 

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -172,6 +172,22 @@ func BashCompleteFns(c *cli.Context) {
 	}
 }
 
+func getFnByAppAndFnName(appName, fnName string) (*models.Fn, error) {
+	provider, err := client.CurrentProvider()
+	if err != nil {
+		return nil, errors.New("could not get context")
+	}
+	app, err := app.GetAppByName(provider.APIClientv2(), appName)
+	if err != nil {
+		return nil, fmt.Errorf("could not get app %v", appName)
+	}
+	fn, err := GetFnByName(provider.APIClientv2(), app.ID, fnName)
+	if err != nil {
+		return nil, fmt.Errorf("could not get function %v", fnName)
+	}
+	return fn, nil
+}
+
 // WithFlags returns a function with specified flags
 func WithFlags(c *cli.Context, fn *models.Fn) {
 	if i := c.String("image"); i != "" {

--- a/objects/log/commands.go
+++ b/objects/log/commands.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"github.com/fnproject/cli/client"
+	"github.com/fnproject/cli/objects/app"
+	"github.com/fnproject/cli/objects/fn"
 	"github.com/urfave/cli"
 )
 
@@ -24,5 +26,13 @@ func Get() cli.Command {
 		},
 		ArgsUsage: "<app-name> <function-name> <call-id>",
 		Action:    l.get,
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			}
+		},
 	}
 }

--- a/objects/trigger/commands.go
+++ b/objects/trigger/commands.go
@@ -2,6 +2,8 @@ package trigger
 
 import (
 	"github.com/fnproject/cli/client"
+	"github.com/fnproject/cli/objects/app"
+	"github.com/fnproject/cli/objects/fn"
 	"github.com/urfave/cli"
 )
 
@@ -27,6 +29,14 @@ func Create() cli.Command {
 		ArgsUsage: "<app-name> <function-name> <trigger-name>",
 		Action:    t.create,
 		Flags:     TriggerFlags,
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			}
+		},
 	}
 }
 
@@ -62,6 +72,14 @@ func List() cli.Command {
 				Value: int64(100),
 			},
 		},
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			}
+		},
 	}
 }
 
@@ -92,6 +110,16 @@ func Update() cli.Command {
 				Usage: "trigger annotations",
 			},
 		},
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			case 2:
+				BashCompleteTriggers(c)
+			}
+		},
 	}
 }
 
@@ -116,6 +144,16 @@ func Delete() cli.Command {
 		},
 		ArgsUsage: "<app-name> <function-name> <trigger-name>",
 		Action:    t.delete,
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			case 2:
+				BashCompleteTriggers(c)
+			}
+		},
 	}
 }
 
@@ -146,5 +184,15 @@ func Inspect() cli.Command {
 		},
 		ArgsUsage: "<app-name> <function-name> <trigger-name>",
 		Action:    t.inspect,
+		BashComplete: func(c *cli.Context) {
+			switch len(c.Args()) {
+			case 0:
+				app.BashCompleteApps(c)
+			case 1:
+				fn.BashCompleteFns(c)
+			case 2:
+				BashCompleteTriggers(c)
+			}
+		},
 	}
 }


### PR DESCRIPTION
This PR adds auto-completion logic to the CLI tool. This is achieved using the urfave library which provides callbacks that can be utilised by bash autocomplete and zsh autocomplete.

### Enabling the feature

To enable auto completion it is necessary to source bash and/or zsh completion scripts from the urfave vendor directory. 

From inside the CLI repo:
- For zsh users: 
`PROG=fn source ./vendor/github.com/urfave/cli/autocomplete/zsh_autocomplete`
- For bash users: 
`PROG=fn source ./vendor/github.com/urfave/cli/autocomplete/bash_autocomplete`

This file can be copied to a more permanent location and sourced in your `.bash_profile` or `.zshrc` file to keep the auto completion feature available in all environments.

> TODO: This could to be incorporated into the distribution process to make it easier to use

### Using the feature
Once the relevant auto_complete file has been sourced and this version of the CLI has been built, begin a command and use `tab` to see suggestions of how to complete your function call.

### Changes

Almost every command that can be auto-completed has had the required logic added with the exception of commands relating to calls and call-ids

Some minor improvements in code reuse and naming consistency were also included since this PR required modification of so many different files anyway.