### PR TITLE
Alias 'fn delete config' to 'fn unset config' (#454)

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -77,7 +77,7 @@ var DeleteCmds = Cmd{
 	"functions": fn.Delete(),
 	"context":   context.Delete(),
 	"triggers":  trigger.Delete(),
-	"config":    ConfigCommand("unset"),
+	"config":    ConfigCommand("delete"),
 }
 
 var GetCmds = Cmd{

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -77,6 +77,7 @@ var DeleteCmds = Cmd{
 	"functions": fn.Delete(),
 	"context":   context.Delete(),
 	"triggers":  trigger.Delete(),
+	"config":    ConfigCommand("unset"),
 }
 
 var GetCmds = Cmd{

--- a/commands/config.go
+++ b/commands/config.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/fnproject/cli/common"
 	"github.com/urfave/cli"
 )
@@ -15,14 +17,16 @@ func ConfigCommand(command string) cli.Command {
 		cmds = GetCommands(ConfigGetCmds)
 	case "configure":
 		cmds = GetCommands(ConfigCmds)
-	case "unset":
+	case "unset", "delete":
 		cmds = GetCommands(ConfigUnsetCmds)
 	}
+
+	usage := strings.Title(command) + " configurations for apps and functions"
 
 	return cli.Command{
 		Name:         "config",
 		ShortName:    "config",
-		Usage:        "Manage configurations for apps and functions",
+		Usage:        usage,
 		Aliases:      []string{"cf"},
 		ArgsUsage:    "<subcommand>",
 		Description:  "This command unsets the configuration of created objects ('app' or 'function').",


### PR DESCRIPTION
Users expect to be able to delete configs using 'fn delete'. Therefore alias the command so they can use either way.

### Link to issue this resolves

Fixes #454 

### What I did
Added an alias to the Config Unset command when someone runs `fn delete`

### How to verify it

* Create an app called `myApp` using the CLI and then:

```
# Add a config
fn config app myApp COMPLETER_BASE_URL "http://127.0.0.1:8081"

# Check it's been added
fn list config app myApp

# Delete the config using the new functionality
fn delete config app myApp COMPLETER_BASE_URL

# Check it's been deleted
fn list config app myApp
```

```
# Ensure documentation is in place
fn delete config --help
```

### One line description for the changelog

> Alias 'fn delete config' to 'fn unset config' 

### Question

The contribution guidelines say to update the [docs](https://github.com/fnproject/docs). These don't seem to have been touched for quite a while. Do you still need me to manually update [fn-delete.md](https://github.com/fnproject/docs/blob/master/cli/ref/fn-delete.md) or will this be done automatically (or by someone else)?