### PR TITLE
Add go mod support for go functions

### DIFF
--- a/langs/go.go
+++ b/langs/go.go
@@ -53,6 +53,13 @@ func (h *GoLangHelper) DockerfileBuildCmds() []string {
 			r = append(r, "ADD . /go/src/func/")
 			r = append(r, "RUN cd /go/src/func/ && dep ensure")
 		}
+	} else if exists("go.mod") {
+		r = append(r, "WORKDIR /go/src/func/")
+		r = append(r, "ENV GO111MODULE=on")
+		if vendor {
+			r = append(r, "ENV GOFLAGS=\"-mod=vendor\"")
+		}
+		r = append(r, "COPY . .")
 	} else {
 		r = append(r, "ADD . /go/src/func/")
 	}
@@ -82,8 +89,8 @@ func (lh *GoLangHelper) GenerateBoilerplate(path string) error {
 	if err := ioutil.WriteFile(codeFile, []byte(helloGoSrcBoilerplate), os.FileMode(0644)); err != nil {
 		return err
 	}
-	depFile := "Gopkg.toml"
-	if err := ioutil.WriteFile(depFile, []byte(depBoilerplate), os.FileMode(0644)); err != nil {
+	modFile := "go.mod"
+	if err := ioutil.WriteFile(modFile, []byte(modBoilerplate), os.FileMode(0644)); err != nil {
 		return err
 	}
 
@@ -122,13 +129,7 @@ func myHandler(ctx context.Context, in io.Reader, out io.Writer) {
 }
 `
 
-	depBoilerplate = `
-[[constraint]]
-  branch = "master"
-  name = "github.com/fnproject/fdk-go"
-
-[prune]
-  go-tests = true
-  unused-packages = true
+	modBoilerplate = `
+module func
 `
 )

--- a/test/cli_init_test.go
+++ b/test/cli_init_test.go
@@ -48,7 +48,7 @@ func TestInitImage(t *testing.T) {
 		origYaml.Version = ""
 		h.WriteYamlFile("func.init.yaml", origYaml)
 
-		err = h.Exec("tar", "-cf", "go.tar", "func.go", "func.init.yaml", "Gopkg.toml")
+		err = h.Exec("tar", "-cf", "go.tar", "func.go", "func.init.yaml", "go.mod")
 		if err != nil {
 			fmt.Println(err)
 			t.Fatal("Failed to create tarball for init-image")


### PR DESCRIPTION
Go based functions were using `dep` by default, this change switches to using go mod.