### PR TITLE
Fix permissions for interpretted function code

### DIFF
--- a/langs/node.go
+++ b/langs/node.go
@@ -117,6 +117,7 @@ func (h *NodeLangHelper) DockerfileCopyCmds() []string {
 	if exists("package.json") && !exists("node_modules") {
 		r = append(r, "COPY --from=build-stage /function/node_modules/ /function/node_modules/")
 	}
+	r = append(r, "RUN chmod -R o+r /function")
 
 	return r
 }

--- a/langs/python.go
+++ b/langs/python.go
@@ -122,6 +122,7 @@ func (h *PythonLangHelper) DockerfileCopyCmds() []string {
 	return []string{
 		"COPY --from=build-stage /python /python",
 		"COPY --from=build-stage /function /function",
+		"RUN chmod -R o+r /python /function",
 		"ENV PYTHONPATH=/function:/python",
 	}
 }

--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -53,7 +53,8 @@ func (h *RubyLangHelper) DockerfileBuildCmds() []string {
 func (h *RubyLangHelper) DockerfileCopyCmds() []string {
 	return []string{
 		"COPY --from=build-stage /usr/lib/ruby/gems/ /usr/lib/ruby/gems/", // skip this if no Gemfile?  Does it matter?
-		"ADD . /function/",
+		"COPY . /function/",
+		"RUN chmod -R o+r /function",
 	}
 }
 


### PR DESCRIPTION
Interpretted function code is copied directly in from the filesystem of
the building instance. We don't know what permissions will exist on this
filesystem so we need to ensure after copying it in that the function
user is able to read the code.