### PR TITLE
Feature: cascading deletion of resources Fixes issue #333

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ data/
 .idea/
 **/*.iml
 **/.DS_Store
-/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/
 .idea/
 **/*.iml
 **/.DS_Store
+/vendor

--- a/common/common.go
+++ b/common/common.go
@@ -600,8 +600,8 @@ func GetFuncYamlVersion(oldFF map[string]interface{}) int {
 	return 1
 }
 
-// UserConfirmedMultiResourceDeleteion will prompt the user for confirmation to delete all the the resources
-func UserConfirmedMultiResourceDeleteion(aps []*modelsv2.App, fns []*modelsv2.Fn, trs []*modelsv2.Trigger) bool {
+// UserConfirmedMultiResourceDeletion will prompt the user for confirmation to delete all the the resources
+func UserConfirmedMultiResourceDeletion(aps []*modelsv2.App, fns []*modelsv2.Fn, trs []*modelsv2.Trigger) bool {
 
 	apsLen := len(aps)
 	fnsLen := len(fns)
@@ -621,20 +621,21 @@ func UserConfirmedMultiResourceDeleteion(aps []*modelsv2.App, fns []*modelsv2.Fn
 	fmt.Printf("Do you wish to proceed? Y/N: ")
 	reader := bufio.NewReader(os.Stdin)
 	input, _ := reader.ReadString('\n')
-	if strings.ToLower(input) == "y\n" {
+	input = strings.TrimSpace(input)
+	if strings.ToLower(input) == "y" {
 		return true
-	} else if strings.ToLower(input) == "n\n" {
+	} else if strings.ToLower(input) == "n" {
 		fmt.Println("Cancelling delete")
 		return false
 	} else {
-		fmt.Println("Unrecognised input, should be y/n")
+		fmt.Println("Unrecognised input, should be Y/N")
 		fmt.Println("Cancelling delete")
 		return false
 	}
 	return true
 }
 
-// ListFnsAndTriggersInApp lists all the fucntions associated with an app and all the triggers associated with each of those functions
+// ListFnsAndTriggersInApp lists all the functions associated with an app and all the triggers associated with each of those functions
 func ListFnsAndTriggersInApp(c *cli.Context, client *fnclient.Fn, app *modelsv2.App) ([]*modelsv2.Fn, []*modelsv2.Trigger, error) {
 	fns, err := ListFnsInApp(c, client, app)
 	if err != nil {

--- a/common/common.go
+++ b/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,14 +18,17 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/spf13/viper"
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/coreos/go-semver/semver"
 	"github.com/fatih/color"
 	"github.com/fnproject/cli/config"
 	"github.com/fnproject/cli/langs"
+	fnclient "github.com/fnproject/fn_go/clientv2"
+	apifns "github.com/fnproject/fn_go/clientv2/fns"
+	apitriggers "github.com/fnproject/fn_go/clientv2/triggers"
+	"github.com/fnproject/fn_go/modelsv2"
+	"github.com/spf13/viper"
 	"github.com/urfave/cli"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Global docker variables.
@@ -594,4 +598,143 @@ func GetFuncYamlVersion(oldFF map[string]interface{}) int {
 		return oldFF["schema_version"].(int)
 	}
 	return 1
+}
+
+// UserConfirmedMultiResourceDeleteion will prompt the user for confirmation to delete all the the resources
+func UserConfirmedMultiResourceDeleteion(aps []*modelsv2.App, fns []*modelsv2.Fn, trs []*modelsv2.Trigger) bool {
+
+	apsLen := len(aps)
+	fnsLen := len(fns)
+	trsLen := len(trs)
+
+	fmt.Println("You are about to delete the following resources:")
+	if apsLen > 0 {
+		fmt.Println("   Applications:", apsLen)
+	}
+	if fnsLen > 0 {
+		fmt.Println("   Functions:   ", fnsLen)
+	}
+	if trsLen > 0 {
+		fmt.Println("   Triggers:    ", trsLen)
+	}
+	fmt.Println("This operation cannot be undone")
+	fmt.Printf("Do you wish to proceed? Y/N: ")
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	if strings.ToLower(input) == "y\n" {
+		return true
+	} else if strings.ToLower(input) == "n\n" {
+		fmt.Println("Cancelling delete")
+		return false
+	} else {
+		fmt.Println("Unrecognised input, should be y/n")
+		fmt.Println("Cancelling delete")
+		return false
+	}
+	return true
+}
+
+// ListFnsAndTriggersInApp lists all the fucntions associated with an app and all the triggers associated with each of those functions
+func ListFnsAndTriggersInApp(c *cli.Context, client *fnclient.Fn, app *modelsv2.App) ([]*modelsv2.Fn, []*modelsv2.Trigger, error) {
+	fns, err := ListFnsInApp(c, client, app)
+	if err != nil {
+		return nil, nil, err
+	}
+	var trs []*modelsv2.Trigger
+	for _, fn := range fns {
+		t, err := ListTriggersInFunc(c, client, fn)
+		if err != nil {
+			return nil, nil, err
+		}
+		trs = append(trs, t...)
+	}
+	return fns, trs, nil
+}
+
+//DeleteFunctions deletes all the functions provided to it. if provided nil it is a no-op
+func DeleteFunctions(c *cli.Context, client *fnclient.Fn, fns []*modelsv2.Fn) error {
+	if fns == nil {
+		return nil
+	}
+	for _, fn := range fns {
+		params := apifns.NewDeleteFnParams()
+		params.FnID = fn.ID
+		_, err := client.Fns.DeleteFn(params)
+		if err != nil {
+			return fmt.Errorf("Failed to delete Function %s: %s", fn.Name, err)
+		}
+		fmt.Println("Function ", fn.Name, " deleted")
+	}
+	return nil
+}
+
+//DeleteTriggers deletes all the triggers provided to it. if provided nil it is a no-op
+func DeleteTriggers(c *cli.Context, client *fnclient.Fn, triggers []*modelsv2.Trigger) error {
+	if triggers == nil {
+		return nil
+	}
+	for _, t := range triggers {
+		params := apitriggers.NewDeleteTriggerParams()
+		params.TriggerID = t.ID
+		_, err := client.Triggers.DeleteTrigger(params)
+		if err != nil {
+			return fmt.Errorf("Failed to Delete trigger %s: %s", t.Name, err)
+		}
+		fmt.Println("Trigger ", t.Name, " deleted")
+	}
+	return nil
+}
+
+//ListFnsInApp gets all the functions associated with an app
+func ListFnsInApp(c *cli.Context, client *fnclient.Fn, app *modelsv2.App) ([]*modelsv2.Fn, error) {
+	params := &apifns.ListFnsParams{
+		Context: context.Background(),
+		AppID:   &app.ID,
+	}
+
+	var resFns []*modelsv2.Fn
+	for {
+		resp, err := client.Fns.ListFns(params)
+
+		if err != nil {
+			return nil, fmt.Errorf("Could not list functions in application %s: %s", app.Name, err)
+		}
+		n := c.Int64("n")
+
+		resFns = append(resFns, resp.Payload.Items...)
+		howManyMore := n - int64(len(resFns)+len(resp.Payload.Items))
+		if howManyMore <= 0 || resp.Payload.NextCursor == "" {
+			break
+		}
+
+		params.Cursor = &resp.Payload.NextCursor
+	}
+
+	return resFns, nil
+}
+
+//ListTriggersInFunc gets all the triggers associated with a function
+func ListTriggersInFunc(c *cli.Context, client *fnclient.Fn, fn *modelsv2.Fn) ([]*modelsv2.Trigger, error) {
+	params := &apitriggers.ListTriggersParams{
+		Context: context.Background(),
+		AppID:   &fn.AppID,
+		FnID:    &fn.ID,
+	}
+
+	var resTriggers []*modelsv2.Trigger
+	for {
+		resp, err := client.Triggers.ListTriggers(params)
+		if err != nil {
+			return nil, fmt.Errorf("Could not list triggers in function %s: %s", fn.Name, err)
+		}
+		n := c.Int64("n")
+
+		resTriggers = append(resTriggers, resp.Payload.Items...)
+		howManyMore := n - int64(len(resTriggers)+len(resp.Payload.Items))
+		if howManyMore <= 0 || resp.Payload.NextCursor == "" {
+			break
+		}
+		params.Cursor = &resp.Payload.NextCursor
+	}
+	return resTriggers, nil
 }

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -329,7 +329,7 @@ func (a *appsCmd) delete(c *cli.Context) error {
 		if c.Bool("force") {
 			shouldContinue = true
 		} else {
-			shouldContinue = common.UserConfirmedMultiResourceDeleteion([]*modelsv2.App{app}, fns, triggers)
+			shouldContinue = common.UserConfirmedMultiResourceDeletion([]*modelsv2.App{app}, fns, triggers)
 		}
 
 		if shouldContinue {

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -317,8 +317,8 @@ func (a *appsCmd) delete(c *cli.Context) error {
 		return err
 	}
 
-	//Cascading delete of sub-objects
-	if c.Bool("cascade") {
+	//recursive delete of sub-objects
+	if c.Bool("recursive") {
 		fns, triggers, err := common.ListFnsAndTriggersInApp(c, a.client, app)
 		if err != nil {
 			return fmt.Errorf("Failed to get associated objects: %s", err)

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,10 +12,9 @@ import (
 
 	"github.com/fnproject/cli/client"
 	"github.com/fnproject/cli/common"
+
 	fnclient "github.com/fnproject/fn_go/clientv2"
 	apiapps "github.com/fnproject/fn_go/clientv2/apps"
-	apifns "github.com/fnproject/fn_go/clientv2/fns"
-	apitriggers "github.com/fnproject/fn_go/clientv2/triggers"
 	"github.com/fnproject/fn_go/modelsv2"
 	"github.com/fnproject/fn_go/provider"
 	"github.com/jmoiron/jsonq"
@@ -319,15 +317,30 @@ func (a *appsCmd) delete(c *cli.Context) error {
 		return err
 	}
 
-	if c.Bool("f") {
-
-		fns, triggers, err := getAssociatedResources(c, a.client, app)
+	//Cascading delete of sub-objects
+	if c.Bool("cascade") {
+		fns, triggers, err := common.ListFnsAndTriggersInApp(c, a.client, app)
 		if err != nil {
 			return fmt.Errorf("Failed to get associated objects: %s", err)
 		}
-		if userConfirmedRecursiveAppDeleteion(fns, triggers) {
-			deleteTriggers(c, a.client, triggers)
-			deleteFunctions(c, a.client, fns)
+
+		//Forced deletion
+		var shouldContinue bool
+		if c.Bool("force") {
+			shouldContinue = true
+		} else {
+			shouldContinue = common.UserConfirmedMultiResourceDeleteion([]*modelsv2.App{app}, fns, triggers)
+		}
+
+		if shouldContinue {
+			err := common.DeleteTriggers(c, a.client, triggers)
+			if err != nil {
+				return fmt.Errorf("Failed to delete associated objects: %s", err)
+			}
+			err = common.DeleteFunctions(c, a.client, fns)
+			if err != nil {
+				return fmt.Errorf("Failed to delete associated objects: %s", err)
+			}
 		} else {
 			return nil
 		}
@@ -396,128 +409,4 @@ func GetAppByName(client *fnclient.Fn, appName string) (*modelsv2.App, error) {
 	}
 
 	return app, nil
-}
-
-func getAssociatedResources(c *cli.Context, client *fnclient.Fn, app *modelsv2.App) ([]*modelsv2.Fn, []*modelsv2.Trigger, error) {
-	fns, err := listFnsInApp(c, client, app)
-	if err != nil {
-		return nil, nil, err
-	}
-	var trs []*modelsv2.Trigger
-	for _, fn := range fns {
-		t, err := listTriggersInFunc(c, client, fn)
-		if err != nil {
-			return nil, nil, err
-		}
-		trs = append(trs, t...)
-	}
-	return fns, trs, nil
-}
-
-func userConfirmedRecursiveAppDeleteion(fns []*modelsv2.Fn, trs []*modelsv2.Trigger) bool {
-	if len(fns) > 0 {
-		fmt.Println("You are about to delete the following resources:")
-		fmt.Println("   Applications: 1")
-		fmt.Println("   Functions:   ", len(fns))
-		fmt.Println("   Triggers:    ", len(trs))
-		fmt.Println("This operation cannot be undone")
-		fmt.Printf("Do you wish to proceed? Y/N: ")
-		reader := bufio.NewReader(os.Stdin)
-		input, _ := reader.ReadString('\n')
-		if strings.ToLower(input) == "y\n" {
-			return true
-		} else if strings.ToLower(input) == "n\n" {
-			fmt.Println("Cancelling delete")
-			return false
-		} else {
-			fmt.Println("Unrecognised input, should be Y/N")
-			fmt.Println("Cancelling delete")
-			return false
-		}
-	}
-	return true
-}
-
-func deleteFunctions(c *cli.Context, client *fnclient.Fn, fns []*modelsv2.Fn) error {
-	if fns == nil {
-		return nil
-	}
-	for _, fn := range fns {
-		params := apifns.NewDeleteFnParams()
-		params.FnID = fn.ID
-		_, err := client.Fns.DeleteFn(params)
-		if err != nil {
-			return fmt.Errorf("Failed to delete Function %s: %s", fn.Name, err)
-		}
-		fmt.Println("Function ", fn.Name, " deleted")
-	}
-	return nil
-}
-
-func deleteTriggers(c *cli.Context, client *fnclient.Fn, triggers []*modelsv2.Trigger) error {
-	if triggers == nil {
-		return nil
-	}
-	for _, t := range triggers {
-		params := apitriggers.NewDeleteTriggerParams()
-		params.TriggerID = t.ID
-		_, err := client.Triggers.DeleteTrigger(params)
-		if err != nil {
-			return fmt.Errorf("Failed to Delete trigger %s: %s", t.Name, err)
-		}
-		fmt.Println("Trigger ", t.Name, " deleted")
-	}
-	return nil
-}
-
-func listFnsInApp(c *cli.Context, client *fnclient.Fn, app *modelsv2.App) ([]*modelsv2.Fn, error) {
-	params := &apifns.ListFnsParams{
-		Context: context.Background(),
-		AppID:   &app.ID,
-	}
-
-	var resFns []*modelsv2.Fn
-	for {
-		resp, err := client.Fns.ListFns(params)
-
-		if err != nil {
-			return nil, fmt.Errorf("Could not list functions in App %s: %s", app.Name, err)
-		}
-		n := c.Int64("n")
-
-		resFns = append(resFns, resp.Payload.Items...)
-		howManyMore := n - int64(len(resFns)+len(resp.Payload.Items))
-		if howManyMore <= 0 || resp.Payload.NextCursor == "" {
-			break
-		}
-
-		params.Cursor = &resp.Payload.NextCursor
-	}
-
-	return resFns, nil
-}
-
-func listTriggersInFunc(c *cli.Context, client *fnclient.Fn, fn *modelsv2.Fn) ([]*modelsv2.Trigger, error) {
-	params := &apitriggers.ListTriggersParams{
-		Context: context.Background(),
-		AppID:   &fn.AppID,
-		FnID:    &fn.ID,
-	}
-
-	var resTriggers []*modelsv2.Trigger
-	for {
-		resp, err := client.Triggers.ListTriggers(params)
-		if err != nil {
-			return nil, fmt.Errorf("Could not list Triggers in Function %s: %s", fn.Name, err)
-		}
-		n := c.Int64("n")
-
-		resTriggers = append(resTriggers, resp.Payload.Items...)
-		howManyMore := n - int64(len(resTriggers)+len(resp.Payload.Items))
-		if howManyMore <= 0 || resp.Payload.NextCursor == "" {
-			break
-		}
-		params.Cursor = &resp.Payload.NextCursor
-	}
-	return resTriggers, nil
 }

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -105,10 +105,16 @@ func Delete() cli.Command {
 				BashCompleteApps(c)
 			}
 		},
-		Flags: []cli.Flag{cli.BoolFlag{
-			Name:  "force, f",
-			Usage: "Delete this app and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
-		}},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "force, f",
+				Usage: "Forces this delete (you will not be asked if you wish to continue with the delete)",
+			},
+			cli.BoolFlag{
+				Name:  "cascade, c",
+				Usage: "Delete this app and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
+			},
+		},
 	}
 }
 

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -111,7 +111,7 @@ func Delete() cli.Command {
 				Usage: "Forces this delete (you will not be asked if you wish to continue with the delete)",
 			},
 			cli.BoolFlag{
-				Name:  "cascade, c",
+				Name:  "recursive, r",
 				Usage: "Delete this app and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
 			},
 		},

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -105,6 +105,10 @@ func Delete() cli.Command {
 				BashCompleteApps(c)
 			}
 		},
+		Flags: []cli.Flag{cli.BoolFlag{
+			Name:  "force, f",
+			Usage: "Delete this app and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
+		}},
 	}
 }
 

--- a/objects/fn/commands.go
+++ b/objects/fn/commands.go
@@ -114,6 +114,16 @@ func Delete() cli.Command {
 				BashCompleteFns(c)
 			}
 		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "force, f",
+				Usage: "Forces this delete (you will not be asked if you wish to continue with the delete)",
+			},
+			cli.BoolFlag{
+				Name:  "cascade, c",
+				Usage: "Delete this function and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
+			},
+		},
 	}
 }
 

