### PR TITLE
Do not create app by default on `fn deploy`

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -45,16 +45,17 @@ func DeployCommand() cli.Command {
 }
 
 type deploycmd struct {
-	appName  string
 	clientV2 *v2Client.Fn
 
-	wd       string
-	verbose  bool
-	local    bool
-	noCache  bool
-	registry string
-	all      bool
-	noBump   bool
+	appName   string
+	createApp bool
+	wd        string
+	verbose   bool
+	local     bool
+	noCache   bool
+	registry  string
+	all       bool
+	noBump    bool
 }
 
 func (p *deploycmd) flags() []cli.Flag {
@@ -63,6 +64,11 @@ func (p *deploycmd) flags() []cli.Flag {
 			Name:        "app",
 			Usage:       "App name to deploy to",
 			Destination: &p.appName,
+		},
+		cli.BoolFlag{
+			Name:        "create-app",
+			Usage:       "Enable automatic creation of app if it doesn't exist during deploy",
+			Destination: &p.createApp,
 		},
 		cli.BoolFlag{
 			Name:        "verbose, v",
@@ -326,16 +332,20 @@ func (p *deploycmd) updateFunction(c *cli.Context, appName string, ff *common.Fu
 
 	app, err := apps.GetAppByName(p.clientV2, appName)
 	if err != nil {
-		app = &modelsV2.App{
-			Name: appName,
-		}
+		if p.createApp {
+			app = &modelsV2.App{
+				Name: appName,
+			}
 
-		err = apps.CreateApp(p.clientV2, app)
-		if err != nil {
-			return err
-		}
-		app, err = apps.GetAppByName(p.clientV2, appName)
-		if err != nil {
+			err = apps.CreateApp(p.clientV2, app)
+			if err != nil {
+				return err
+			}
+			app, err = apps.GetAppByName(p.clientV2, appName)
+			if err != nil {
+				return err
+			}
+		} else {
 			return err
 		}
 	}
@@ -390,7 +400,6 @@ func (p *deploycmd) updateFunction(c *cli.Context, appName string, ff *common.Fu
 
 	return nil
 }
-
 
 func (p *deploycmd) updateAppConfig(appf *common.AppFile) error {
 	app, err := apps.GetAppByName(p.clientV2, appf.Name)

--- a/test/cli_misc_test.go
+++ b/test/cli_misc_test.go
@@ -30,7 +30,6 @@ func withMinimalFunction(h *testharness.CLIHarness) {
 	})
 }
 
-
 // this is messy and nasty  as we generate different potential values for FN_API_URL based on its type
 func fnApiUrlVariations(t *testing.T) []string {
 
@@ -204,6 +203,20 @@ func TestAppYamlDeploy(t *testing.T) {
 	h.Fn("invoke", appName, fnName).AssertSuccess()
 }
 
+func TestDeployCreateApp(t *testing.T) {
+	t.Parallel()
+
+	h := testharness.Create(t)
+	defer h.Cleanup()
+
+	appName := h.NewAppName()
+	fnName := h.NewFuncName(appName)
+	h.MkDir(fnName)
+	h.Cd(fnName)
+	withMinimalFunction(h)
+	h.Fn("deploy", "--local", "--app", appName, "--create-app").AssertSuccess()
+}
+
 func TestBump(t *testing.T) {
 	t.Parallel()
 
@@ -219,6 +232,7 @@ func TestBump(t *testing.T) {
 	}
 
 	appName := h.NewAppName()
+	h.Fn("create", "app", appName).AssertSuccess()
 	fnName := h.NewFuncName(appName)
 	h.MkDir(fnName)
 	h.Cd(fnName)


### PR DESCRIPTION
Dependent on https://github.com/fnproject/cli/pull/528 in order to build/test

In response to user feedback from @shaunsmith this disables creation of apps by default with `fn deploy`

Old behaviour can be restored using `fn deploy --create-app`

This will have documentation impact!