### PR TITLE
Decouple and tidy up init code

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -20,13 +20,9 @@ it will print an error message then exit.
 */
 
 import (
-	"archive/tar"
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -248,48 +244,10 @@ func (a *initFnCmd) init(c *cli.Context) error {
 	a.ff.Schema_version = common.LatestYamlVersion
 
 	if initImage != "" {
-
-		err = runInitImage(initImage, a)
+		err := a.doInitImage(err, initImage, c)
 		if err != nil {
 			return err
 		}
-
-		// Merge the func.init.yaml from the initImage with a.ff
-		//     write out the new func file
-		var initFf, err = common.ParseFuncfile("func.init.yaml")
-		if err != nil {
-			return errors.New("init-image did not produce a valid func.init.yaml")
-		}
-
-		// Build up a combined func.yaml (in a.ff) from the init-image and defaults and cli-args
-		//     The following fields are already in a.ff:
-		//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
-		//     Add the following from the init-image:
-		//         build, build_image, cmd, content_type, entrypoint, expects, headers, run_image, runtime
-		a.ff.Build = initFf.Build
-		a.ff.Build_image = initFf.BuildImage
-		a.ff.Cmd = initFf.Cmd
-		a.ff.Content_type = initFf.ContentType
-		a.ff.Entrypoint = initFf.Entrypoint
-		a.ff.Expects = initFf.Expects
-		a.ff.Run_image = initFf.RunImage
-		a.ff.Runtime = initFf.Runtime
-
-		// Then CLI args can override some init-image options (TODO: remove this with #383)
-		if c.String("cmd") != "" {
-			a.ff.Cmd = c.String("cmd")
-		}
-
-		if c.String("entrypoint") != "" {
-			a.ff.Entrypoint = c.String("entrypoint")
-		}
-
-		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ff); err != nil {
-			return err
-		}
-
-		os.Remove("func.init.yaml")
-
 	} else {
 		// TODO: why don't we treat "docker" runtime as just another language helper?
 		// Then can get rid of several Docker specific if/else's like this one.
@@ -299,81 +257,34 @@ func (a *initFnCmd) init(c *cli.Context) error {
 				return err
 			}
 		}
+	}
 
-		if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ff); err != nil {
-			return err
-		}
+	if err := common.EncodeFuncFileV20180708YAML("func.yaml", a.ff); err != nil {
+		return err
 	}
 
 	fmt.Println("func.yaml created.")
 	return nil
 }
 
