### PR TITLE
this removes func format from everything

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -251,14 +251,13 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		//     The following fields are already in a.ff:
 		//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
 		//     Add the following from the init-image:
-		//         build, build_image, cmd, content_type, entrypoint, expects, format, headers, run_image, runtime
+		//         build, build_image, cmd, content_type, entrypoint, expects, headers, run_image, runtime
 		a.ff.Build = initFf.Build
 		a.ff.Build_image = initFf.BuildImage
 		a.ff.Cmd = initFf.Cmd
 		a.ff.Content_type = initFf.ContentType
 		a.ff.Entrypoint = initFf.Entrypoint
 		a.ff.Expects = initFf.Expects
-		a.ff.Format = initFf.Format
 		a.ff.Run_image = initFf.RunImage
 		a.ff.Runtime = initFf.Runtime
 
@@ -269,10 +268,6 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 		if c.String("entrypoint") != "" {
 			a.ff.Entrypoint = c.String("entrypoint")
-		}
-
-		if c.String("format") != "" {
-			a.ff.Format = c.String("format")
 		}
 
 		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ff); err != nil {
@@ -383,9 +378,6 @@ func (a *initFnCmd) generateBoilerplate(path, runtime string) error {
 
 func (a *initFnCmd) bindFn(fn *modelsV2.Fn) {
 	ff := a.ff
-	if fn.Format != "" {
-		ff.Format = fn.Format
-	}
 	if fn.Memory > 0 {
 		ff.Memory = fn.Memory
 	}
@@ -439,10 +431,6 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 			return err
 		}
 		fmt.Printf("Found %v function, assuming %v runtime.\n", helper.Runtime(), helper.Runtime())
-		//need to default this to default format to be backwards compatible. Might want to just not allow this anymore, fail here.
-		if c.String("format") == "" {
-			a.ff.Format = "default"
-		}
 	} else {
 		helper = langs.GetLangHelper(runtime)
 	}
@@ -464,8 +452,6 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 		}
 
 		a.ff.Runtime = runtime
-
-		a.ff.Format = "http-stream"
 
 		if c.Uint64("memory") == 0 {
 			a.ff.Memory = helper.CustomMemory()

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -71,7 +71,6 @@ type FuncFile struct {
 	Type        string                 `yaml:"type,omitempty" json:"type,omitempty"`
 	Memory      uint64                 `yaml:"memory,omitempty" json:"memory,omitempty"`
 	Cpus        string                 `yaml:"cpus,omitempty" json:"cpus,omitempty"`
-	Format      string                 `yaml:"format,omitempty" json:"format,omitempty"`
 	Timeout     *int32                 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
 	Path        string                 `yaml:"path,omitempty" json:"path,omitempty"`
 	Config      map[string]string      `yaml:"config,omitempty" json:"config,omitempty"`
@@ -94,7 +93,6 @@ type FuncFileV20180708 struct {
 	Cmd          string `yaml:"cmd,omitempty" json:"cmd,omitempty"`
 	Entrypoint   string `yaml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
 	Content_type string `yaml:"content_type,omitempty" json:"content_type,omitempty"`
-	Format       string `yaml:"format,omitempty" json:"format,omitempty"`
 	Type         string `yaml:"type,omitempty" json:"type,omitempty"`
 	Memory       uint64 `yaml:"memory,omitempty" json:"memory,omitempty"`
 	Timeout      *int32 `yaml:"timeout,omitempty" json:"timeout,omitempty"`

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -37,10 +37,6 @@ var FnFlags = []cli.Flag{
 		Name:  "config,c",
 		Usage: "Function configuration",
 	},
-	cli.StringFlag{
-		Name:  "format,f",
-		Usage: "Hot container IO format - can be one of: default, http, json or cloudevent (check FDK docs to see which are supported for the FDK in use.)",
-	},
 	cli.IntFlag{
 		Name:  "timeout",
 		Usage: "Function timeout (eg. 30)",
@@ -193,10 +189,6 @@ func WithFlags(c *cli.Context, fn *models.Fn) {
 	if i := c.String("image"); i != "" {
 		fn.Image = i
 	}
-	if f := c.String("format"); f != "" {
-		fn.Format = f
-	}
-
 	if m := c.Uint64("memory"); m > 0 {
 		fn.Memory = m
 	}
@@ -228,11 +220,6 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 	if ff.ImageNameV20180708() != "" { // args take precedence
 		fn.Image = ff.ImageNameV20180708()
 	}
-
-	if ff.Format != "" {
-		fn.Format = ff.Format
-	}
-
 	if ff.Timeout != nil {
 		fn.Timeout = ff.Timeout
 	}

--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -15,10 +15,10 @@ var Runtimes = []struct {
 	{"java", ""},
 	{"java8", ""},
 	{"java11", ""},
-	{"kotlin", `{"name": "John"}`}, //  no arg fn run is broken https://github.com/fnproject/cli/issues/262
+	{"kotlin", ""},
 	{"node", ""},
 	{"ruby", ""},
-	{"python", `{"name": "John"}`},
+	{"python", ""},
 }
 
 func TestFnInitWithBoilerplateBuildsRuns(t *testing.T) {


### PR DESCRIPTION
format is dead now, so we can remove all the flags and docs about it here.

technically, we should preserve this in old functions format to migrate,
however since there's no field to migrate to, it doesn't seem worth the
cognitive baggage?

there's a test that all our runtimes work off our generated func.yaml and
boilerplate, so that should prove that this change is ok.