### PR TITLE
Update output to make it clear that paths are relative

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -59,7 +59,7 @@ func (b *buildcmd) build(c *cli.Context) error {
 
 	path := c.Args().First()
 	if path != "" {
-		fmt.Printf("Building function at: /%s\n", path)
+		fmt.Printf("Building function at: ./%s\n", path)
 		dir = filepath.Join(dir, path)
 	}
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -199,7 +199,7 @@ func (p *deploycmd) deploySingle(c *cli.Context, app *models.App) error {
 		// if we're in the context of an app, first arg is path to the function
 		path := c.Args().First()
 		if path != "" {
-			fmt.Printf("Deploying function at: /%s\n", path)
+			fmt.Printf("Deploying function at: ./%s\n", path)
 		}
 		dir = filepath.Join(wd, path)
 	}
@@ -228,7 +228,7 @@ func (p *deploycmd) deployAll(c *cli.Context, app *models.App) error {
 		// if we're in the context of an app, first arg is path to the function
 		path := c.Args().First()
 		if path != "" {
-			fmt.Printf("Deploying function at: /%s\n", path)
+			fmt.Printf("Deploying function at: ./%s\n", path)
 		}
 		dir = filepath.Join(wd, path)
 	}

--- a/commands/init.go
+++ b/commands/init.go
@@ -177,7 +177,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 
 	path := c.Args().First()
 	if path != "" {
-		fmt.Printf("Creating function at: /%s\n", path)
+		fmt.Printf("Creating function at: ./%s\n", path)
 		dir = filepath.Join(dir, path)
 
 		// check if dir exists, if it does, then we can't create function


### PR DESCRIPTION
I noticed that the CLI prints some slightly misleading output which makes it seem like functions are in the root of your filesystem when they're actually in the current directory. This is a minor fix to make it more clear.