### PR TITLE
Python function build improvements

### DIFF
--- a/langs/python.go
+++ b/langs/python.go
@@ -71,8 +71,8 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 	if exists("requirements.txt") {
 		pip_cmd := `RUN pip3 install --target /python/  --no-cache --no-cache-dir`
 		if exists(".pip_cache") {
-			r = append(r, "ADD .pip_cache /function/")
-			pip_cmd += " --find-links file:///function/.pip_cache"
+			r = append(r, "ADD .pip_cache /function/.pip_cache")
+			pip_cmd += " --no-index --find-links /function/.pip_cache"
 		}
 		r = append(r, "ADD requirements.txt /function/")
 		r = append(r, fmt.Sprintf(`

--- a/langs/python.go
+++ b/langs/python.go
@@ -75,7 +75,8 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 			pip_cmd += " --find-links file:///function/.pip_cache"
 		}
 		r = append(r, "ADD requirements.txt /function/")
-		r = append(r, fmt.Sprintf(`%v requirements.txt &&\
+		r = append(r, fmt.Sprintf(`
+			%v -r requirements.txt &&\
 			 rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv /function/.pip_cache`, pip_cmd))
 	}
 	r = append(r, "ADD . /function/")

--- a/langs/python.go
+++ b/langs/python.go
@@ -77,12 +77,14 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 		r = append(r, "ADD requirements.txt /function/")
 		r = append(r, fmt.Sprintf(`
 			%v -r requirements.txt &&\
-			 rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv /function/.pip_cache`, pip_cmd))
+			 rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv`, pip_cmd))
 	}
 	r = append(r, "ADD . /function/")
 	if exists("setup.py") {
 		r = append(r, "python setup.py install")
 	}
+	r = append(r, "RUN rm -fr /function/.pip_cache")
+
 	return r
 }
 

--- a/langs/python.go
+++ b/langs/python.go
@@ -69,11 +69,14 @@ func (h *PythonLangHelper) Entrypoint() (string, error) {
 func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 	var r []string
 	if exists("requirements.txt") {
+		pip_cmd := `RUN pip3 install --target /python/  --no-cache --no-cache-dir`
+		if exists(".pip_cache") {
+			r = append(r, "ADD .pip_cache /function/")
+			pip_cmd += " --find-links file:///function/.pip_cache"
+		}
 		r = append(r, "ADD requirements.txt /function/")
-		r = append(r, `
-RUN pip3 install --target /python/  --no-cache --no-cache-dir -r requirements.txt &&\
-    rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv`)
-
+		r = append(r, fmt.Sprintf(`%v requirements.txt &&\
+			 rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv /function/.pip_cache`, pip_cmd))
 	}
 	r = append(r, "ADD . /function/")
 	if exists("setup.py") {

--- a/langs/python.go
+++ b/langs/python.go
@@ -76,6 +76,9 @@ RUN pip3 install --target /python/  --no-cache --no-cache-dir -r requirements.tx
 
 	}
 	r = append(r, "ADD . /function/")
+	if exists("setup.py") {
+		r = append(r, "python setup.py install")
+	}
 	return r
 }
 


### PR DESCRIPTION
This PR contains two things:

1. `setup.py` - this change allows functions to be packaged as redistributable python libraries. So, there are 2 things: `requirements.txt` as a placeholder for all deps references and `setup.py` that sets up the whole project. With first Fn CLI installs all dependencies into python path, with the second one, Fn CLI will add function's packages/modules into python path as well.
No impact on current behaviour, backwards-compatible change.

2. `.pip_cache` - with this change, Fn CLI will allow developers to use cached dependencies during function's build, there are reasons for this: some python libs may be stored within corp. networks, some of the dependencies being developed locally and not yet published anywhere.
No impact on current behaviour, backwards-compatible change.

