### PR TITLE
Invoke refix

### DIFF
--- a/test/cli_invoke_test.go
+++ b/test/cli_invoke_test.go
@@ -16,7 +16,7 @@ func TestFnInvokeInvalidImage(t *testing.T) {
 	funcName1 := h.NewFuncName(appName1)
 	h.Fn("create", "app", appName1).AssertSuccess()
 	h.Fn("create", "function", appName1, funcName1, "foo/duffimage:0.0.1").AssertSuccess()
-	h.Fn("invoke", appName1, funcName1).AssertFailed()
+	h.Fn("invoke", appName1, funcName1).AssertStdoutContains("Failed to pull image")
 }
 
 func TestFnInvokeValidImage(t *testing.T) {


### PR DESCRIPTION
this is the same as #538 except for a fix that copies all of stdin before
creating the request, to appease the oci request signing code as it expects
content length to be set and will not set it itself after reading the body. the
commits are split to make it easy to see the change.

this fixes #552 