### PR TITLE
Allowing `fn inspect functions` and `fn list functions` for PBF(Pre-Built Functions) function with empty image and digest field. By default, it was not supported.    

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,13 @@
 
 # Releases
 
+## v 0.6.24
+
+* Allowing `fn inspect functions` and `fn list functions` for PBF(Pre-Built Functions) function with empty image and digest field. By default, it was not supported. 
+  
+  Note: If you have functions created using Pre-Built Functions, then please upgrade to this version to have fn list and fn inspect  work properly
+
+
 ## v 0.6.7
 
 * Support for following languages versions:

--- a/commands/invoke_windows.go
+++ b/commands/invoke_windows.go
@@ -13,30 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// +build windows
 
 package commands
 
 import (
 	"io"
 	"os"
+	"syscall"
+	"unsafe"
 )
 
 func stdin() io.Reader {
-	/*
 	if isTerminal(int(os.Stdin.Fd())) {
 		return nil
 	}
-	 */
 	return os.Stdin
 }
 
 func isTerminal(fd int) bool {
-	return true
-	/*
 	kernel32 := syscall.NewLazyDLL("kernel32.dll")
 	procGetConsoleMode := kernel32.NewProc("GetConsoleMode")
 	var st uint32
 	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
 	return r != 0 && e == 0
-	 */
 }

--- a/commands/invoke_windows.go
+++ b/commands/invoke_windows.go
@@ -13,28 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// +build windows
 
 package commands
 
 import (
 	"io"
 	"os"
-	"syscall"
-	"unsafe"
 )
 
 func stdin() io.Reader {
+	/*
 	if isTerminal(int(os.Stdin.Fd())) {
 		return nil
 	}
+	 */
 	return os.Stdin
 }
 
 func isTerminal(fd int) bool {
+	return true
+	/*
 	kernel32 := syscall.NewLazyDLL("kernel32.dll")
 	procGetConsoleMode := kernel32.NewProc("GetConsoleMode")
 	var st uint32
 	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
 	return r != 0 && e == 0
+	 */
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fnproject/cli
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/fatih/color v0.0.0-20170926111411-5df930a27be2
-	github.com/fnproject/fn_go v0.8.6
+	github.com/fnproject/fn_go v0.8.7
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/semver-bump v0.0.0-20140912095342-88e6c9f2fe39
 	github.com/go-openapi/runtime v0.19.23
@@ -22,7 +22,5 @@ require (
 	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-replace github.com/fnproject/fn_go v0.8.6 => /Users/sunny/Functions/pbf/fn_go
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,6 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
+replace github.com/fnproject/fn_go v0.8.6 => /Users/sunny/Functions/pbf/fn_go
+
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/fatih/color v0.0.0-20170926111411-5df930a27be2 h1:40J76vs1Y7oiHFqTrQH
 github.com/fatih/color v0.0.0-20170926111411-5df930a27be2/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fnproject/fn_go v0.8.6 h1:CO2ouYc9ZytENgeHe36gGRFKwCb7nM7wf7Y+VGkI7eA=
 github.com/fnproject/fn_go v0.8.6/go.mod h1:qQhi3sVpjmPVnxVwnWySZDjG0tackIT6IQjJ6BjiQpc=
+github.com/fnproject/fn_go v0.8.7 h1:XtRc5EWfRmTmlfkR5rfRFB9BejnEpYukmXHRS0ME0Q4=
+github.com/fnproject/fn_go v0.8.7/go.mod h1:qQhi3sVpjmPVnxVwnWySZDjG0tackIT6IQjJ6BjiQpc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
@@ -241,7 +241,19 @@ func ociFnToV2(ociFn functions.Function) *modelsv2.Fn {
 	annotations := make(map[string]interface{})
 	invokeEndpoint := fmt.Sprintf(invokeEndpointFmtString, *ociFn.InvokeEndpoint, *ociFn.Id)
 	annotations[annotationCompartmentId] = *ociFn.CompartmentId
-	annotations[annotationImageDigest] = *ociFn.ImageDigest
+
+	// For pbf functions image and its digest will be always empty
+	imageDigest := ""
+	if ociFn.ImageDigest != nil {
+		imageDigest = *ociFn.ImageDigest
+	}
+
+	image := ""
+	if ociFn.Image != nil {
+		image = *ociFn.Image
+	}
+
+	annotations[annotationImageDigest] = imageDigest
 	annotations[annotationInvokeEndpoint] = invokeEndpoint
 
 	var timeoutPtr *int32
@@ -256,7 +268,7 @@ func ociFnToV2(ociFn functions.Function) *modelsv2.Fn {
 		Config:      ociFn.Config,
 		CreatedAt:   strfmt.DateTime(ociFn.TimeCreated.Time),
 		ID:          *ociFn.Id,
-		Image:       *ociFn.Image,
+		Image:       image,
 		Memory:      uint64(*ociFn.MemoryInMBs),
 		Name:        *ociFn.DisplayName,
 		Timeout:     timeoutPtr,
@@ -268,7 +280,19 @@ func ociFnSummaryToV2(ociFnSummary functions.FunctionSummary) *modelsv2.Fn {
 	annotations := make(map[string]interface{})
 	invokeEndpoint := fmt.Sprintf(invokeEndpointFmtString, *ociFnSummary.InvokeEndpoint, *ociFnSummary.Id)
 	annotations[annotationCompartmentId] = *ociFnSummary.CompartmentId
-	annotations[annotationImageDigest] = *ociFnSummary.ImageDigest
+
+	// For pbf functions image and its digest will be always empty
+	imageDigest := ""
+	if ociFnSummary.ImageDigest != nil {
+		imageDigest = *ociFnSummary.ImageDigest
+	}
+
+	image := ""
+	if ociFnSummary.Image != nil {
+		image = *ociFnSummary.Image
+	}
+
+	annotations[annotationImageDigest] = imageDigest
 	annotations[annotationInvokeEndpoint] = invokeEndpoint
 
 	var timeoutPtr *int32
@@ -282,7 +306,7 @@ func ociFnSummaryToV2(ociFnSummary functions.FunctionSummary) *modelsv2.Fn {
 		AppID:       *ociFnSummary.ApplicationId,
 		CreatedAt:   strfmt.DateTime(ociFnSummary.TimeCreated.Time),
 		ID:          *ociFnSummary.Id,
-		Image:       *ociFnSummary.Image,
+		Image:       image,
 		Memory:      uint64(*ociFnSummary.MemoryInMBs),
 		Name:        *ociFnSummary.DisplayName,
 		Timeout:     timeoutPtr,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/coreos/go-semver/semver
 # github.com/fatih/color v0.0.0-20170926111411-5df930a27be2
 ## explicit
 github.com/fatih/color
-# github.com/fnproject/fn_go v0.8.6
+# github.com/fnproject/fn_go v0.8.6 => /Users/sunny/Functions/pbf/fn_go
 ## explicit
 github.com/fnproject/fn_go
 github.com/fnproject/fn_go/client/version

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/coreos/go-semver/semver
 # github.com/fatih/color v0.0.0-20170926111411-5df930a27be2
 ## explicit
 github.com/fatih/color
-# github.com/fnproject/fn_go v0.8.6 => /Users/sunny/Functions/pbf/fn_go
+# github.com/fnproject/fn_go v0.8.7
 ## explicit
 github.com/fnproject/fn_go
 github.com/fnproject/fn_go/client/version


### PR DESCRIPTION
Allowing `fn inspect functions` and `fn list functions` for PBF(Pre-Built Functions) function with empty image and digest field. By default, it was not supported. 