### PR TITLE
Go runtime 1.15 support and FDK Version changes

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -26,7 +26,7 @@ func BuildCommand() cli.Command {
 }
 
 type buildcmd struct {
-	noCache          bool
+	noCache bool
 }
 
 func (b *buildcmd) flags() []cli.Flag {

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -46,14 +46,14 @@ func DeployCommand() cli.Command {
 type deploycmd struct {
 	clientV2 *v2Client.Fn
 
-	appName          string
-	createApp        bool
-	wd               string
-	local            bool
-	noCache          bool
-	registry         string
-	all              bool
-	noBump           bool
+	appName   string
+	createApp bool
+	wd        string
+	local     bool
+	noCache   bool
+	registry  string
+	all       bool
+	noBump    bool
 }
 
 func (p *deploycmd) flags() []cli.Flag {

--- a/langs/base.go
+++ b/langs/base.go
@@ -7,11 +7,11 @@ import (
 
 // not a map because some helpers can handle multiple keys
 var helpers = []LangHelper{}
-var fallBackOlderVersions = map[string] LangHelper{}
+var fallBackOlderVersions = map[string]LangHelper{}
 
 func init() {
 
-	registerHelper(&GoLangHelper{})
+	registerHelper(&GoLangHelper{Version: "1.15"})
 	// order matter, 'java' will pick up the first JavaLangHelper
 	registerHelper(&JavaLangHelper{version: "11"})
 	registerHelper(&JavaLangHelper{version: "8"})
@@ -102,6 +102,8 @@ type LangHelper interface {
 	GenerateBoilerplate(string) error
 	// FixImagesOnInit determines if images should be fixed on initialization - BuildFromImage and RunFromImage will be written to func.yaml
 	FixImagesOnInit() bool
+	// GetLatestFDKVersion checks the package repository and returns the latest version of FDK version if available.
+	GetLatestFDKVersion() (string, error)
 }
 
 func defaultHandles(h LangHelper, lang string) bool {
@@ -117,18 +119,19 @@ func defaultHandles(h LangHelper, lang string) bool {
 type BaseHelper struct {
 }
 
-func (h *BaseHelper) IsMultiStage() bool               { return true }
-func (h *BaseHelper) DockerfileBuildCmds() []string    { return []string{} }
-func (h *BaseHelper) DockerfileCopyCmds() []string     { return []string{} }
-func (h *BaseHelper) Entrypoint() (string, error)      { return "", nil }
-func (h *BaseHelper) Cmd() (string, error)             { return "", nil }
-func (h *BaseHelper) HasPreBuild() bool                { return false }
-func (h *BaseHelper) PreBuild() error                  { return nil }
-func (h *BaseHelper) AfterBuild() error                { return nil }
-func (h *BaseHelper) HasBoilerplate() bool             { return false }
-func (h *BaseHelper) GenerateBoilerplate(string) error { return nil }
-func (h *BaseHelper) CustomMemory() uint64             { return 0 }
-func (h *BaseHelper) FixImagesOnInit() bool            { return false }
+func (h *BaseHelper) IsMultiStage() bool                   { return true }
+func (h *BaseHelper) DockerfileBuildCmds() []string        { return []string{} }
+func (h *BaseHelper) DockerfileCopyCmds() []string         { return []string{} }
+func (h *BaseHelper) Entrypoint() (string, error)          { return "", nil }
+func (h *BaseHelper) Cmd() (string, error)                 { return "", nil }
+func (h *BaseHelper) HasPreBuild() bool                    { return false }
+func (h *BaseHelper) PreBuild() error                      { return nil }
+func (h *BaseHelper) AfterBuild() error                    { return nil }
+func (h *BaseHelper) HasBoilerplate() bool                 { return false }
+func (h *BaseHelper) GenerateBoilerplate(string) error     { return nil }
+func (h *BaseHelper) CustomMemory() uint64                 { return 0 }
+func (h *BaseHelper) FixImagesOnInit() bool                { return false }
+func (h *BaseHelper) GetLatestFDKVersion() (string, error) { return "", nil }
 
 // exists checks if a file exists
 func exists(name string) bool {

--- a/langs/go.go
+++ b/langs/go.go
@@ -1,8 +1,11 @@
 package langs
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 )
@@ -24,18 +27,18 @@ func (h *GoLangHelper) CustomMemory() uint64 {
 }
 
 func (lh *GoLangHelper) LangStrings() []string {
-	return []string{"go"}
+	return []string{"go", fmt.Sprintf("go%s", lh.Version)}
 }
 func (lh *GoLangHelper) Extensions() []string {
 	return []string{".go"}
 }
 
 func (lh *GoLangHelper) BuildFromImage() (string, error) {
-	return "fnproject/go:dev", nil
+	return fmt.Sprintf("fnproject/go:%s-dev", lh.Version), nil
 }
 
 func (lh *GoLangHelper) RunFromImage() (string, error) {
-	return "fnproject/go", nil
+	return fmt.Sprintf("fnproject/go:%s", lh.Version), nil
 }
 
 func (h *GoLangHelper) DockerfileBuildCmds() []string {
@@ -91,11 +94,33 @@ func (lh *GoLangHelper) GenerateBoilerplate(path string) error {
 		return err
 	}
 	modFile := "go.mod"
-	if err := ioutil.WriteFile(modFile, []byte(modBoilerplate), os.FileMode(0644)); err != nil {
+	fdkVersion, _ := lh.GetLatestFDKVersion()
+	if err := ioutil.WriteFile(modFile, []byte(fmt.Sprintf(modBoilerplate, fdkVersion)), os.FileMode(0644)); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+type githubTagResponse struct {
+	Name string `json:"name"`
+}
+
+func (h *GoLangHelper) GetLatestFDKVersion() (string, error) {
+	// Github API has limit on number of calls
+	resp, err := http.Get("https://api.github.com/repos/fnproject/fdk-go/tags")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	responseBody := []githubTagResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		return "", err
+	}
+	if len(responseBody) == 0 {
+		return "", errors.New("Could not read latest version of FDK from tags")
+	}
+	return responseBody[0].Name, nil
 }
 
 const (
@@ -134,6 +159,8 @@ func myHandler(ctx context.Context, in io.Reader, out io.Writer) {
 
 	modBoilerplate = `
 module func
+
+require github.com/fnproject/fdk-go %s
 `
 )
 

--- a/langs/java.go
+++ b/langs/java.go
@@ -41,7 +41,7 @@ func (h *JavaLangHelper) Extensions() []string {
 // BuildFromImage returns the Docker image used to compile the Maven function project
 func (h *JavaLangHelper) BuildFromImage() (string, error) {
 
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +57,7 @@ func (h *JavaLangHelper) BuildFromImage() (string, error) {
 
 // RunFromImage returns the Docker image used to run the Java function.
 func (h *JavaLangHelper) RunFromImage() (string, error) {
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +84,7 @@ func (h *JavaLangHelper) GenerateBoilerplate(path string) error {
 		return ErrBoilerplateExists
 	}
 
-	apiVersion, err := h.getFDKAPIVersion()
+	apiVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func pomFileContent(APIversion, javaVersion, pomType string) string {
 	}
 }
 
-func (h *JavaLangHelper) getFDKAPIVersion() (string, error) {
+func (h *JavaLangHelper) GetLatestFDKVersion() (string, error) {
 
 	if h.latestFdkVersion != "" {
 		return h.latestFdkVersion, nil
@@ -200,7 +200,7 @@ func (h *JavaLangHelper) getFDKAPIVersion() (string, error) {
 	if version != "" {
 		return version, nil
 	}
-	version,pType, err := getFDKLatestFromURL(mavenVersionUrl, bintrayVersionURL)
+	version, pType, err := getFDKLatestFromURL(mavenVersionUrl, bintrayVersionURL)
 	if err != nil {
 		return "", fetchError
 	}
@@ -220,7 +220,7 @@ func getFDKLatestFromURL(comURL string, bintrayURL string) (string, string, erro
 	if err == nil {
 		version, e1 := parseMavenResponse(data)
 		if e1 == nil {
-			return version,"maven", e1
+			return version, "maven", e1
 		}
 	}
 
@@ -234,7 +234,7 @@ func getFDKLatestFromURL(comURL string, bintrayURL string) (string, string, erro
 	}
 
 	//In all other case return error as latest FDK version is not identified
-	return "", "",err
+	return "", "", err
 }
 
 func getURLResponse(url string, inSecureSkipVerify bool) ([]byte, error) {
@@ -255,7 +255,7 @@ func getURLResponse(url string, inSecureSkipVerify bool) ([]byte, error) {
 	if err != nil || resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Failed to fetch response from URL %s Error: %v Status: %d", url, err, resp.StatusCode)
 	}
-	data, err:=ioutil.ReadAll(resp.Body)
+	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/langs/kotlin.go
+++ b/langs/kotlin.go
@@ -38,7 +38,7 @@ func (h *KotlinLangHelper) Extensions() []string {
 // BuildFromImage returns the Docker image used to compile the Maven function project
 func (h *KotlinLangHelper) BuildFromImage() (string, error) {
 
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return "", err
 	}
@@ -48,7 +48,7 @@ func (h *KotlinLangHelper) BuildFromImage() (string, error) {
 
 // RunFromImage returns the Docker image used to run the Kotlin function.
 func (h *KotlinLangHelper) RunFromImage() (string, error) {
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +70,7 @@ func (h *KotlinLangHelper) GenerateBoilerplate(path string) error {
 		return ErrBoilerplateExists
 	}
 
-	apiVersion, err := h.getFDKAPIVersion()
+	apiVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func kotlinPomFileContent(APIversion, pomType string) string {
 	}
 }
 
-func (lh *KotlinLangHelper) getFDKAPIVersion() (string, error) {
+func (lh *KotlinLangHelper) GetLatestFDKVersion() (string, error) {
 
 	if lh.latestFdkVersion != "" {
 		return lh.latestFdkVersion, nil
@@ -185,7 +185,7 @@ func (lh *KotlinLangHelper) getFDKAPIVersion() (string, error) {
 	if version != "" {
 		return version, nil
 	}
-	version,pType, err := getFDKLatestFromURL(mavenVersionUrl, bintrayVersionURL)
+	version, pType, err := getFDKLatestFromURL(mavenVersionUrl, bintrayVersionURL)
 	if err != nil {
 		return "", fetchError
 	}

--- a/langs/node.go
+++ b/langs/node.go
@@ -61,7 +61,7 @@ const packageJsonContent = `{
 `
 
 func (h *NodeLangHelper) GenerateBoilerplate(path string) error {
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func (h *NodeLangHelper) DockerfileCopyCmds() []string {
 	return r
 }
 
-func (h *NodeLangHelper) getFDKAPIVersion() (string, error) {
+func (h *NodeLangHelper) GetLatestFDKVersion() (string, error) {
 
 	const versionURL = "https://registry.npmjs.org/@fnproject/fdk"
 	const versionEnv = "FN_NODE_FDK_VERSION"
@@ -161,5 +161,3 @@ func (h *NodeLangHelper) getFDKAPIVersion() (string, error) {
 func (h *NodeLangHelper) FixImagesOnInit() bool {
 	return true
 }
-
-

--- a/langs/ruby.go
+++ b/langs/ruby.go
@@ -68,7 +68,7 @@ func (h *RubyLangHelper) Entrypoint() (string, error) {
 func (h *RubyLangHelper) HasBoilerplate() bool { return true }
 
 func (h *RubyLangHelper) GenerateBoilerplate(path string) error {
-	fdkVersion, err := h.getFDKAPIVersion()
+	fdkVersion, err := h.GetLatestFDKVersion()
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (h *RubyLangHelper) GenerateBoilerplate(path string) error {
 	return nil
 }
 
-func (h *RubyLangHelper) getFDKAPIVersion() (string, error) {
+func (h *RubyLangHelper) GetLatestFDKVersion() (string, error) {
 
 	const versionURL = "https://rubygems.org/api/v1/versions/fdk/latest.json"
 	const versionEnv = "FN_RUBY_FDK_VERSION"


### PR DESCRIPTION
Added GetLatestFDKVersion method to LanguageHelper
Added ability to get latest FDK version for Go and Python on init.
Formatted the code
Added tag go1.15