### PR TITLE
Add fdk-go requirement to hello world mod file

### DIFF
--- a/langs/go.go
+++ b/langs/go.go
@@ -129,7 +129,8 @@ func myHandler(ctx context.Context, in io.Reader, out io.Writer) {
 }
 `
 
-	modBoilerplate = `
-module func
+	modBoilerplate = `module func
+
+require github.com/fnproject/fdk-go master
 `
 )


### PR DESCRIPTION
I noticed a discrepancy between the requirements specified in the CLI boilerplate hello world `go.mod` and the `go.mod` specified in the Go FDK: https://github.com/fnproject/fdk-go/blob/master/examples/hello/go.mod. Since the example uses the FDK, I believe it should be specified as a requirement in the modules file.