### PR TITLE
Make python relative imports work

### DIFF
--- a/langs/python.go
+++ b/langs/python.go
@@ -63,7 +63,7 @@ func (h *PythonLangHelper) RunFromImage() (string, error) {
 }
 
 func (h *PythonLangHelper) Entrypoint() (string, error) {
-	return "/python/bin/fdk /function/func.py handler", nil
+	return "/python/bin/fdk func.py handler", nil
 }
 
 func (h *PythonLangHelper) DockerfileBuildCmds() []string {
@@ -76,6 +76,9 @@ RUN pip3 install --target /python/  --no-cache --no-cache-dir -r requirements.tx
 
 	}
 	r = append(r, "ADD . /function/")
+	if exists("setup.py") {
+		r = append(r, "python setup.py install")
+	}
 	return r
 }
 
@@ -112,5 +115,6 @@ func (h *PythonLangHelper) DockerfileCopyCmds() []string {
 		"COPY --from=build-stage /function /function",
 		"COPY --from=build-stage /python /python",
 		"ENV PYTHONPATH=/python",
+		"WORKDIR /function",
 	}
 }


### PR DESCRIPTION
With an FDK update we changed an entrypoint, so, a user's code lives in /function folder within the final image

 People would still have an assumption that `import my_blah_module` would work where `my_blah_module`  is a side file to "func.py".
 However, that wouldn't work because the current folder is set to "/", but for the sake of good UX it has to be set to "/function".

 Side change:
 - support for native `setuptools`: if setup.py exists in function's folder
   there's a need to call it right after the dependencies installed (pip install -r requirements.txt);
   this is for developers who do redistributable wheel/egg functions
