### PR TITLE
Revendor fn_go: Oracle providers shim blank digest fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fnproject/cli
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/fatih/color v0.0.0-20170926111411-5df930a27be2
-	github.com/fnproject/fn_go v0.8.0
+	github.com/fnproject/fn_go v0.8.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/semver-bump v0.0.0-20140912095342-88e6c9f2fe39
 	github.com/go-openapi/runtime v0.19.23

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v0.0.0-20170926111411-5df930a27be2 h1:40J76vs1Y7oiHFqTrQHQ6A5u8vbXJdLaMkC9iHU/uMw=
 github.com/fatih/color v0.0.0-20170926111411-5df930a27be2/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fnproject/fn_go v0.8.0 h1:rTErUTuqjJplweDAY7F5Nw1UyaY17HZgwMkWu8ZN2FY=
-github.com/fnproject/fn_go v0.8.0/go.mod h1:xmSLdSo2aP1Asnr8Jcv3deB4WqZHzdkqQwtOifBpv0Q=
+github.com/fnproject/fn_go v0.8.1 h1:Jr58UNk6nF897gIPTlaa3lAZ85lJ7gQv9+zSPS2nqrI=
+github.com/fnproject/fn_go v0.8.1/go.mod h1:xmSLdSo2aP1Asnr8Jcv3deB4WqZHzdkqQwtOifBpv0Q=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/client/client_mock.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/client/client_mock.go
@@ -329,6 +329,9 @@ func NewMockFunctionsManagementClientBasic(ctrl *gomock.Controller) FunctionsMan
 				digest := "OriginalFunctionDigest"
 				if request.ImageDigest != nil {
 					digest = *request.ImageDigest
+					if digest == "" {
+						return functions.UpdateFunctionResponse{}, fmt.Errorf("invalid image digest")
+					}
 				}
 				memory := int64(128)
 				if request.MemoryInMBs != nil {

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
@@ -230,6 +230,10 @@ func parseDigestAnnotation(annotations map[string]interface{}) (*string, error) 
 		return nil, fmt.Errorf("invalid image digest")
 	}
 
+	if digest == "" {
+		return nil, nil
+	}
+
 	return &digest, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/coreos/go-semver/semver
 # github.com/fatih/color v0.0.0-20170926111411-5df930a27be2
 ## explicit
 github.com/fatih/color
-# github.com/fnproject/fn_go v0.8.0
+# github.com/fnproject/fn_go v0.8.1
 ## explicit
 github.com/fnproject/fn_go
 github.com/fnproject/fn_go/client/version


### PR DESCRIPTION
See https://github.com/fnproject/fn_go/pull/43