### PR TITLE
Update push.go to remove hardcoded references to Docker Hub

### DIFF
--- a/commands/push.go
+++ b/commands/push.go
@@ -38,7 +38,7 @@ func (p *pushcmd) flags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:        "registry",
-			Usage:       "Set the Docker owner for images and optionally the registry. This will be prefixed to your function name for pushing to Docker registries.\n eg: `--registry username` will set your Docker Hub owner. `--registry registry.hub.docker.com/username` will set the registry and owner.",
+			Usage:       "Set the Docker owner for images and optionally the registry. This will be prefixed to your function name for pushing to Docker registries.\n eg: `--registry username` will set only the owner prefix. `--registry registry.hub.docker.com/username` will set the registry and owner.",
 			Destination: &p.registry,
 		},
 	}
@@ -66,7 +66,7 @@ func (p *pushcmd) push(c *cli.Context) error {
 			return err
 		}
 
-		fmt.Printf("Function %v pushed successfully to Docker Hub.\n", ff.ImageNameV20180708())
+		fmt.Printf("Function %v pushed successfully to the registry.\n", ff.ImageNameV20180708())
 		return nil
 	}
 
@@ -85,6 +85,6 @@ func (p *pushcmd) push(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("Function %v pushed successfully to Docker Hub.\n", ff.ImageName())
+	fmt.Printf("Function %v pushed successfully to the registry.\n", ff.ImageName())
 	return nil
 }


### PR DESCRIPTION
Resolves some confusing messages about Docker Hub when pushing images to alternative docker registries.

Before:

```
...
b61c7ac22d6e: Pushed
f5d98c1f9470: Pushed
270b3f9af07e: Pushed
6270adb5794c: Pushed
0.0.1: digest: sha256:5800eba3d96fa56ff1c486a5efa3e508b3aa4165fc5e43544782740a03871479 size: 2619
Function iad.ocir.io/myteam/prefix/some-func:0.0.1 pushed successfully to Docker Hub.
```

After:


```
...
0.0.1: digest: sha256:5800eba3d96fa56ff1c486a5efa3e508b3aa4165fc5e43544782740a03871479 size: 2619
Function iad.ocir.io/myteam/prefix/some-func:0.0.1 pushed successfully to the registry.
```