--- a/objects/fn/commands.go
+++ b/objects/fn/commands.go
@@ -120,7 +120,7 @@ func Delete() cli.Command {
 				Usage: "Forces this delete (you will not be asked if you wish to continue with the delete)",
 			},
 			cli.BoolFlag{
-				Name:  "cascade, c",
+				Name:  "recursive, r",
 				Usage: "Delete this function and all associated resources (can fail part way through execution after deleting some resources without the ability to undo)",
 			},
 		},

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -551,6 +551,31 @@ func (f *fnsCmd) delete(c *cli.Context) error {
 		return err
 	}
 
+	//Cascading delete of sub-objects
+	if c.Bool("cascade") {
+		triggers, err := common.ListTriggersInFunc(c, f.client, fn)
+		if err != nil {
+			return fmt.Errorf("Failed to get associated objects: %s", err)
+		}
+
+		//Forced delete
+		var shouldContinue bool
+		if c.Bool("force") {
+			shouldContinue = true
+		} else {
+			shouldContinue = common.UserConfirmedMultiResourceDeleteion(nil, []*modelsv2.Fn{fn}, triggers)
+		}
+
+		if shouldContinue {
+			err := common.DeleteTriggers(c, f.client, triggers)
+			if err != nil {
+				return fmt.Errorf("Failed to delete associated objects: %s", err)
+			}
+		} else {
+			return nil
+		}
+	}
+
 	params := apifns.NewDeleteFnParams()
 	params.FnID = fn.ID
 	_, err = f.client.Fns.DeleteFn(params)
