### PR TITLE
Adding Python 3.6 support

### DIFF
--- a/langs/base.go
+++ b/langs/base.go
@@ -14,6 +14,7 @@ func init() {
 	registerHelper(&JavaLangHelper{version: "8"})
 	registerHelper(&JavaLangHelper{version: "11"})
 	registerHelper(&NodeLangHelper{})
+	registerHelper(&PythonLangHelper{Version: "3.6"})
 	registerHelper(&PythonLangHelper{Version: "3.7.1"})
 	registerHelper(&RubyLangHelper{})
 	registerHelper(&KotlinLangHelper{})


### PR DESCRIPTION
New Python FDK (version 0.1.3) supports Python 3.5.2+ and we already have Python 3.6 images (`fnproject/python:3.6-dev` and `fnproject/python:3.6`).
There are no objects to get Python 3.6 support for the CLI, boilerplate and the base images.
