### PR TITLE
Added support for net8.0

### DIFF
--- a/langs/base.go
+++ b/langs/base.go
@@ -31,6 +31,7 @@ var helpers = []LangHelper{}
 var fallBackOlderVersions = map[string]LangHelper{}
 
 func init() {
+	registerHelper(&DotnetLangHelper{Version: "8.0"})
 	registerHelper(&DotnetLangHelper{Version: "6.0"})
 	registerHelper(&DotnetLangHelper{Version: "3.1"})
 	registerHelper(&GoLangHelper{Version: "1.19"})

--- a/langs/dotnet.go
+++ b/langs/dotnet.go
@@ -27,6 +27,7 @@ import (
 var dotnetToFrameworkVersionMap = map[string]string{
 	"3.1": "netcoreapp3.1",
 	"6.0": "net6.0",
+	"8.0": "net8.0",
 }
 
 type DotnetLangHelper struct {

--- a/test/cli_lang_boilerplate_test.go
+++ b/test/cli_lang_boilerplate_test.go
@@ -33,6 +33,7 @@ var Runtimes = []struct {
 	{"dotnet", ""},
 	{"dotnet3.1", ""},
 	{"dotnet6.0", ""},
+	{"dotnet8.0", ""},
 	{"java", ""},
 	{"java8", ""},
 	{"java11", ""},


### PR DESCRIPTION
`go/bin/fn init --help

DEVELOPMENT COMMANDS
  fn init -   Create a local func.yaml file

USAGE
  fn [global options] init [command options] [function-subdirectory]

DESCRIPTION
  This command creates a func.yaml file in the current directory.

COMMAND OPTIONS
  --name value                   Name of the function. Defaults to directory name in lowercase.
  --force                        Overwrite existing func.yaml
  --runtime value                Choose an existing runtime - dotnet, dotnet3.1, dotnet6.0, dotnet8.0, go, go1.18, go1.19, java, java11, java17, java8, kotlin, node, node18, node20, python, python3.11, python3.8, python3.9, ruby, ruby3.1
  --init-image value             A Docker image which will create a function template
  --entrypoint value             Entrypoint is the command to run to start this function - equivalent to Dockerfile ENTRYPOINT.
  --cmd value                    Command to run to start this function - equivalent to Dockerfile CMD.
  --version value                Set initial function version (default: "0.0.1")
  --working-dir value, -w value  Specify the working directory to initialise a function, must be the full path.
  --trigger value                Specify the trigger type - permitted values are 'http'.
  --memory value, -m value       Memory in MiB (default: 0)
  --config value, -c value       Function configuration
  --timeout value                Function timeout (eg. 30) (default: 0)
  --idle-timeout value           Function idle timeout (eg. 30) (default: 0)
  --annotation value             Function annotation (can be specified multiple times)`
  
  `go/bin/fn init --runtime dotnet8.0` 