### PR TITLE
Added code to print dockerfile when running build in verbose mode

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -273,6 +273,19 @@ func PrintContextualInfo() {
 	fmt.Println("Current Context: ", currentContext)
 }
 
+func PrintDockerfileContent(dockerfile string, stdout io.Writer) {
+	file, err := os.Open(dockerfile)
+	if err != nil {
+		fmt.Fprintf(stdout, err.Error())
+		fmt.Fprintf(stdout, "\n")
+		return
+	}
+	defer file.Close()
+	fmt.Fprintf(stdout, "Dockerfile content\n-----------------------------------\n")
+	_, _ = io.Copy(stdout, file)
+	fmt.Fprintf(stdout, "-----------------------------------\n")
+}
+
 func GetContainerEngineType() (string, error) {
 	containerEngineType := viper.GetString(config.ContainerEngineType)
 	err := config.ValidateContainerEngineType(containerEngineType)
@@ -404,6 +417,7 @@ func RunBuild(verbose bool, dir, imageName, dockerfile string, buildArgs []strin
 		fmt.Println()
 		buildOut = os.Stdout
 		buildErr = os.Stderr
+		PrintDockerfileContent(dockerfile, buildOut)
 		PrintContextualInfo()
 	} else {
 		// print dots. quit channel explanation: https://stackoverflow.com/a/16466581/105562


### PR DESCRIPTION
We want the user to be able to see dockerfile when they are running CLI in verbose mode.

Output:
```
gaurav@pc gp % cli deploy --app gaursain -v --local
Deploying gp to app: gaursain
Bumped to version 0.0.25
Using Container engine docker
Building image fndemouser/gp:0.0.25 
Dockerfile content
-----------------------------------
FROM fnproject/go:1.15-dev as build-stage
WORKDIR /function
WORKDIR /go/src/func/
ENV GO111MODULE=on
COPY . .
RUN cd /go/src/func/ && go build -o func
FROM fnproject/go:1.15
WORKDIR /function
COPY --from=build-stage /go/src/func/func /function/
ENTRYPOINT ["./func"]
-----------------------------------
// Other build logs
```