### PR TITLE
Upgrade to go v1.13.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - GO111MODULE=on
       - GOFLAGS=-mod=vendor
       - GOPATH=/home/circleci/go
-      - GOVERSION=1.12.3
+      - GOVERSION=1.13.3
       - OS=linux
       - ARCH=amd64
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/fnproject/cli
 
+go 1.13
+
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/coreos/go-semver v0.2.0

--- a/test/simplefunc/go.mod
+++ b/test/simplefunc/go.mod
@@ -1,5 +1,5 @@
 module github.com/fnproject/cli/test/simplefunc
 
-go 1.12
+go 1.13
 
 require github.com/fnproject/fdk-go v0.0.0-20181025170718-26ed643bea68


### PR DESCRIPTION
Relates to https://github.com/Homebrew/homebrew-core/pull/45897

We already ship the formula with latest go, so it would be nice to bump the version to go `v1.13.3`.