### PR TITLE
Fix: adding ability to update function's image

### DIFF
--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -49,6 +49,10 @@ var FnFlags = []cli.Flag{
 		Name:  "annotation",
 		Usage: "Function annotation (can be specified multiple times)",
 	},
+	cli.StringFlag{
+		Name:  "image",
+		Usage: "Function image",
+	},
 }
 var updateFnFlags = FnFlags
 


### PR DESCRIPTION
Before this commit, the CLI provided almost all Fn model attributes except function's image. Meaning that users weren't able to update function with another image using:
```
    $ fn update fn
```

Before:
```
fn update fn -h

MANAGEMENT COMMAND
  fn update function - Update a function in application
    
USAGE
  fn [global options] update function [command options] <app-name> <function-name> 
    
DESCRIPTION
  This command updates a function in an application.
    
COMMAND OPTIONS
  --memory value, -m value  Memory in MiB (default: 0)
  --config value, -c value  Function configuration
  --timeout value           Function timeout (eg. 30) (default: 0)
  --idle-timeout value      Function idle timeout (eg. 30) (default: 0)
  --annotation value        Function annotation (can be specified multiple times)
```

Now:
```
fn update fn -h

MANAGEMENT COMMAND
  fn update function - Update a function in application

USAGE
  fn [global options] update function [command options] <app-name> <function-name>

DESCRIPTION
  This command updates a function in an application.

COMMAND OPTIONS
  --memory value, -m value  Memory in MiB (default: 0)
  --config value, -c value  Function configuration
  --timeout value           Function timeout (eg. 30) (default: 0)
  --idle-timeout value      Function idle timeout (eg. 30) (default: 0)
  --annotation value        Function annotation (can be specified multiple times)
  --image value             Function image

```

Fix by itself is very trivial, because all necessary code is already there, the only thing that was missing is the CLI option.
