### PR TITLE
Add Object Storage settings to CLI context configuration

### DIFF
--- a/config/context_file.go
+++ b/config/context_file.go
@@ -27,6 +27,8 @@ type ContextFile struct {
 	ContextProvider string `yaml:"provider" json:"provider"`
 	EnvFnAPIURL     string `yaml:"api-url" json:"apiUrl"`
 	EnvFnRegistry   string `yaml:"registry" json:"registry"`
+	ObjectStorageBucketName string `yaml:"object_storage_bucket_name" json:"objectStorageBucketName"`
+	ObjectStorageNamespace  string `yaml:"namespace" json:"namespace"`
 }
 
 // NewContextFile creates a new instance of the context YAML file

--- a/config/context_file_test.go
+++ b/config/context_file_test.go
@@ -60,6 +60,14 @@ func TestContextFile(t *testing.T) {
 			if actual.EnvFnRegistry != tst.expected.EnvFnRegistry {
 				t.Fatalf("EnvFnRegistry: expected '%s', but got '%s'", tst.expected.EnvFnRegistry, actual.EnvFnRegistry)
 			}
+
+			if actual.ObjectStorageBucketName != tst.expected.ObjectStorageBucketName {
+				t.Fatalf("ObjectStorageBucketName: expected '%s', but got '%s'", tst.expected.ObjectStorageBucketName, actual.ObjectStorageBucketName)
+			}
+
+			if actual.ObjectStorageNamespace != tst.expected.ObjectStorageNamespace {
+				t.Fatalf("ObjectStorageNamespace: expected '%s', but got '%s'", tst.expected.ObjectStorageNamespace, actual.ObjectStorageNamespace)
+			}
 		})
 	}
 }
@@ -73,11 +81,15 @@ func prepareTestFiles(folder string) ([]testCase, error) {
 			contents: `
 api-url: http://localhost:8080
 provider: default
-registry: "someregistry"`,
+registry: "someregistry"
+object_storage_bucket_name: "code-only-test-files"
+namespace: "oracledevnamespace"`,
 			expected: &ContextFile{
-				ContextProvider: "default",
-				EnvFnAPIURL:     "http://localhost:8080",
-				EnvFnRegistry:   "someregistry",
+				ContextProvider:         "default",
+				EnvFnAPIURL:             "http://localhost:8080",
+				EnvFnRegistry:           "someregistry",
+				ObjectStorageBucketName: "code-only-test-files",
+				ObjectStorageNamespace:  "oracledevnamespace",
 			},
 		},
 	}


### PR DESCRIPTION
Add Object Storage-related fields to the CLI context configuration model so later code-only workflows can resolve upload-backed source settings from the active context.

Included
- support for:
  - object_storage_bucket_name
  - namespace
- parsing coverage in config/context_file_test.go
