### PR TITLE
clean up invoke output

### DIFF
--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -195,7 +195,6 @@ func outputNormal(output io.Writer, resp *http.Response, includeCallID bool) {
 	}
 
 	// at this point, it's not an fn error, so output function output as is
-	// TODO we should give users the option to see a status code too, like call id?
 
 	lcc := lastCharChecker{reader: body}
 	body = &lcc

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -117,9 +117,10 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 
 	err := client.Invoke(cl.provider, invokeURL, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
 	// we don't want to show the help message if invoke fails, just copy error to
-	// stderr but don't return the error from Invoke
+	// stderr but don't return the error from Invoke. also exit early here
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
 	}
 	return nil
 }

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -85,7 +85,6 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 		appName := c.Args().Get(0)
 		fnName := c.Args().Get(1)
 
-    
 		if appName == "" || fnName == "" {
 			return errors.New("missing app and function name")
 		}
@@ -116,5 +115,11 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 		}
 	}
 
-	return client.Invoke(cl.provider, invokeURL, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
+	err := client.Invoke(cl.provider, invokeURL, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
+	// we don't want to show the help message if invoke fails, just copy error to
+	// stderr but don't return the error from Invoke
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
+	return nil
 }

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -1,8 +1,13 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 
 	"errors"
 
@@ -16,7 +21,10 @@ import (
 )
 
 // FnInvokeEndpointAnnotation is the annotation that exposes the fn invoke endpoint as defined in models/fn.go
-const FnInvokeEndpointAnnotation = "fnproject.io/fn/invokeEndpoint"
+const (
+	FnInvokeEndpointAnnotation = "fnproject.io/fn/invokeEndpoint"
+	CallIDHeader               = "Fn-Call-Id"
+)
 
 type invokeCmd struct {
 	provider provider.Provider
@@ -30,16 +38,16 @@ var InvokeFnFlags = []cli.Flag{
 		Usage: "Specify the function invoke endpoint for this function, the app-name and func-name parameters will be ignored",
 	},
 	cli.StringFlag{
-		Name:  "method",
-		Usage: "Http method for function",
-	},
-	cli.StringFlag{
 		Name:  "content-type",
 		Usage: "The payload Content-Type for the function invocation.",
 	},
 	cli.BoolFlag{
 		Name:  "display-call-id",
 		Usage: "whether display call ID or not",
+	},
+	cli.StringFlag{
+		Name:  "output",
+		Usage: "Output format (json)",
 	},
 }
 
@@ -115,12 +123,100 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 		}
 	}
 
-	err := client.Invoke(cl.provider, invokeURL, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
-	// we don't want to show the help message if invoke fails, just copy error to
-	// stderr but don't return the error from Invoke. also exit early here
+	resp, err := client.Invoke(cl.provider,
+		client.InvokeRequest{
+			URL:         invokeURL,
+			Content:     content,
+			Env:         c.StringSlice("e"),
+			ContentType: contentType,
+		},
+	)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		return err
 	}
+	defer resp.Body.Close()
+
+	outputFormat := strings.ToLower(c.String("output"))
+	if outputFormat == "json" {
+		outputJSON(os.Stdout, resp)
+	} else {
+		outputNormal(os.Stdout, resp, c.Bool("display-call-id"))
+	}
+	// TODO we should have a 'raw' option to output the raw http request, it may be useful, idk
+
 	return nil