@@ -559,6 +584,6 @@ func (f *fnsCmd) delete(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Println(appName, fnName, "deleted")
+	fmt.Println("Function", fnName, "deleted")
 	return nil
 }

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -563,7 +563,7 @@ func (f *fnsCmd) delete(c *cli.Context) error {
 		if c.Bool("force") {
 			shouldContinue = true
 		} else {
-			shouldContinue = common.UserConfirmedMultiResourceDeleteion(nil, []*modelsv2.Fn{fn}, triggers)
+			shouldContinue = common.UserConfirmedMultiResourceDeletion(nil, []*modelsv2.Fn{fn}, triggers)
 		}
 
 		if shouldContinue {

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -551,8 +551,8 @@ func (f *fnsCmd) delete(c *cli.Context) error {
 		return err
 	}
 
-	//Cascading delete of sub-objects
-	if c.Bool("cascade") {
+	//recursive delete of sub-objects
+	if c.Bool("recursive") {
 		triggers, err := common.ListTriggersInFunc(c, f.client, fn)
 		if err != nil {
 			return fmt.Errorf("Failed to get associated objects: %s", err)

--- a/test/cli_crud_test.go
+++ b/test/cli_crud_test.go
@@ -218,3 +218,21 @@ func TestEmptyConfigs(t *testing.T) {
 	h.Fn("unset", "config", "app", appName1, "nonexistantKey").AssertSuccess()
 	h.Fn("unset", "config", "function", appName1, funcName1, "nonexistantKey").AssertSuccess()
 }
+
+func TestRecursiveDelete(t *testing.T) {
+	t.Parallel()
+
+	h := testharness.Create(t)
+	defer h.Cleanup()
+	appName1 := h.NewAppName()
+	funcName1 := h.NewFuncName(appName1)
+	triggerName1 := h.NewTriggerName(appName1, funcName1)
+
+	h.Fn("create", "app", appName1).AssertSuccess()
+	h.Fn("create", "function", appName1, funcName1, "foo/duffimage:0.0.1").AssertSuccess()
+	h.Fn("create", "trigger", appName1, funcName1, triggerName1, "--type", "http", "--source", "/mytrigger").AssertSuccess()
+	h.Fn("delete", "app", appName1, "-f", "-r").AssertSuccess().
+		AssertStdoutContains(appName1).
+		AssertStdoutContains(funcName1).
+		AssertStdoutContains(triggerName1)
+}


### PR DESCRIPTION
This addresses issue #333 
This PR adds two flags to delete commands for Applications and Functions objects:

- **recursive (r)**:  Will retrieve all sub-objects and attempt to delete them from the bottom up before deleting the primary resource (user is prompted to continue after all of the associated resources are listed)
- **force (f)**: Will silence the prompt from a recursive delete and just deletes all resources without further user input (this only has an effect when used in combination with the recursive flag)


## Example usage:
### example cascading
command:
```
fn delete fn <app-name> <fn-name> -r
```
will result in this prompt:
```
You are about to delete the following resources:
   Functions:    1
   Triggers:     <number of associated triggers>
This operation cannot be undone
Do you wish to proceed? y/n: 
```
if the user replies 'y' then:
```
Trigger  <trigger-name>  deleted
Function  <fn-name>  deleted
```
if the user replies 'n' then nothing is deleted:
```
Cancelling delete
```

### example cascading & forced
command:
```
fn delete app -f -r <app-name> 
```
results in:
```
Trigger  <trigger-name>  deleted
Function  <fn-name>  deleted
App <app-nam> deleted
```
