### PR TITLE
Upgrade the Go version to 1.23.10 to mitigate the CVE-2025-22874

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 
 # Releases
+## v 0.6.43
+
+* Upgrade the Go version to 1.23.10 to mitigate the CVE-2025-22874
 ## v 0.6.41
 
 * Add missing release note for v0.6.40

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,4 @@ require (
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.10


### PR DESCRIPTION
Upgrade the Go version to 1.23.10 to mitigate the CVE-2025-22874