### PR TITLE
moving app check up

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -15,8 +15,6 @@ import (
 	trigger "github.com/fnproject/cli/objects/trigger"
 	v2Client "github.com/fnproject/fn_go/clientv2"
 	clientApps "github.com/fnproject/fn_go/clientv2/apps"
-	clientFns "github.com/fnproject/fn_go/clientv2/fns"
-	clientTrigs "github.com/fnproject/fn_go/clientv2/triggers"
 	models "github.com/fnproject/fn_go/modelsv2"
 	"github.com/urfave/cli"
 )
@@ -150,7 +148,7 @@ func (p *deploycmd) deploy(c *cli.Context) error {
 	}
 
 	app, err := apps.GetAppByName(p.clientV2, appName)
-	if _, ok := err.(*clientApps.GetAppNotFound); ok && p.createApp {
+	if _, ok := err.(apps.NameNotFoundError); ok && p.createApp {
 		app = &models.App{
 			Name: appName,
 		}
@@ -347,8 +345,7 @@ func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.Func
 	}
 
 	fnRes, err := function.GetFnByName(p.clientV2, appID, ff.Name)
-	fmt.Printf("YODAWG %T %v\n", err, err)
-	if _, ok := err.(*clientFns.GetFnNotFound); ok {
+	if _, ok := err.(function.NameNotFoundError); ok {
 		fn.Name = ff.Name
 		fn, err = function.CreateFn(p.clientV2, appID, fn)
 		if err != nil {
@@ -376,7 +373,7 @@ func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.Func
 			}
 
 			trigs, err := trigger.GetTriggerByName(p.clientV2, appID, fn.ID, t.Name)
-			if _, ok := err.(*clientTrigs.GetTriggerNotFound); ok {
+			if _, ok := err.(trigger.NameNotFoundError); ok {
 				err = trigger.CreateTrigger(p.clientV2, trig)
 				if err != nil {
 					return err

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -183,12 +183,12 @@ func (p *deploycmd) deploy(c *cli.Context) error {
 	if p.all {
 		return p.deployAll(c, app)
 	}
-	return p.deploySingle(c, app)
+	return p.deploySingle(c, app, appf != nil)
 }
 
 // deploySingle deploys a single function, either the current directory or if in the context
 // of an app and user provides relative path as the first arg, it will deploy that function.
-func (p *deploycmd) deploySingle(c *cli.Context, app *models.App) error {
+func (p *deploycmd) deploySingle(c *cli.Context, app *models.App, isAppYAML bool) error {
 	var dir string
 	wd := common.GetWd()
 
@@ -220,7 +220,10 @@ func (p *deploycmd) deploySingle(c *cli.Context, app *models.App) error {
 		if err != nil {
 			return err
 		}
-		if dir == wd {
+		if isAppYAML && dir == wd {
+			// TODO(reed): why are we setting this any differently than anything else? this is magical.
+			// for app.yaml that don't provide a func.yaml with a name, we use '$PWD-root' instead of '$PWD'
+			// for the name of the function - this is really weird. remove?
 			setFuncInfoV20180708(ff, app.Name)
 		}
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -347,6 +347,7 @@ func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.Func
 	}
 
 	fnRes, err := function.GetFnByName(p.clientV2, appID, ff.Name)
+	fmt.Printf("YODAWG %T %v\n", err, err)
 	if _, ok := err.(*clientFns.GetFnNotFound); ok {
 		fn.Name = ff.Name
 		fn, err = function.CreateFn(p.clientV2, appID, fn)

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -336,6 +336,15 @@ func PutFn(f *fnclient.Fn, fnID string, fn *models.Fn) error {
 	return nil
 }
 
+// NameNotFoundError error for app not found when looked up by name
+type NameNotFoundError struct {
+	Name string
+}
+
+func (n NameNotFoundError) Error() string {
+	return fmt.Sprintf("function %s not found", n.Name)
+}
+
 // GetFnByName looks up a fn by name using the given client
 func GetFnByName(client *fnclient.Fn, appID, fnName string) (*models.Fn, error) {
 	resp, err := client.Fns.ListFns(&apifns.ListFnsParams{
@@ -354,7 +363,7 @@ func GetFnByName(client *fnclient.Fn, appID, fnName string) (*models.Fn, error) 
 		}
 	}
 	if fn == nil {
-		return nil, fmt.Errorf("function %s not found", fnName)
+		return nil, NameNotFoundError{fnName}
 	}
 
 	return fn, nil

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -271,20 +271,19 @@ func (f *fnsCmd) create(c *cli.Context) error {
 		return errors.New("no image specified")
 	}
 
-	_, err := CreateFn(f.client, appName, fn)
+	a, err := app.GetAppByName(f.client, appName)
+	if err != nil {
+		return err
+	}
+
+	_, err = CreateFn(f.client, a.ID, fn)
 	return err
 }
 
 // CreateFn request
-func CreateFn(r *fnclient.Fn, appName string, fn *models.Fn) (*models.Fn, error) {
-	a, err := app.GetAppByName(r, appName)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO(reed): this validation should all be server side
-	fn.AppID = a.ID
-	err = common.ValidateTagImageName(fn.Image)
+func CreateFn(r *fnclient.Fn, appID string, fn *models.Fn) (*models.Fn, error) {
+	fn.AppID = appID
+	err := common.ValidateTagImageName(fn.Image)
 	if err != nil {
 		return nil, err
 	}

--- a/objects/trigger/triggers.go
+++ b/objects/trigger/triggers.go
@@ -383,7 +383,7 @@ func GetTriggerByName(client *fnclient.Fn, appID string, fnID string, triggerNam
 		return nil, err
 	}
 	if len(triggerList.Payload.Items) == 0 {
-		return nil, fmt.Errorf("Trigger %s not found", triggerName)
+		return nil, NameNotFoundError{triggerName}
 	}
 
 	return triggerList.Payload.Items[0], nil
@@ -394,4 +394,13 @@ func WithFlags(c *cli.Context, t *models.Trigger) {
 	if len(c.StringSlice("annotation")) > 0 {
 		t.Annotations = common.ExtractAnnotations(c)
 	}
+}
+
+// NameNotFoundError error for app not found when looked up by name
+type NameNotFoundError struct {
+	Name string
+}
+
+func (n NameNotFoundError) Error() string {
+	return fmt.Sprintf("trigger %s not found", n.Name)
 }

--- a/testharness/harness.go
+++ b/testharness/harness.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -96,7 +95,7 @@ func (cr *CmdResult) AssertSuccess() *CmdResult {
 // AssertStdoutContains asserts that the string appears somewhere in the stdout
 func (cr *CmdResult) AssertStdoutContains(match string) *CmdResult {
 	if !strings.Contains(cr.Stdout, match) {
-		log.Fatalf("Expected stdout  message (%s) not found in result: %v", match, cr)
+		cr.t.Fatalf("Expected stdout  message (%s) not found in result: %v", match, cr)
 	}
 	return cr
 }
@@ -112,7 +111,7 @@ func (cr *CmdResult) AssertStdoutContainsEach(matches []string) *CmdResult {
 // AssertStderrContains asserts that the string appears somewhere in the stderr
 func (cr *CmdResult) AssertStderrContains(match string) *CmdResult {
 	if !strings.Contains(cr.Stderr, match) {
-		log.Fatalf("Expected sdterr message (%s) not found in result: %v", match, cr)
+		cr.t.Fatalf("Expected sdterr message (%s) not found in result: %v", match, cr)
 	}
 	return cr
 }
@@ -451,9 +450,7 @@ func (h *CLIHarness) Cd(s string) {
 
 }
 func (h *CLIHarness) pushHistoryf(s string, args ...interface{}) {
-	//log.Printf(s, args...)
 	h.history = append(h.history, fmt.Sprintf(s, args...))
-
 }
 
 // MkDir creates a directory in the current cwd
@@ -533,18 +530,18 @@ func (cr *CmdResult) AssertStdoutContainsJSON(query []string, value interface{})
 	routeObj := map[string]interface{}{}
 	err := json.Unmarshal([]byte(cr.Stdout), &routeObj)
 	if err != nil {
-		log.Fatalf("Failed to parse routes inspect as JSON %v, %v", err, cr)
+		cr.t.Fatalf("Failed to parse routes inspect as JSON %v, %v", err, cr)
 	}
 
 	q := jsonq.NewQuery(routeObj)
 
 	val, err := q.Interface(query...)
 	if err != nil {
-		log.Fatalf("Failed to find path %v in json body %v", query, cr.Stdout)
+		cr.t.Fatalf("Failed to find path %v in json body %v", query, cr.Stdout)
 	}
 
 	if val != value {
-		log.Fatalf("Expected %s to be %v but was %s, %v", strings.Join(query, "."), value, val, cr)
+		cr.t.Fatalf("Expected %s to be %v but was %s, %v", strings.Join(query, "."), value, val, cr)
 	}
 }
 
@@ -552,13 +549,13 @@ func (cr *CmdResult) AssertStdoutMissingJSONPath(query []string) {
 	routeObj := map[string]interface{}{}
 	err := json.Unmarshal([]byte(cr.Stdout), &routeObj)
 	if err != nil {
-		log.Fatalf("Failed to parse routes inspect as JSON %v, %v", err, cr)
+		cr.t.Fatalf("Failed to parse routes inspect as JSON %v, %v", err, cr)
 	}
 
 	q := jsonq.NewQuery(routeObj)
 	_, err = q.Interface(query...)
 	if err == nil {
-		log.Fatalf("Found path %v in json body %v when it was supposed to be missing", query, cr.Stdout)
+		cr.t.Fatalf("Found path %v in json body %v when it was supposed to be missing", query, cr.Stdout)
 	}
 }
 


### PR DESCRIPTION
now that we require apps to exist when deploying them, we should check whether
the app exists before running around and bumping and creating images and all
that, this makes that change. for deploy all this reduces the number of api
calls substantially, we were checking the app each function. obviously this
whole thing is not really atomic, so it can fail pretty spectacularly, but we
aren't really worried about that (and arguably this code is much safer to
delete-create race deploying to 'the wrong app' since it uses id all the way
through for deploy all)

cleaned up error handling to only create functions, triggers, and apps if they
don't exist, not just if any error happens. saves some api calls when service
is down or something, but mostly it doesn't mask any errors from doing the
original get when it's not a not found error (things like permissions this
could be useful).

reduced api calls by one when a function doesn't exist (we don't need to go
get it after creating, the api returns it with the id filled in). /sarcasticwoo

* move app yaml deploy up to app get/create at the top of deploy, reduces
calls to get and create app and cleans up the code
* fix deploy of app.yaml logic error, this test was previously passing that
should have failed, because using an app.yaml meant incidentally that the app
would get created if necessary
* add additional tests to see that app.yaml deploy actually sets the config
and an additional test that it works for both create and update of an app
* cleaned up deploy to use app object code for cleanliness (error handling
improvements)
* make tests use test fatal facilities and not log package