-func runInitImage(initImage string, a *initFnCmd) error {
-	fmt.Println("Building from init-image: " + initImage)
-
-	// Run the initImage
-	var c1ErrB bytes.Buffer
-	tarR, tarW := io.Pipe()
-
-	c1 := exec.Command("docker", "run", "--rm", "-e", "FN_FUNCTION_NAME="+a.ff.Name, initImage)
-	c1.Stderr = &c1ErrB
-	c1.Stdout = tarW
-
-	c1Err := c1.Start()
-	if c1Err != nil {
-		fmt.Println(c1ErrB.String())
-		return errors.New("Error running init-image")
-	}
-
-	err := untarStream(tarR)
+func (a *initFnCmd) doInitImage(err error, initImage string, c *cli.Context) error {
+	err = common.DockerRunInitImage(initImage, a.ff.Name)
 	if err != nil {
-		return errors.New("Error un-tarring the output of the init-image")
+		return err
 	}
-
+	err = common.MergeFuncFileInitYAML("func.init.yaml", a.ff)
+	if err != nil {
+		return err
+	}
+	// Then CLI args can override some init-image options (TODO: remove this with #383)
+	if c.String("cmd") != "" {
+		a.ff.Cmd = c.String("cmd")
+	}
+	if c.String("entrypoint") != "" {
+		a.ff.Entrypoint = c.String("entrypoint")
+	}
+	_ = os.Remove("func.init.yaml")
 	return nil
-}
-
-// Untars an io.Reader into the cwd
-func untarStream(r io.Reader) error {
-
-	tr := tar.NewReader(r)
-	for {
-		header, err := tr.Next()
-
-		if err == io.EOF {
-			// if no more files are found we are finished
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		switch header.Typeflag {
-		// if its a dir and it doesn't exist create it
-		case tar.TypeDir:
-			if _, err := os.Stat(header.Name); err != nil {
-				if err := os.MkdirAll(header.Name, 0755); err != nil {
-					return err
-				}
-			}
-
-		// if it's a file create it
-		case tar.TypeReg:
-			f, err := os.OpenFile(header.Name, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-
-			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
-				return err
-			}
-
-			f.Close()
-		}
-	}
 }
 
 func (a *initFnCmd) generateBoilerplate(path, runtime string) error {

--- a/commands/init.go
+++ b/commands/init.go
@@ -244,7 +244,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 	a.ff.Schema_version = common.LatestYamlVersion
 
 	if initImage != "" {
-		err := a.doInitImage(err, initImage, c)
+		err := a.doInitImage(initImage, c)
 		if err != nil {
 			return err
 		}
@@ -267,8 +267,8 @@ func (a *initFnCmd) init(c *cli.Context) error {
 	return nil
 }
 
-func (a *initFnCmd) doInitImage(err error, initImage string, c *cli.Context) error {
-	err = common.DockerRunInitImage(initImage, a.ff.Name)
+func (a *initFnCmd) doInitImage(initImage string, c *cli.Context) error {
+	err := common.DockerRunInitImage(initImage, a.ff.Name)
 	if err != nil {
 		return err
 	}

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,7 +12,7 @@ import (
 	"github.com/fnproject/cli/config"
 	"github.com/spf13/viper"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -359,4 +360,27 @@ func (ff *FuncFileV20180708) ImageNameV20180708() string {
 		fname = fmt.Sprintf("%s:%s", fname, ff.Version)
 	}
 	return fname
+}
+
+// Merge the func.init.yaml from the initImage with a.ff
+//     write out the new func file
+func MergeFuncFileInitYAML(path string, ff *FuncFileV20180708) error {
+	var initFf, err = ParseFuncfile(path)
+	if err != nil {
+		return errors.New("init-image did not produce a valid func.init.yaml")
+	}
+	// Build up a combined func.yaml (in a.ff) from the init-image and defaults and cli-args
+	//     The following fields are already in a.ff:
+	//         config, cpus, idle_timeout, memory, name, path, timeout, type, triggers, version
+	//     Add the following from the init-image:
+	//         build, build_image, cmd, content_type, entrypoint, expects, headers, run_image, runtime
+	ff.Build = initFf.Build
+	ff.Build_image = initFf.BuildImage
+	ff.Cmd = initFf.Cmd
+	ff.Content_type = initFf.ContentType
+	ff.Entrypoint = initFf.Entrypoint
+	ff.Expects = initFf.Expects
+	ff.Run_image = initFf.RunImage
+	ff.Runtime = initFf.Runtime
+	return nil
 }

--- a/common/funcfile_test.go
+++ b/common/funcfile_test.go
@@ -1,0 +1,105 @@
+package common
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+)
+
+func TestMergeFuncFileInitYAML(t *testing.T) {
+
+	ff := FuncFileV20180708{
+		Schema_version: 0,
+		Name:           "old",
+		Version:        "old",
+		Runtime:        "old",
+		Build_image:    "old",
+		Run_image:      "old",
+		Cmd:            "old",
+		Entrypoint:     "old",
+		Content_type:   "old",
+		Type:           "old",
+		Memory:         0,
+		Timeout:        nil,
+		IDLE_timeout:   nil,
+		Config:         nil,
+		Annotations:    nil,
+		Build:          nil,
+		Expects:        Expects{},
+		Triggers:       nil,
+	}
+
+	tests := []struct {
+		name     string
+		initYAML string
+		wantErr  bool
+		wantFF   FuncFileV20180708
+	}{
+		{
+			name:     "invalid init yaml",
+			initYAML: "foobaryaml",
+			wantErr:  true,
+			wantFF:   ff,
+		},
+		{
+			name: "valid init file replaces old func file",
+			initYAML: `
+schema_version: 20180708
+version: 0.0.1
+runtime: go
+entrypoint: ./func
+`,
+			wantErr: false,
+			wantFF: FuncFileV20180708{
+				Schema_version: 0,
+				Name:           "old",
+				Version:        "old",
+				Runtime:        "go",
+				Build_image:    "",
+				Run_image:      "",
+				Cmd:            "",
+				Entrypoint:     "./func",
+				Content_type:   "",
+				Type:           "old",
+				Memory:         0,
+				Timeout:        nil,
+				IDLE_timeout:   nil,
+				Config:         nil,
+				Annotations:    nil,
+				Build:          nil,
+				Expects:        Expects{},
+				Triggers:       nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			folder, filePath := createInitYAML(tt.initYAML)
+			defer os.RemoveAll(folder)
+			if err := MergeFuncFileInitYAML(filePath, &ff); (err != nil) != tt.wantErr {
+				t.Errorf("MergeFuncFileInitYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(ff, tt.wantFF) {
+				t.Errorf("MergeFuncFileInitYAML() did not merge func file correctly, got = %v, want %v", ff, tt.wantFF)
+			}
+		})
+	}
+}
+
+func createInitYAML(contents string) (string, string) {
+	folder, err := ioutil.TempDir(os.TempDir(), "fn-tests")
+	if err != nil {
+		panic(err)
+	}
+	filePath := path.Join(folder, "func.init.yaml")
+	f, err := os.Create(filePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	_, _ = f.WriteString(contents)
+
+	return folder, filePath
+}


### PR DESCRIPTION
In preparation for using an init image as the default function generation image for the Go language helper, I moved some code around and wrote some tests.

Phase 2 will be to define an init image in the language helper, and call that instead of the boilerplate.
