### PR TITLE
fix hot relad issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn watch --app <app>
 This watches the current directory recursively and triggers:
 
 ```sh
-fn deploy --app <app> --local --no-bump
+fn deploy --app <app> --local
 ```
 
 ### Ignoring paths

--- a/commands/start.go
+++ b/commands/start.go
@@ -125,6 +125,10 @@ func start(c *cli.Context) error {
 	if c.String("log-level") != "" {
 		args = append(args, "-e", fmt.Sprintf("FN_LOG_LEVEL=%v", c.String("log-level")))
 	}
+	if c.Bool("local-debug") {
+		args = append(args, "-e", fmt.Sprintf("FN_HOT_START_TIMEOUT_MSECS=%d", 300000))
+	}
+
 	if c.String("env-file") != "" {
 		args = append(args, "--env-file", c.String("env-file"))
 	}

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -21,10 +21,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/fnproject/cli/common"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -39,6 +42,8 @@ const (
 	fnIgnoreFileName     = ".fnignore"
 )
 
+var watchFuncYamlVersionLine = regexp.MustCompile(`(?m)^\s*version\s*:\s*.*$`)
+
 // WatchCommand returns watch cli.Command.
 //
 // Usage: fn watch --app <app>
@@ -51,7 +56,7 @@ func WatchCommand() cli.Command {
 		Usage:    "\tWatches the current directory and redeploys to a local Fn server on changes.",
 		Category: "DEVELOPMENT COMMANDS",
 		Description: "Watches all files under the current directory recursively. " +
-			"When a file changes, it runs: fn deploy --app <app> --local --no-bump. " +
+			"When a file changes, it runs: fn deploy --app <app> --local. " +
 			"Paths can be ignored via default ignores and optionally a .fnignore file.",
 		Flags: []cli.Flag{
 			cli.StringFlag{
@@ -140,6 +145,14 @@ func (w *watchcmd) watchLoop(ctx context.Context, root string, appName string, w
 		debounceTimer  *time.Timer
 	)
 
+	// If func.yaml changes only by its "version:" line, ignore it (those changes are
+	// frequently made automatically by tools and do not affect the deploy outcome).
+	funcYamlPath, err := common.FindFuncfile(root)
+	if err != nil {
+		return err
+	}
+	prevFuncYamlFiltered, _ := readFileFilterFuncYamlVersion(funcYamlPath)
+
 	var triggerDeploy func()
 
 	triggerDeploy = func() {
@@ -217,6 +230,20 @@ func (w *watchcmd) watchLoop(ctx context.Context, root string, appName string, w
 				break
 			}
 
+			// Special-case func.yaml: ignore changes where the only modification is
+			// the value of the top-level `version:` key.
+			if samePath(event.Name, funcYamlPath) && event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+				curFiltered, err := readFileFilterFuncYamlVersion(funcYamlPath)
+				if err == nil {
+					if prevFuncYamlFiltered != nil && string(curFiltered) == string(prevFuncYamlFiltered) {
+						// Ignore the event.
+						break
+					}
+					prevFuncYamlFiltered = curFiltered
+				}
+				// If we can't read, fall back to normal change behavior.
+			}
+
 			// Treat any write/create/remove/rename as a change signal.
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) != 0 {
 				scheduleDeploy(event.Name)
@@ -237,7 +264,7 @@ func runFnDeployLocal(ctx context.Context, dir string, appName string) error {
 		return err
 	}
 
-	cmd := exec.CommandContext(ctx, executable, "deploy", "--app", appName, "--local", "--no-bump")
+	cmd := exec.CommandContext(ctx, executable, "deploy", "--app", appName, "--local")
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -340,4 +367,33 @@ func addRecursiveWatches(watcher *fsnotify.Watcher, root string, ignore watchIgn
 		}
 		return nil
 	})
+}
+
+func samePath(a, b string) bool {
+	aa, err := filepath.Abs(a)
+	if err != nil {
+		aa = a
+	}
+	bb, err := filepath.Abs(b)
+	if err != nil {
+		bb = b
+	}
+	return filepath.Clean(aa) == filepath.Clean(bb)
+}
+
+func readFileFilterFuncYamlVersion(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove any version lines so changes to those lines do not trigger deploy.
+	filtered := watchFuncYamlVersionLine.ReplaceAll(b, []byte(""))
+	return filtered, nil
 }

--- a/commands/watch_test.go
+++ b/commands/watch_test.go
@@ -19,6 +19,10 @@ func TestWatchLoopSingleChangeTriggersSingleDeploy(t *testing.T) {
 	if err := os.WriteFile(targetFile, []byte("v1"), 0644); err != nil {
 		t.Fatal(err)
 	}
+	funcYamlFile := filepath.Join(root, "func.yaml")
+	if err := os.WriteFile(funcYamlFile, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	restoreDeployFn := runFnDeployLocalFn
 	defer func() { runFnDeployLocalFn = restoreDeployFn }()
@@ -73,6 +77,10 @@ func TestWatchLoopCoalescesChangesDuringDeployIntoOneFollowUp(t *testing.T) {
 	root := t.TempDir()
 	targetFile := filepath.Join(root, "func.py")
 	if err := os.WriteFile(targetFile, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	funcYamlFile := filepath.Join(root, "func.yaml")
+	if err := os.WriteFile(funcYamlFile, []byte("v1"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -196,6 +204,79 @@ func TestLoadWatchIgnoreReadsFnIgnoreAndExtras(t *testing.T) {
 	}
 	if !ig.shouldIgnore(root, filepath.Join(root, "nested", "agit .log"), false) {
 		t.Fatal("expected glob-based segment ignore to match nested file")
+	}
+}
+
+func TestWatchLoopIgnoresFuncYamlVersionOnlyChanges(t *testing.T) {
+	root := t.TempDir()
+	funcYaml := filepath.Join(root, "func.yaml")
+	if err := os.WriteFile(funcYaml, []byte("version: 0.0.1\nname: f\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	restoreDeployFn := runFnDeployLocalFn
+	defer func() { runFnDeployLocalFn = restoreDeployFn }()
+
+	var calls int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runFnDeployLocalFn = func(_ context.Context, _ string, _ string) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	}
+
+	w := watchcmd{debounce: 20 * time.Millisecond}
+	ignore, err := loadWatchIgnore(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- w.watchLoop(ctx, root, "myapp", ignore)
+	}()
+
+	// allow watcher to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Change only the func.yaml version line. This should not trigger deploy.
+	if err := os.WriteFile(funcYaml, []byte("version: 0.0.2\nname: f\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait longer than debounce and assert no deploy happened
+	time.Sleep(200 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		cancel()
+		<-done
+		t.Fatalf("expected 0 deploys for version-only change, got %d", got)
+	}
+
+	// Now make a real change. This should trigger deploy.
+	if err := os.WriteFile(funcYaml, []byte("version: 0.0.3\nname: f2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for deploy to trigger
+	deadline := time.Now().Add(3 * time.Second)
+	for atomic.LoadInt32(&calls) == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		cancel()
+		<-done
+		t.Fatalf("expected 1 deploy after non-version change, got %d", got)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watch loop failed: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for watch loop")
 	}
 }
 


### PR DESCRIPTION
We could not use "no-bump" option in deploying functions locally as the hot container running in FnServer will not detect the code change and will still use the old image.

FnServer calculated the slot hash by using image version only (and also other attributes). If we do not update image version, the FnServer will not pick up the new change if there is a hot container is already running.

Also fixed a hot container init timeout issue if developer is using local debug mode. Setting it to 5 mins so that developer has enough time to attach an IDE debugger when container is waiting to start.