+}
+
+func outputJSON(output io.Writer, resp *http.Response) {
+	var b bytes.Buffer
+	// TODO this is lame
+	io.Copy(&b, resp.Body)
+
+	i := struct {
+		Body       string      `json:"body"`
+		Headers    http.Header `json:"headers"`
+		StatusCode int         `json:"status_code"`
+	}{
+		Body:       b.String(),
+		Headers:    resp.Header,
+		StatusCode: resp.StatusCode,
+	}
+
+	enc := json.NewEncoder(output)
+	enc.SetIndent("", "    ")
+	enc.Encode(i)
+}
+
+func outputNormal(output io.Writer, resp *http.Response, includeCallID bool) {
+	if cid, ok := resp.Header[CallIDHeader]; ok && includeCallID {
+		fmt.Fprint(output, fmt.Sprintf("Call ID: %v\n", cid[0]))
+	}
+
+	var body io.Reader = resp.Body
+	if resp.StatusCode >= 400 {
+		// if we don't get json, we need to buffer the input so that we can
+		// display the user's function output as it was...
+		var b bytes.Buffer
+		body = io.TeeReader(resp.Body, &b)
+
+		var msg struct {
+			Message string `json:"message"`
+		}
+		err := json.NewDecoder(body).Decode(&msg)
+		if err == nil && msg.Message != "" {
+			// this is likely from fn, so unravel this...
+			// TODO this should be stderr maybe? meh...
+			fmt.Fprintf(output, "Error invoking function. status: %v message: %v\n", resp.StatusCode, msg.Message)
+			return
+		}
+
+		// read anything written to buffer first, then copy out rest of body
+		body = io.MultiReader(&b, resp.Body)
+	}
+
+	// at this point, it's not an fn error, so output function output as is
+	// TODO we should give users the option to see a status code too, like call id?
+
+	lcc := lastCharChecker{reader: body}
+	body = &lcc
+	io.Copy(output, body)
+
+	// #1408 - flush stdout
+	if lcc.last != '\n' {
+		fmt.Fprintln(output)
+	}
+}
+
+// lastCharChecker wraps an io.Reader to return the last read character
+type lastCharChecker struct {
+	reader io.Reader
+	last   byte
+}
+
+func (l *lastCharChecker) Read(b []byte) (int, error) {
+	n, err := l.reader.Read(b)
+	if n > 0 {
+		l.last = b[n-1]
+	}
+	return n, err
 }

--- a/test/cli_invoke_test.go
+++ b/test/cli_invoke_test.go
@@ -16,7 +16,7 @@ func TestFnInvokeInvalidImage(t *testing.T) {
 	funcName1 := h.NewFuncName(appName1)
 	h.Fn("create", "app", appName1).AssertSuccess()
 	h.Fn("create", "function", appName1, funcName1, "foo/duffimage:0.0.1").AssertSuccess()
-	h.Fn("invoke", appName1, funcName1).AssertFailed()
+	h.Fn("invoke", appName1, funcName1).AssertStdoutContains("Failed to pull image")
 }
 
 func TestFnInvokeValidImage(t *testing.T) {


### PR DESCRIPTION
* no more async output catch (not a thing, at the moment)
* we can get fn errors that have a call id, so attempt to unwind them first
instead of just outputting them in json format. this should still output
user's function output even for non-200 responses the same, unless they use
the same json we do for errors which are non-empty, in which case adding some
window dressing from the cli doesn't seem horrible?
* adds a \n to the output of the cli invoke to make terminals more happy with it

below displays the issues we had previously where we were showing the full json
error from fn instead of unraveling it to show to the user, also we were
previously showing the help message if the function invoke returned >400,
which could denote a successful invocation that simply returns a >400 (from a
user perspective) - cleaned both of these up, and merged the errors into one
line instead of 2. I'm open to feedback on formatting the error, I'm tempted
to just do `Error invoking function: 504 Timed out` - open to other ideas.

master:

```
✗: cli invoke testapp hello
{"message":"Timed out"}

Fn: Error calling function: status 504

See 'fn <command> --help' for more information. Client version: 0.5.51
```

now:

```
✗: cli invoke testapp hello
Error invoking function. status: 504 message: Timed out
```

success output is the same:

```
 ✗: cli invoke testapp hello
{"message":"Hello World"}
```

except now if the function doesn't output a \n last, then the cli will, this
closes #1408 so that we play nice with the terminal