### PR TITLE
Rejig the Python copy commands

### DIFF
--- a/langs/python.go
+++ b/langs/python.go
@@ -118,8 +118,8 @@ def handler(ctx, data: io.BytesIO=None):
 
 func (h *PythonLangHelper) DockerfileCopyCmds() []string {
 	return []string{
-		"COPY --from=build-stage /function /function",
 		"COPY --from=build-stage /python /python",
-		"ENV PYTHONPATH=/python",
+		"COPY --from=build-stage /function /function",
+		"ENV PYTHONPATH=/function:/python",
 	}
 }


### PR DESCRIPTION
A small change to func.py can peturb a potentially larger layer
containing required libraries; shift the copy around to avoid this.

Add /function to the PYTHONPATH - this permits adding small sets of
other modules in a cheap & cheerful fashion alongside the func.py

The results here from a build are

```
/function/func.py & co.
/python/required-libraries
... the base image ...
```

as opposed to

```
/python/required-libraries
/function/func.py & co.
... the base image ...
```