### PR TITLE
test init for all python versions

### DIFF
--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -19,6 +19,8 @@ var Runtimes = []struct {
 	{"node", ""},
 	{"ruby", ""},
 	{"python", ""},
+	{"python3.6", ""},
+	{"python3.7.1", ""},
 }
 
 func TestFnInitWithBoilerplateBuildsRuns(t *testing.T) {


### PR DESCRIPTION
add `python3.6` and `python3.7.1` to cli boilerplate tests