### PR TITLE
WiP Change default content type to JSON

### DIFF
--- a/client/invoke.go
+++ b/client/invoke.go
@@ -80,7 +80,7 @@ func Invoke(provider provider.Provider, ireq InvokeRequest) (*http.Response, err
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	} else {
-		req.Header.Set("Content-Type", "text/plain")
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	if len(env) > 0 {


### PR DESCRIPTION
Change the default content type to `application/json`. It was always ignored anyway, but I've made another PR in fn_go that means that it will be used: https://github.com/fnproject/fn_go/pull/56

Once that PR is merged we should revendor `fn_go` with this PR.