### PR TITLE
Fix logic to parse registry for images in higher realms

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -558,12 +558,12 @@ func getRepositoryName(ff *common.FuncFileV20180708) (string, error) {
 	if len(parts) != 2 {
 		return "", fmt.Errorf("cannot parse image %s", ff.ImageNameV20180708())
 	}
-	pattern := regexp.MustCompile("(.*)\\.ocir\\.io/([^/]*)/(.*)")
+	pattern := regexp.MustCompile("(.*)ocir\\.([^/]*)/([^/]*)/(.*)")
 	parts = pattern.FindStringSubmatch(parts[0])
-	if len(parts) != 4 {
+	if len(parts) != 5 {
 		return "", fmt.Errorf("cannot parse registry for image %s", ff.ImageNameV20180708())
 	}
-	return parts[3], nil
+	return parts[4], nil
 }
 
 func getImageDigest(ff *common.FuncFileV20180708) (string, error) {


### PR DESCRIPTION
Corresponding Jira Ticket: [FAAS-8815](https://jira.oci.oraclecorp.com/browse/FAAS-8815)

Tested the regexp logic using the following sample imageNames for different realms:
 oc2: ocir.us-langley-1.oci.oraclegovcloud.com/bmcdw/anuracha/hello-java:0.0.1
oc3: ocir.us-gov-ashburn-1.oci.oraclegovcloud.com/bmcdw/anuracha/hello-java:0.0.1
oc4: ocir.uk-gov-london-1.oci.oraclegovcloud.uk/bmcdw/anuracha/hello-java:0.0.1
oc5: ocir.us-tacoma-1.oci.oracleonsrcloud.com/bmcdw/anuracha/hello-java:0.0.1
oc6: ocir.us-gov-fortworth-1.oci.oraclecloud.ic.gov/bmcdw/anuracha/hello-java:0.0.1
oc7: ocir.us-gov-sterling-1.oci.oc.ic.gov/bmcdw/anuracha/hello-java:0.0.1
oc8: ocir.ap-chiyoda-1.oci.oraclecloud8.com/bmcdw/anuracha/hello-java:0.0.1
oc9: ocir.me-dcc-muscat-1.oci.oraclecloud9.com/bmcdw/anuracha/hello-java:0.0.1