### PR TITLE
Add Python 3.8.5 and make Python images smaller

### DIFF
--- a/langs/base.go
+++ b/langs/base.go
@@ -2,7 +2,6 @@ package langs
 
 import (
 	"errors"
-	"fmt"
 	"os"
 )
 
@@ -116,8 +115,4 @@ func exists(name string) bool {
 		}
 	}
 	return true
-}
-
-func dockerBuildError(err error) error {
-	return fmt.Errorf("error running docker build: %v", err)
 }

--- a/langs/base.go
+++ b/langs/base.go
@@ -15,8 +15,9 @@ func init() {
 	registerHelper(&JavaLangHelper{version: "8"})
 	registerHelper(&NodeLangHelper{})
 	// order matter, 'python' will pick up the first PythonLangHelper
-	registerHelper(&PythonLangHelper{Version: "3.6"})
+	registerHelper(&PythonLangHelper{Version: "3.8.5"})
 	registerHelper(&PythonLangHelper{Version: "3.7.1"})
+	registerHelper(&PythonLangHelper{Version: "3.6"})
 	registerHelper(&RubyLangHelper{})
 	registerHelper(&KotlinLangHelper{})
 }

--- a/langs/python.go
+++ b/langs/python.go
@@ -77,7 +77,8 @@ func (h *PythonLangHelper) DockerfileBuildCmds() []string {
 		r = append(r, "ADD requirements.txt /function/")
 		r = append(r, fmt.Sprintf(`
 			%v -r requirements.txt &&\
-			 rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv`, pip_cmd))
+			    rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv &&\
+			    chmod -R o+r /python`, pip_cmd))
 	}
 	r = append(r, "ADD . /function/")
 	if exists("setup.py") {
@@ -122,7 +123,7 @@ func (h *PythonLangHelper) DockerfileCopyCmds() []string {
 	return []string{
 		"COPY --from=build-stage /python /python",
 		"COPY --from=build-stage /function /function",
-		"RUN chmod -R o+r /python /function",
+		"RUN chmod -R o+r /function",
 		"ENV PYTHONPATH=/function:/python",
 	}
 }

--- a/langs/python.go
+++ b/langs/python.go
@@ -100,7 +100,7 @@ import logging
 from fdk import response
 
 
-def handler(ctx, data: io.BytesIO=None):
+def handler(ctx, data: io.BytesIO = None):
     name = "World"
     try:
         body = json.loads(data.getvalue())


### PR DESCRIPTION
## Python 3.8.5 is a supported language, and the default for "python"

It's the default for "python", because it leads to smaller images.


## Python images are now smaller

This patch changes the file mode of the `/python` tree as part of the
build image, which avoids duplicating the pip installed libraries in
the final layer. This makes docker push and pull much faster.

"Hello world" with Python 3.8.5:

| requirements.txt | image size now | image size before | saving |
| ---------------- | -------------- | ----------------- | ------ |
| fdk              |          136MB |             161MB |    15% |
| fdk & oci        |          202MB |             292MB |    30% |


## Minor fixups

* Make Python boilerplate meet PEP 8 standard
* Remove unused func "dockerBuildError" (dead code)
