### PR TITLE
Revert "clean up invoke output (#538)"

### DIFF
--- a/client/invoke.go
+++ b/client/invoke.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -10,6 +13,11 @@ import (
 
 	"github.com/fnproject/fn_go/provider"
 	"github.com/go-openapi/runtime/logger"
+)
+
+const (
+	FN_CALL_ID             = "Fn-Call-Id"
+	MaximumRequestBodySize = 5 * 1024 * 1024 // bytes
 )
 
 func EnvAsHeader(req *http.Request, selectedEnv []string) {
@@ -25,26 +33,35 @@ func EnvAsHeader(req *http.Request, selectedEnv []string) {
 	}
 }
 
-// InvokeRequest are the parameters provided to Invoke
-type InvokeRequest struct {
-	URL         string
-	Content     io.Reader
-	Env         []string
-	ContentType string
-	// TODO headers should be their real type?
+type apiErr struct {
+	Message string `json:"message"`
 }
 
-// Invoke calls the fn invoke API
-func Invoke(provider provider.Provider, ireq InvokeRequest) (*http.Response, error) {
-	invokeURL := ireq.URL
-	content := ireq.Content
-	env := ireq.Env
-	contentType := ireq.ContentType
-	method := "POST"
+type callID struct {
+	CallID string `json:"call_id"`
+	Error  apiErr `json:"error"`
+}
 
-	req, err := http.NewRequest(method, invokeURL, content)
-	if err != nil {
-		return nil, fmt.Errorf("Error creating request to service: %s", err)
+func Invoke(provider provider.Provider, invokeUrl string, content io.Reader, output io.Writer, method string, env []string, contentType string, includeCallID bool) error {
+
+	method = "POST"
+
+	// Read the request body (up to the maximum size), as this is used in the
+	// authentication signature
+	var req *http.Request
+	if content != nil {
+		b, err := ioutil.ReadAll(io.LimitReader(content, MaximumRequestBodySize))
+		buffer := bytes.NewBuffer(b)
+		req, err = http.NewRequest(method, invokeUrl, buffer)
+		if err != nil {
+			return fmt.Errorf("Error creating request to service: %s", err)
+		}
+	} else {
+		var err error
+		req, err = http.NewRequest(method, invokeUrl, nil)
+		if err != nil {
+			return fmt.Errorf("Error creating request to service: %s", err)
+		}
 	}
 
 	if contentType != "" {
@@ -63,25 +80,54 @@ func Invoke(provider provider.Provider, ireq InvokeRequest) (*http.Response, err
 	if logger.DebugEnabled() {
 		b, err := httputil.DumpRequestOut(req, content != nil)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error dumping req", err)
+			return err
 		}
-		os.Stderr.Write(b)
-		fmt.Fprintln(os.Stderr)
+		fmt.Printf(string(b) + "\n")
 	}
 
 	resp, err := httpClient.Do(req)
+
 	if err != nil {
-		return nil, fmt.Errorf("Error invoking function: %s", err)
+		return fmt.Errorf("Error invoking fn: %s", err)
 	}
 
 	if logger.DebugEnabled() {
 		b, err := httputil.DumpResponse(resp, true)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error dumping resp", err)
+			return err
 		}
-		os.Stderr.Write(b)
-		fmt.Fprintln(os.Stderr)
+		fmt.Printf(string(b) + "\n")
 	}
 
-	return resp, nil
+	// for sync calls
+	if call_id, found := resp.Header[FN_CALL_ID]; found {
+		if includeCallID {
+			fmt.Fprint(os.Stderr, fmt.Sprintf("Call ID: %v\n", call_id[0]))
+		}
+		io.Copy(output, resp.Body)
+	} else {
+		// for async calls and error discovering
+		c := &callID{}
+		err = json.NewDecoder(resp.Body).Decode(c)
+		if err == nil {
+			// decode would not fail in both cases:
+			// - call id in body
+			// - error in body
+			// that's why we need to check values of attributes
+			if c.CallID != "" {
+				fmt.Fprint(os.Stderr, fmt.Sprintf("Call ID: %v\n", c.CallID))
+			} else {
+				fmt.Fprint(output, fmt.Sprintf("Error: %v\n", c.Error.Message))
+			}
+		} else {
+			return err
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		// TODO: parse out error message
+		return fmt.Errorf("Error calling function: status %v", resp.StatusCode)
+	}
+
+	return nil
 }

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -1,13 +1,8 @@
 package commands
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"strings"
 
 	"errors"
 
@@ -21,10 +16,7 @@ import (
 )
 
 // FnInvokeEndpointAnnotation is the annotation that exposes the fn invoke endpoint as defined in models/fn.go
-const (
-	FnInvokeEndpointAnnotation = "fnproject.io/fn/invokeEndpoint"
-	CallIDHeader               = "Fn-Call-Id"
-)
+const FnInvokeEndpointAnnotation = "fnproject.io/fn/invokeEndpoint"
 
 type invokeCmd struct {
 	provider provider.Provider
@@ -38,16 +30,16 @@ var InvokeFnFlags = []cli.Flag{
 		Usage: "Specify the function invoke endpoint for this function, the app-name and func-name parameters will be ignored",
 	},
 	cli.StringFlag{
+		Name:  "method",
+		Usage: "Http method for function",
+	},
+	cli.StringFlag{
 		Name:  "content-type",
 		Usage: "The payload Content-Type for the function invocation.",
 	},
 	cli.BoolFlag{
 		Name:  "display-call-id",
 		Usage: "whether display call ID or not",
-	},
-	cli.StringFlag{
-		Name:  "output",
-		Usage: "Output format (json)",
 	},
 }
 
@@ -93,6 +85,7 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 		appName := c.Args().Get(0)
 		fnName := c.Args().Get(1)
 
+    
 		if appName == "" || fnName == "" {
 			return errors.New("missing app and function name")
 		}
@@ -123,99 +116,5 @@ func (cl *invokeCmd) Invoke(c *cli.Context) error {
 		}
 	}
 
-	resp, err := client.Invoke(cl.provider,
-		client.InvokeRequest{
-			URL:         invokeURL,
-			Content:     content,
-			Env:         c.StringSlice("e"),
-			ContentType: contentType,
-		},
-	)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	outputFormat := strings.ToLower(c.String("output"))
-	if outputFormat == "json" {
-		outputJSON(os.Stdout, resp)
-	} else {
-		outputNormal(os.Stdout, resp, c.Bool("display-call-id"))
-	}
-	// TODO we should have a 'raw' option to output the raw http request, it may be useful, idk
-
-	return nil
-}
-
-func outputJSON(output io.Writer, resp *http.Response) {
-	var b bytes.Buffer
-	// TODO this is lame
-	io.Copy(&b, resp.Body)
-
-	i := struct {
-		Body       string      `json:"body"`
-		Headers    http.Header `json:"headers"`
-		StatusCode int         `json:"status_code"`
-	}{
-		Body:       b.String(),
-		Headers:    resp.Header,
-		StatusCode: resp.StatusCode,
-	}
-
-	enc := json.NewEncoder(output)
-	enc.SetIndent("", "    ")
-	enc.Encode(i)
-}
-
-func outputNormal(output io.Writer, resp *http.Response, includeCallID bool) {
-	if cid, ok := resp.Header[CallIDHeader]; ok && includeCallID {
-		fmt.Fprint(output, fmt.Sprintf("Call ID: %v\n", cid[0]))
-	}
-
-	var body io.Reader = resp.Body
-	if resp.StatusCode >= 400 {
-		// if we don't get json, we need to buffer the input so that we can
-		// display the user's function output as it was...
-		var b bytes.Buffer
-		body = io.TeeReader(resp.Body, &b)
-
-		var msg struct {
-			Message string `json:"message"`
-		}
-		err := json.NewDecoder(body).Decode(&msg)
-		if err == nil && msg.Message != "" {
-			// this is likely from fn, so unravel this...
-			// TODO this should be stderr maybe? meh...
-			fmt.Fprintf(output, "Error invoking function. status: %v message: %v\n", resp.StatusCode, msg.Message)
-			return
-		}
-
-		// read anything written to buffer first, then copy out rest of body
-		body = io.MultiReader(&b, resp.Body)
-	}
-
-	// at this point, it's not an fn error, so output function output as is
-
-	lcc := lastCharChecker{reader: body}
-	body = &lcc
-	io.Copy(output, body)
-
-	// #1408 - flush stdout
-	if lcc.last != '\n' {
-		fmt.Fprintln(output)
-	}
-}
-
-// lastCharChecker wraps an io.Reader to return the last read character
-type lastCharChecker struct {
-	reader io.Reader
-	last   byte
-}
-
-func (l *lastCharChecker) Read(b []byte) (int, error) {
-	n, err := l.reader.Read(b)
-	if n > 0 {
-		l.last = b[n-1]
-	}
-	return n, err
+	return client.Invoke(cl.provider, invokeURL, content, os.Stdout, c.String("method"), c.StringSlice("e"), contentType, c.Bool("display-call-id"))
 }

--- a/test/cli_invoke_test.go
+++ b/test/cli_invoke_test.go
@@ -16,7 +16,7 @@ func TestFnInvokeInvalidImage(t *testing.T) {
 	funcName1 := h.NewFuncName(appName1)
 	h.Fn("create", "app", appName1).AssertSuccess()
 	h.Fn("create", "function", appName1, funcName1, "foo/duffimage:0.0.1").AssertSuccess()
-	h.Fn("invoke", appName1, funcName1).AssertStdoutContains("Failed to pull image")
+	h.Fn("invoke", appName1, funcName1).AssertFailed()
 }
 
 func TestFnInvokeValidImage(t *testing.T) {


### PR DESCRIPTION
This reverts commit ce8ab8a531678b4c62aa7ab86df9a564c0e4eb41. The changes in the commit caused invokes with a payload to fail with 401 Not Authenticated. Initial investigation seems to show the body might not be getting sent correctly. Without the offending commit, `echo -n '{name: foo}' | DEBUG=1 fn invoke harry-test hello` shows `{name: foo}` as the body of the request in the debug output. With the changes in the commit, the same CLI command shows
```
b
{name: foo}
0

``` 
as the body in the debug output. Reverting the commit for now until the issue is fixed.