### PR TITLE
Add registry namespace

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -423,6 +423,7 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 				if err != nil {
 					return err
 				}
+				buildImage = common.AddContainerNamespace(buildImage)
 				a.ff.Build_image = buildImage
 			}
 			if helper.IsMultiStage() {
@@ -431,6 +432,7 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 					if err != nil {
 						return err
 					}
+					runImage = common.AddContainerNamespace(runImage)
 					a.ff.Run_image = runImage
 				}
 			}

--- a/common/common.go
+++ b/common/common.go
@@ -53,7 +53,10 @@ const (
 	FunctionsDockerImage       = "fnproject/fnserver"
 	FuncfileDockerRuntime      = "docker"
 	MinRequiredDockerVersion   = "17.5.0"
-	ContainerRegistryNamespace = "docker.io/"
+	ContainerRegistryNamespace = ""
+	//Change the containerRegistryNamespace while migrating the images to a different repository.
+	// The values should ghcr.io/ for github container registry, container-registry.oracle.com/ for OCR and docker.io or blank space for dockerhub.
+	//Currently keeping the value as blank due to cli_runtime_fallback_build test failure.
 )
 
 var GlobalVerbose bool

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -84,3 +84,23 @@ func Test_proxyArgs(t *testing.T) {
 		}
 	}
 }
+
+func Test_addNamespace(t *testing.T) {
+	testCases := []struct {
+		image         string
+		fullImageName string
+	}{
+		{image: "fnproject/go", fullImageName: ContainerRegistryNamespace + "fnproject/go"},
+		{image: "fnproject/dotnet", fullImageName: ContainerRegistryNamespace + "fnproject/dotnet"},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.image, func(t *testing.T) {
+			imageName := AddContainerNamespace(c.image)
+			if imageName != c.fullImageName {
+				t.Fatalf("expected %s but got %s", c.fullImageName, imageName)
+			}
+			t.Logf("Output %s", imageName)
+		})
+	}
+}

--- a/test/cli_runtime_fallback_build_test.go
+++ b/test/cli_runtime_fallback_build_test.go
@@ -18,10 +18,12 @@ package test
 
 import (
 	"fmt"
-	"github.com/fnproject/cli/langs"
-	"github.com/fnproject/cli/testharness"
 	"strings"
 	"testing"
+
+	"github.com/fnproject/cli/common"
+	"github.com/fnproject/cli/langs"
+	"github.com/fnproject/cli/testharness"
 )
 
 const (
@@ -45,11 +47,11 @@ entrypoint: ruby func.rb`
 )
 
 /*
-	This test case check for backwards compatibility with older cli func.yaml file
-	Cases Tested:
-	1. During `fn build` make sure Build_image and Run_image are stamped in func.yaml file
-	2. Function container is build using proper fallback runtime and dev image, check
-		by invoking container and fetching runtime version, should match with fallback version.
+This test case check for backwards compatibility with older cli func.yaml file
+Cases Tested:
+ 1. During `fn build` make sure Build_image and Run_image are stamped in func.yaml file
+ 2. Function container is build using proper fallback runtime and dev image, check
+    by invoking container and fetching runtime version, should match with fallback version.
 */
 func TestFnBuildWithOlderRuntimeWithoutVersion(t *testing.T) {
 	t.Run("`fn invoke` should return the fallback ruby version", func(t *testing.T) {
@@ -85,10 +87,15 @@ func TestFnBuildWithOlderRuntimeWithoutVersion(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+		bi = common.AddContainerNamespace(bi)
+		fmt.Println(bi)
+
 		ri, err := fallBackHandler.RunFromImage()
 		if err != nil {
 			panic(err)
 		}
+		ri = common.AddContainerNamespace(ri)
+		fmt.Println(ri)
 
 		updatedFuncFile := h.GetYamlFile("func.yaml")
 		if bi == "" || ri == "" {


### PR DESCRIPTION
Use a const variable ContainerRegistryNamespace to add the namespace of any registry like ghcr.io, ocr.io etc before the name of the image names. It would make the task of migrating to any other repositories an easier task, as we would only have to change the variable rather than changing the image names of all the runtimes.