### PR TITLE
Modify init-image to pass through proxy settings and use StdoutPipe to prevent failing init image execution from blocking forever

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -751,36 +751,50 @@ func ListTriggersInFunc(c *cli.Context, client *fnclient.Fn, fn *modelsv2.Fn) ([
 func DockerRunInitImage(initImage string, fName string) error {
 	fmt.Println("Running init-image: " + initImage)
 
-	// Run the initImage
-	var c1ErrB bytes.Buffer
-	tarR, tarW := io.Pipe()
+	args := []string{"run", "--rm", "-e", "FN_FUNCTION_NAME=" + fName}
+	args = append(args, proxyArgs()...)
+	args = append(args, initImage)
 
-	c1 := exec.Command("docker", "run", "--rm", "-e",
-		"FN_FUNCTION_NAME="+fName,
-		"-e", "http_proxy="+os.Getenv("http_proxy"),
-		"-e", "https_proxy="+os.Getenv("https_proxy"),
-		"-e", "no_proxy="+os.Getenv("no_proxy"),
-		initImage)
-	c1.Stderr = &c1ErrB
-	c1.Stdout = tarW
-
-	c1Err := c1.Start()
-	if c1Err != nil {
-		fmt.Println(c1ErrB.String())
-		return errors.New("Error running init-image")
+	fmt.Printf("Executing docker command: %s\n", strings.Join(args, " "))
+	cmd := exec.Command("docker", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("Error attaching stdout pipe to init-image cmd: %v.", err)
 	}
 
-	err := untarStream(tarR)
+	err = cmd.Start()
 	if err != nil {
-		return errors.New("Error un-tarring the output of the init-image")
+		return fmt.Errorf("Error starting init-image: %v. Stderr: '%s'", err, stderr.String())
+	}
+
+	err = untarStream(stdout)
+	if err != nil {
+		return fmt.Errorf("Error un-tarring stdout from the init-image: %v", err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("Error running init-image: %v. Stderr: '%s'", err, stderr.String())
 	}
 
 	return nil
 }
 
+// Get any proxy environment variables
+func proxyArgs() []string {
+	args := make([]string, 0)
+	for _, a := range []string{"http_proxy", "https_proxy", "ftp_proxy", "no_proxy", "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "NO_PROXY"} {
+		if val, ok := os.LookupEnv(a); ok {
+			args = append(args, "-e", a+"="+val)
+		}
+	}
+	return args
+}
+
 // Untars an io.Reader into the cwd
 func untarStream(r io.Reader) error {
-
 	tr := tar.NewReader(r)
 	for {
 		header, err := tr.Next()

--- a/common/common.go
+++ b/common/common.go
@@ -755,7 +755,12 @@ func DockerRunInitImage(initImage string, fName string) error {
 	var c1ErrB bytes.Buffer
 	tarR, tarW := io.Pipe()
 
-	c1 := exec.Command("docker", "run", "--rm", "-e", "FN_FUNCTION_NAME="+fName, initImage)
+	c1 := exec.Command("docker", "run", "--rm", "-e",
+		"FN_FUNCTION_NAME="+fName,
+		"-e", "http_proxy="+os.Getenv("http_proxy"),
+		"-e", "https_proxy="+os.Getenv("https_proxy"),
+		"-e", "no_proxy="+os.Getenv("no_proxy"),
+		initImage)
 	c1.Stderr = &c1ErrB
 	c1.Stdout = tarW
 
@@ -814,4 +819,3 @@ func untarStream(r io.Reader) error {
 		}
 	}
 }
-


### PR DESCRIPTION
Pass through http proxy variables to init-image docker invocation. Use StdoutPipe to prevent failing init image execution from blocking forever.

Testing:

**Error case (with bad proxy settings passed through):**

```
$ fn init --init-image fdk-go-init:latest tmp
Creating function at: ./tmp
Running init-image: fdk-go-init
Executing docker command: run --rm -e FN_FUNCTION_NAME=tmp -e https_proxy=http://foo.com:80 fdk-go-init:latest

Fn: Error running init-image: exit status 1. Stderr: 'go: creating new go.mod: module tmp
build tmp: cannot load github.com/fnproject/fdk-go: cannot find module providing package github.com/fnproject/fdk-go
'
```

**Success case (with no proxy settings passed through):**

```
$ fn init --init-image fdk-go-init:latest tmp
Creating function at: ./tmp
Running init-image: fdk-go-init:latest
Executing docker command: run --rm -e FN_FUNCTION_NAME=tmp fdk-go-init:latest
func.yaml created.

$ ls tmp
func.go   func.yaml go.mod

$ cd tmp

$ fn --registry test deploy --local --no-bump --app goapp
Deploying tmp to app: goapp
Building image test/tmp:0.0.1 ..........
Updating function tmp using image test/tmp:0.0.1...
Successfully created function: tmp with test/tmp:0.0.1

$  fn invoke goapp tmp
{"message":"Hello World"}
```

