### PR TITLE
Added webpack support for Node

### DIFF
--- a/config/version.go
+++ b/config/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version of Fn CLI
-var Version = "0.6.8"
+var Version = "0.6.9"
 
 func GetVersion(versionType string) string {
 	base := "https://github.com/fnproject/cli/releases"

--- a/langs/node.go
+++ b/langs/node.go
@@ -98,7 +98,9 @@ func (h *NodeLangHelper) Entrypoint() (string, error) {
 func (h *NodeLangHelper) DockerfileBuildCmds() []string {
 	r := []string{}
 	// skip npm -install if node_modules is local - allows local development
-	if exists("package.json") && !exists("node_modules") {
+	if exists("dist") {
+		// Do nothing
+	} else if exists("package.json") && !exists("node_modules") {
 		if exists("package-lock.json") {
 			r = append(r, "ADD package-lock.json /function/")
 		}
@@ -112,7 +114,13 @@ func (h *NodeLangHelper) DockerfileBuildCmds() []string {
 }
 
 func (h *NodeLangHelper) DockerfileCopyCmds() []string {
+	// If they have a dist folder (likely from webpack) let's just include that
+	if exists("dist") {
+		r := []string{"ADD dist/main.js /function/func.js"}
+		return r
+	}
 	// excessive but content could be anything really
+
 	r := []string{"ADD . /function/"}
 	if exists("package.json") && !exists("node_modules") {
 		r = append(r, "COPY --from=build-stage /function/node_modules/ /function/node_modules/")


### PR DESCRIPTION
Added the ability to use a compiled dist folder script rather than the full code. Reduces overall file size and allows you to have test code that isn't compiled and sent to the server. 

Resolves Issue #629 