### PR TITLE
Podman has been integrated to be used as an optional replacement for docker

### DIFF
--- a/commands/build_server.go
+++ b/commands/build_server.go
@@ -113,7 +113,11 @@ func (b *BuildServerCmd) buildServer(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = common.RunBuild(common.IsVerbose(), dir, c.String("tag"), "Dockerfile", nil, b.noCache)
+	containerEngineType, err := common.GetContainerEngineType()
+	if err != nil {
+		return err
+	}
+	err = common.RunBuild(common.IsVerbose(), dir, c.String("tag"), "Dockerfile", nil, b.noCache, containerEngineType)
 	if err != nil {
 		return err
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -23,13 +23,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fnproject/fn_go/provider/oracle"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/fnproject/fn_go/provider/oracle"
 
 	client "github.com/fnproject/cli/client"
 	common "github.com/fnproject/cli/common"
@@ -361,7 +362,7 @@ func (p *deploycmd) deployFuncV20180708(c *cli.Context, app *models.App, funcfil
 	}
 
 	if !p.local {
-		if err := common.DockerPushV20180708(funcfile); err != nil {
+		if err := common.PushV20180708(funcfile); err != nil {
 			return err
 		}
 	}
@@ -529,13 +530,17 @@ func getRepositoryName(ff *common.FuncFileV20180708) (string, error) {
 }
 
 func getImageDigest(ff *common.FuncFileV20180708) (string, error) {
+	containerEngineType, err := common.GetContainerEngineType()
+	if err != nil {
+		return "", err
+	}
 	fmt.Printf("Fetching image digest for %s\n", ff.ImageNameV20180708())
 	parts := strings.Split(ff.ImageNameV20180708(), ":")
 	if len(parts) < 2 {
 		return "", fmt.Errorf("failed to parse image %s", ff.ImageNameV20180708())
 	}
 	image, tag := parts[0], parts[1]
-	imageDigests, err := exec.Command("docker", "images", "--digests", image, "--format", "{{.Tag}} {{.Digest}}").Output()
+	imageDigests, err := exec.Command(containerEngineType, "images", "--digests", image, "--format", "{{.Tag}} {{.Digest}}").Output()
 	if err != nil {
 		return "", fmt.Errorf("error while listing image digests for %s, %s", ff.ImageNameV20180708(), err)
 	}

--- a/commands/init.go
+++ b/commands/init.go
@@ -294,7 +294,7 @@ func (a *initFnCmd) init(c *cli.Context) error {
 }
 
 func (a *initFnCmd) doInitImage(initImage string, c *cli.Context) error {
-	err := common.DockerRunInitImage(initImage, a.ff.Name)
+	err := common.RunInitImage(initImage, a.ff.Name)
 	if err != nil {
 		return err
 	}

--- a/commands/push.go
+++ b/commands/push.go
@@ -77,7 +77,7 @@ func (p *pushcmd) push(c *cli.Context) error {
 
 		fmt.Println("pushing", ff.ImageNameV20180708())
 
-		if err := common.DockerPushV20180708(ff); err != nil {
+		if err := common.PushV20180708(ff); err != nil {
 			return err
 		}
 
@@ -96,7 +96,7 @@ func (p *pushcmd) push(c *cli.Context) error {
 
 	fmt.Println("pushing", ff.ImageName())
 
-	if err := common.DockerPush(ff); err != nil {
+	if err := common.Push(ff); err != nil {
 		return err
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -75,3 +75,25 @@ func TestDefaultContextConfigContents(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateContainerEngineType(t *testing.T) {
+	testCases := []struct {
+		actual      string
+		expectedErr string
+	}{
+		{actual: "docker", expectedErr: ""},
+		{actual: "podman", expectedErr: ""},
+		{actual: "default", expectedErr: "Invalid Container Engine"},
+	}
+	for _, c := range testCases {
+		t.Run(c.actual, func(t *testing.T) {
+			errString := ""
+			if err := ValidateContainerEngineType(c.actual); err != nil {
+				errString = err.Error()
+			}
+			if c.expectedErr != errString {
+				t.Fatalf("expected %s but got %s", c.expectedErr, errString)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func newFn() *cli.App {
 	
 {{bold "ENVIRONMENT VARIABLES"}}
 	FN_API_URL		 {{italic "Fn server address"}}
-	FN_REGISTRY		 {{italic "Docker registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]USERNAME]"}}{{if .VisibleCommands}}
+	FN_REGISTRY		 {{italic "Docker / Podman registry to push images to, use username only to push to Docker Hub - [[registry.hub.docker.com/]USERNAME]"}}{{if .VisibleCommands}}
 		
 {{bold "GENERAL COMMANDS"}}{{end}}{{else}}{{range .VisibleCategories}}{{if .Name}}{{bold .Name}}{{end}}{{end}}
 	{{boldcyan .HelpName}}{{if .Usage}}{{" - "}}{{italic .Usage}}


### PR DESCRIPTION
Changes which will pick the container engine name from the environment and replaced all the docker argument with the variable of containerEngineType