### PR TITLE
Python 2 style print no longer supported on Ubuntu image

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -53,8 +53,8 @@ git push origin $tag
 # For GitHub
 url='https://api.github.com/repos/fnproject/cli/releases'
 output=$(curl -s -u $GH_DEPLOY_USER:$GH_DEPLOY_KEY -d "{\"tag_name\": \"$version\", \"name\": \"$version\"}" $url)
-upload_url=$(echo "$output" | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["upload_url"]' | sed -E "s/\{.*//")
-html_url=$(echo "$output" | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["html_url"]')
+upload_url=$(echo "$output" | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["upload_url"])' | sed -E "s/\{.*//")
+html_url=$(echo "$output" | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["html_url"])')
 curl --data-binary "@fn_linux"  -H "Content-Type: application/octet-stream" -u $GH_DEPLOY_USER:$GH_DEPLOY_KEY $upload_url\?name\=fn_linux >/dev/null
 curl --data-binary "@fn_mac"    -H "Content-Type: application/octet-stream" -u $GH_DEPLOY_USER:$GH_DEPLOY_KEY $upload_url\?name\=fn_mac >/dev/null
 curl --data-binary "@fn.exe"    -H "Content-Type: application/octet-stream" -u $GH_DEPLOY_USER:$GH_DEPLOY_KEY $upload_url\?name\=fn.exe >/dev/null


### PR DESCRIPTION
Fix for release.sh script error: SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?