### PR TITLE
bump max request size to 10Mb

### DIFF
--- a/client/invoke.go
+++ b/client/invoke.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	MaximumRequestBodySize = 5 * 1024 * 1024 // bytes
+	MaximumRequestBodySize = 10 * 1024 * 1024 // bytes
 )
 
 func EnvAsHeader(req *http.Request, selectedEnv []string) {


### PR DESCRIPTION
OCI accepts requests up to 6Mb, the CLI currently caps these at 5Mb - bumping the CLI limit to 10MB as a workaround