### PR TITLE
small fixes to deploy

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -224,7 +224,12 @@ func (p *deploycmd) deployAll(c *cli.Context, app *models.App) error {
 	if c.String("working-dir") != "" {
 		dir = c.String("working-dir")
 	} else {
-		dir = wd
+		// if we're in the context of an app, first arg is path to the function
+		path := c.Args().First()
+		if path != "" {
+			fmt.Printf("Deploying function at: /%s\n", path)
+		}
+		dir = filepath.Join(wd, path)
 	}
 
 	var funcFound bool

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -53,6 +53,9 @@ type Expects struct {
 
 // FuncFile defines the internal structure of a func.yaml/json/yml
 type FuncFile struct {
+	// just for posterity, this won't be set on old files, but we can check that
+	Schema_version int `yaml:"schema_version,omitempty" json:"schema_version,omitempty"`
+
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// Build params
@@ -208,9 +211,7 @@ func decodeFuncfileJSON(path string) (*FuncFile, error) {
 		return nil, fmt.Errorf("could not open %s for parsing. Error: %v", path, err)
 	}
 	ff := &FuncFile{}
-	// ff.Route = &fnmodels.Route{}
 	err = json.NewDecoder(f).Decode(ff)
-	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
@@ -221,7 +222,6 @@ func decodeFuncfileYAML(path string) (*FuncFile, error) {
 	}
 	ff := &FuncFile{}
 	err = yaml.Unmarshal(b, ff)
-	// ff := fff.MakeFuncFile()
 	return ff, err
 }
 
@@ -275,15 +275,22 @@ func LoadFuncFileV20180708(path string) (string, *FuncFileV20180708, error) {
 	return FindAndParseFuncFileV20180708(path)
 }
 
-func ParseFuncFileV20180708(path string) (*FuncFileV20180708, error) {
+func ParseFuncFileV20180708(path string) (ff *FuncFileV20180708, err error) {
 	ext := filepath.Ext(path)
 	switch ext {
 	case ".json":
-		return decodeFuncFileV20180708JSON(path)
+		ff, err = decodeFuncFileV20180708JSON(path)
 	case ".yaml", ".yml":
-		return decodeFuncFileV20180708YAML(path)
+		ff, err = decodeFuncFileV20180708YAML(path)
+	default:
+		return nil, errUnexpectedFileFormat
 	}
-	return nil, errUnexpectedFileFormat
+
+	if err == nil && ff.Schema_version != V20180708 {
+		// todo: we should maybe not assume this, but it's more useful than saying 'version mismatch' for users...
+		return nil, fmt.Errorf("unsupported func.yaml version, please use the migrate command to update your function metadata")
+	}
+	return ff, err
 }
 
 func decodeFuncFileV20180708JSON(path string) (*FuncFileV20180708, error) {

--- a/common/schema.go
+++ b/common/schema.go
@@ -8,7 +8,10 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-const LatestYamlVersion = 20180708
+const (
+	V20180708         = 20180708
+	LatestYamlVersion = V20180708
+)
 
 const V20180708Schema = `{
     "title": "V20180708 func file schema",

--- a/common/walker.go
+++ b/common/walker.go
@@ -41,7 +41,7 @@ func WalkFuncs(root string, walkFn walkFuncsFunc) error {
 	})
 }
 
-// WalkFuncs is similar to filepath.Walk except only returns func.yaml's (so on per function)
+// WalkFuncsV20180708 is similar to filepath.Walk except only returns func.yaml's (so on per function)
 func WalkFuncsV20180708(root string, walkFn walkFuncsFuncV20180708) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
* if a user deploys a single function in a directory with an app.yaml and a
func.yaml that doesn't supply a name, this will now be named `$PWD` rather
than `$appname-root`, just like any other function that doesn't supply a name
in its func.yaml
* if a user deploys all with a function in the root directory that does not
supply a name in its func.yaml, this will now be named `$PWD` rather than
`$appname-root`, just like any other function that doesn't supply a name in
its func.yaml
* deploy all was using `--dir` which was an undocumented flag to specify the
`--working-dir` (as far as I can tell), this now aligns with deploy's help and
deploy single to use `--working-dir` for deploy all
* doing one less file read of the func yaml on deploy single now to check
version, woo... moved version check into parse step for func files.

I believe the reason for the old behavior was for apps to be able to have a
root route `/` and have that as the default behavior when specifying no
function name in the app root directory - now that names and routes aren't
tangled into the same thing, and we weren't using that policy anymore anyway,
I think it makes sense to move to using the $PWD name when not specifying a
name in the func.yaml like we are everywhere else, for consistency if
anything.