### PR TITLE
Add subnet-id usability, resource tag support, and PBF function create support to Fn CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,44 @@ These OCI Functions settings can be used through multiple Fn CLI workflows:
 - `fn create function` / `fn update function` to apply them directly from the CLI
 - `fn deploy` to apply values persisted in `func.yaml`
 
+### Application networking
+Create an OCI Functions application with a subnet OCID using a dedicated flag:
+
+```sh
+fn create app <app-name> --subnet-id <subnet-ocid>
+```
+
+For Oracle-backed apps, `fn create app` requires at least one subnet. `fn update app --subnet-id` is currently not supported through the current OCI update API model and returns a clear error instead.
+
+### Resource tags
+Add freeform tags using `--tag key=value`:
+
+```sh
+fn create app <app-name> --subnet-id <subnet-ocid> --tag Department=Finance
+fn create function <app-name> <function-name> <image> --tag Team=Payments
+```
+
+Add defined tags using `--defined-tag namespace.key=value`:
+
+```sh
+fn create app <app-name> --subnet-id <subnet-ocid> --defined-tag dry_run_tag.example-tag=10
+fn create function <app-name> <function-name> <image> --defined-tag Operations.CostCenter=42
+```
+
+By default, plain scalar defined-tag values are treated as strings. Use explicit JSON only when needed:
+
+```sh
+fn create app <app-name> --subnet-id <subnet-ocid> \
+  --defined-tag 'custom.meta={"level":2}'
+```
+
+Update flows also support tag removal and clear semantics:
+
+```sh
+fn update app <app-name> --remove-tag Department --clear-defined-tags
+fn update function <app-name> <function-name> --remove-defined-tag Operations.CostCenter
+```
+
 ### Examples
 Initialize a function with provisioned concurrency:
 
@@ -93,6 +131,11 @@ Example `func.yaml` output:
 ```yaml
 deploy:
   oci:
+    freeform_tags:
+      Department: Finance
+    defined_tags:
+      Operations:
+        CostCenter: "42"
     provisionedConcurrency:
       strategy: CONSTANT
       count: 40
@@ -107,6 +150,21 @@ deploy:
 ```
 
 When these OCI-specific flags are used with a non-Oracle provider or local Fn server workflows, Fn CLI accepts them and emits user-friendly warnings where the settings are not applicable.
+
+### Pre-Built Function create support
+Create a function from a Pre-Built Function (PBF) listing OCID:
+
+```sh
+fn create function <app-name> <function-name> --pbf <pbf-listing-ocid>
+```
+
+For PBF create flows:
+- `--image` and `--pbf` are mutually exclusive
+- the image positional argument is optional when `--pbf` is used
+- Fn CLI automatically resolves the minimum required memory from the current PBF version when possible
+- if you specify `--memory`, it must be greater than or equal to the PBF minimum requirement
+
+Current limitation: `--pbf` support is currently focused on `fn create function` and is not yet persisted through `func.yaml` / deploy flows.
 
 ### Detached invoke examples
 Invoke a function in detached mode:

--- a/commands/init.go
+++ b/commands/init.go
@@ -119,6 +119,14 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Name:  "annotation",
 			Usage: "Function annotation (can be specified multiple times)",
 		},
+		cli.StringSliceFlag{
+			Name:  "tag",
+			Usage: "Freeform tag in key=value form (can be specified multiple times)",
+		},
+		cli.StringSliceFlag{
+			Name:  "defined-tag",
+			Usage: "Defined tag in namespace.key=value form (can be specified multiple times)",
+		},
 		cli.StringFlag{
 			Name:  "detached-timeout",
 			Usage: "Set OCI detached mode timeout using a duration like 20m or 1h",
@@ -212,6 +220,15 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		return err
 	}
 	common.SetProvisionedConcurrency(a.ff, pcConfig)
+	freeformTags, err := common.ParseFreeformTagSpecs(c.StringSlice("tag"))
+	if err != nil {
+		return err
+	}
+	definedTags, err := common.ParseDefinedTagSpecs(c.StringSlice("defined-tag"))
+	if err != nil {
+		return err
+	}
+	common.SetOCIResourceTagsOnFuncFile(a.ff, freeformTags, definedTags)
 
 	runtime := c.String("runtime")
 	initImage := c.String("init-image")

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -90,7 +90,9 @@ type OCIProvisionedConcurrencyConfig struct {
 // OCIFunctionDeployConfig stores OCI-specific deploy configuration for a function.
 type OCIFunctionDeployConfig struct {
 	ProvisionedConcurrency *OCIProvisionedConcurrencyConfig `yaml:"provisioned_concurrency,omitempty" json:"provisioned_concurrency,omitempty"`
-	DetachedMode           *OCIDetachedModeConfig          `yaml:"detached_mode,omitempty" json:"detached_mode,omitempty"`
+	DetachedMode           *OCIDetachedModeConfig           `yaml:"detached_mode,omitempty" json:"detached_mode,omitempty"`
+	FreeformTags           map[string]string                `yaml:"freeform_tags,omitempty" json:"freeform_tags,omitempty"`
+	DefinedTags            OCIDefinedTags                   `yaml:"defined_tags,omitempty" json:"defined_tags,omitempty"`
 }
 
 // FuncDeployConfig stores deploy-time configuration sections in func.yaml.
@@ -434,6 +436,9 @@ func (ff *FuncFileV20180708) HasOCIManagedFunctionSettings() bool {
 	if oci.DetachedMode != nil && (oci.DetachedMode.Timeout != "" || oci.DetachedMode.OnSuccess != nil || oci.DetachedMode.OnFailure != nil) {
 		return true
 	}
+	if len(oci.FreeformTags) > 0 || len(oci.DefinedTags) > 0 {
+		return true
+	}
 
 	return false
 }
@@ -453,6 +458,7 @@ func (ff *FuncFileV20180708) OCIManagedFunctionSettingNames() []string {
 	if oci.DetachedMode != nil && (oci.DetachedMode.Timeout != "" || oci.DetachedMode.OnSuccess != nil || oci.DetachedMode.OnFailure != nil) {
 		settings = append(settings, "detached_mode")
 	}
+	settings = append(settings, OCIManagedResourceTagSettingNames(ff)...)
 
 	return settings
 }

--- a/common/oci_tags.go
+++ b/common/oci_tags.go
@@ -1,0 +1,335 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	AnnotationOCIResourceFreeformTags = "oracle.com/oci/freeformTags"
+	AnnotationOCIResourceDefinedTags  = "oracle.com/oci/definedTags"
+)
+
+// OCIDefinedTags stores user-friendly defined tag values for func.yaml persistence.
+// Values may be strings, numbers, booleans, objects, arrays, or null.
+type OCIDefinedTags map[string]map[string]interface{}
+
+func ParseFreeformTagSpecs(specs []string) (map[string]string, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	tags := make(map[string]string)
+	for _, spec := range specs {
+		parts := strings.SplitN(strings.TrimSpace(spec), "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid tag %q (expected key=value)", spec)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			return nil, fmt.Errorf("invalid tag %q (key must not be empty)", spec)
+		}
+		tags[key] = value
+	}
+	return tags, nil
+}
+
+func ParseDefinedTagSpecs(specs []string) (OCIDefinedTags, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	tags := make(OCIDefinedTags)
+	for _, spec := range specs {
+		parts := strings.SplitN(strings.TrimSpace(spec), "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid defined tag %q (expected namespace.key=value)", spec)
+		}
+		qualifier := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		nsKey := strings.SplitN(qualifier, ".", 2)
+		if len(nsKey) != 2 || strings.TrimSpace(nsKey[0]) == "" || strings.TrimSpace(nsKey[1]) == "" {
+			return nil, fmt.Errorf("invalid defined tag %q (expected namespace.key=value)", spec)
+		}
+		namespace := strings.TrimSpace(nsKey[0])
+		key := strings.TrimSpace(nsKey[1])
+		if tags[namespace] == nil {
+			tags[namespace] = make(map[string]interface{})
+		}
+		tags[namespace][key] = parseDefinedTagValue(value)
+	}
+	return tags, nil
+}
+
+func ConvertDefinedTagsToInterface(tags OCIDefinedTags) map[string]map[string]interface{} {
+	if len(tags) == 0 {
+		return nil
+	}
+	converted := make(map[string]map[string]interface{}, len(tags))
+	for namespace, values := range tags {
+		converted[namespace] = make(map[string]interface{}, len(values))
+		for key, value := range values {
+			converted[namespace][key] = value
+		}
+	}
+	return converted
+}
+
+func ConvertDefinedTagsFromInterface(tags map[string]map[string]interface{}) OCIDefinedTags {
+	if len(tags) == 0 {
+		return nil
+	}
+	converted := make(OCIDefinedTags, len(tags))
+	for namespace, values := range tags {
+		converted[namespace] = make(map[string]interface{}, len(values))
+		for key, value := range values {
+			converted[namespace][key] = value
+		}
+	}
+	return converted
+}
+
+func parseDefinedTagValue(value string) interface{} {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if !shouldParseDefinedTagValueAsJSON(trimmed) {
+		return value
+	}
+	var decoded interface{}
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
+		return decoded
+	}
+	return value
+}
+
+func shouldParseDefinedTagValueAsJSON(value string) bool {
+	if value == "" {
+		return false
+	}
+	switch value[0] {
+	case '{', '[', '"':
+		return true
+	default:
+		return false
+	}
+}
+
+func SetOCIResourceTagsOnFuncFile(ff *FuncFileV20180708, freeform map[string]string, defined OCIDefinedTags) {
+	if ff == nil {
+		return
+	}
+	if len(freeform) == 0 && len(defined) == 0 {
+		return
+	}
+	if ff.Deploy == nil {
+		ff.Deploy = &FuncDeployConfig{}
+	}
+	if ff.Deploy.OCI == nil {
+		ff.Deploy.OCI = &OCIFunctionDeployConfig{}
+	}
+	if len(freeform) > 0 {
+		ff.Deploy.OCI.FreeformTags = freeform
+	}
+	if len(defined) > 0 {
+		ff.Deploy.OCI.DefinedTags = defined
+	}
+}
+
+func OCIManagedResourceTagSettingNames(ff *FuncFileV20180708) []string {
+	if ff == nil || ff.Deploy == nil || ff.Deploy.OCI == nil {
+		return nil
+	}
+	settings := []string{}
+	if len(ff.Deploy.OCI.FreeformTags) > 0 {
+		settings = append(settings, "freeform_tags")
+	}
+	if len(ff.Deploy.OCI.DefinedTags) > 0 {
+		settings = append(settings, "defined_tags")
+	}
+	sort.Strings(settings)
+	return settings
+}
+
+func freeformTagsFromAnnotationValue(value interface{}) (map[string]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	result := map[string]string{}
+	switch typed := value.(type) {
+	case map[string]string:
+		for key, v := range typed {
+			result[key] = v
+		}
+		return result, nil
+	case map[string]interface{}:
+		for key, v := range typed {
+			result[key] = fmt.Sprint(v)
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("invalid freeform tags annotation")
+	}
+}
+
+func definedTagsFromAnnotationValue(value interface{}) (OCIDefinedTags, error) {
+	if value == nil {
+		return nil, nil
+	}
+	result := OCIDefinedTags{}
+	switch typed := value.(type) {
+	case map[string]map[string]string:
+		for namespace, values := range typed {
+			result[namespace] = map[string]interface{}{}
+			for key, v := range values {
+				result[namespace][key] = v
+			}
+		}
+		return result, nil
+	case map[string]map[string]interface{}:
+		return ConvertDefinedTagsFromInterface(typed), nil
+	case map[string]interface{}:
+		for namespace, rawValues := range typed {
+			converted := map[string]interface{}{}
+			switch values := rawValues.(type) {
+			case map[string]interface{}:
+				for key, value := range values {
+					converted[key] = value
+				}
+			case map[string]string:
+				for key, value := range values {
+					converted[key] = value
+				}
+			default:
+				return nil, fmt.Errorf("invalid defined tags annotation")
+			}
+			result[namespace] = converted
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("invalid defined tags annotation")
+	}
+}
+
+func setFreeformTagAnnotation(annotations map[string]interface{}, tags map[string]string) {
+	value := map[string]interface{}{}
+	for key, tagValue := range tags {
+		value[key] = tagValue
+	}
+	annotations[AnnotationOCIResourceFreeformTags] = value
+}
+
+func setDefinedTagAnnotation(annotations map[string]interface{}, tags OCIDefinedTags) {
+	if len(tags) == 0 {
+		annotations[AnnotationOCIResourceDefinedTags] = map[string]map[string]interface{}{}
+		return
+	}
+	annotations[AnnotationOCIResourceDefinedTags] = ConvertDefinedTagsToInterface(tags)
+}
+
+func parseDefinedTagKeySpec(spec string) (string, string, error) {
+	parts := strings.SplitN(strings.TrimSpace(spec), ".", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("invalid defined tag key %q (expected namespace.key)", spec)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func ApplyOCIResourceTagFlagsToAnnotations(
+	annotations map[string]interface{},
+	freeformSpecs []string,
+	definedSpecs []string,
+	removeFreeform []string,
+	removeDefined []string,
+	clearFreeform bool,
+	clearDefined bool,
+) (map[string]interface{}, error) {
+	if annotations == nil {
+		annotations = make(map[string]interface{})
+	}
+	freeform, err := freeformTagsFromAnnotationValue(annotations[AnnotationOCIResourceFreeformTags])
+	if err != nil {
+		return nil, err
+	}
+	defined, err := definedTagsFromAnnotationValue(annotations[AnnotationOCIResourceDefinedTags])
+	if err != nil {
+		return nil, err
+	}
+	if freeform == nil {
+		freeform = map[string]string{}
+	}
+	if defined == nil {
+		defined = OCIDefinedTags{}
+	}
+
+	if clearFreeform {
+		freeform = map[string]string{}
+	}
+	if clearDefined {
+		defined = OCIDefinedTags{}
+	}
+
+	parsedFreeform, err := ParseFreeformTagSpecs(freeformSpecs)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range parsedFreeform {
+		freeform[key] = value
+	}
+
+	parsedDefined, err := ParseDefinedTagSpecs(definedSpecs)
+	if err != nil {
+		return nil, err
+	}
+	for namespace, values := range parsedDefined {
+		if defined[namespace] == nil {
+			defined[namespace] = map[string]interface{}{}
+		}
+		for key, value := range values {
+			defined[namespace][key] = value
+		}
+	}
+
+	for _, key := range removeFreeform {
+		delete(freeform, strings.TrimSpace(key))
+	}
+	for _, spec := range removeDefined {
+		namespace, key, err := parseDefinedTagKeySpec(spec)
+		if err != nil {
+			return nil, err
+		}
+		if defined[namespace] != nil {
+			delete(defined[namespace], key)
+			if len(defined[namespace]) == 0 {
+				delete(defined, namespace)
+			}
+		}
+	}
+
+	if len(freeform) > 0 || clearFreeform || len(removeFreeform) > 0 {
+		setFreeformTagAnnotation(annotations, freeform)
+	} else {
+		delete(annotations, AnnotationOCIResourceFreeformTags)
+	}
+	if len(defined) > 0 || clearDefined || len(removeDefined) > 0 {
+		setDefinedTagAnnotation(annotations, defined)
+	} else {
+		delete(annotations, AnnotationOCIResourceDefinedTags)
+	}
+	return annotations, nil
+}
+
+func ApplyOCIResourceTagsToAnnotations(annotations map[string]interface{}, freeform map[string]string, defined OCIDefinedTags) map[string]interface{} {
+	if annotations == nil {
+		annotations = make(map[string]interface{})
+	}
+	if len(freeform) > 0 {
+		setFreeformTagAnnotation(annotations, freeform)
+	}
+	if len(defined) > 0 {
+		setDefinedTagAnnotation(annotations, defined)
+	}
+	return annotations
+}

--- a/common/oci_tags_test.go
+++ b/common/oci_tags_test.go
@@ -1,0 +1,113 @@
+package common
+
+import "testing"
+
+func TestApplyOCIResourceTagFlagsToAnnotations(t *testing.T) {
+	annotations, err := ApplyOCIResourceTagFlagsToAnnotations(nil, []string{"Department=Finance"}, []string{"Operations.CostCenter=42"}, nil, nil, false, false)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations() error = %v", err)
+	}
+	freeform, err := freeformTagsFromAnnotationValue(annotations[AnnotationOCIResourceFreeformTags])
+	if err != nil {
+		t.Fatalf("freeformTagsFromAnnotationValue() error = %v", err)
+	}
+	if freeform["Department"] != "Finance" {
+		t.Fatalf("expected Department=Finance, got %#v", freeform)
+	}
+	defined, err := definedTagsFromAnnotationValue(annotations[AnnotationOCIResourceDefinedTags])
+	if err != nil {
+		t.Fatalf("definedTagsFromAnnotationValue() error = %v", err)
+	}
+	if defined["Operations"]["CostCenter"] != "42" {
+		t.Fatalf("expected Operations.CostCenter=42, got %#v", defined)
+	}
+
+	annotations, err = ApplyOCIResourceTagFlagsToAnnotations(annotations, nil, nil, []string{"Department"}, []string{"Operations.CostCenter"}, false, false)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations(remove) error = %v", err)
+	}
+	freeform, _ = freeformTagsFromAnnotationValue(annotations[AnnotationOCIResourceFreeformTags])
+	if len(freeform) != 0 {
+		t.Fatalf("expected freeform tags to be empty, got %#v", freeform)
+	}
+	defined, _ = definedTagsFromAnnotationValue(annotations[AnnotationOCIResourceDefinedTags])
+	if len(defined) != 0 {
+		t.Fatalf("expected defined tags to be empty, got %#v", defined)
+	}
+}
+
+func TestApplyOCIResourceTagFlagsToAnnotationsKeepsEmptyMapsForRemoval(t *testing.T) {
+	annotations, err := ApplyOCIResourceTagFlagsToAnnotations(nil, []string{"Department=Finance"}, []string{"Operations.CostCenter=42"}, nil, nil, false, false)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations() error = %v", err)
+	}
+	annotations, err = ApplyOCIResourceTagFlagsToAnnotations(annotations, nil, nil, []string{"Department"}, []string{"Operations.CostCenter"}, false, false)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations(remove) error = %v", err)
+	}
+	if _, ok := annotations[AnnotationOCIResourceFreeformTags]; !ok {
+		t.Fatal("expected freeform tags annotation to remain present as empty map for removal semantics")
+	}
+	if _, ok := annotations[AnnotationOCIResourceDefinedTags]; !ok {
+		t.Fatal("expected defined tags annotation to remain present as empty map for removal semantics")
+	}
+}
+
+func TestSetOCIResourceTagsOnFuncFile(t *testing.T) {
+	ff := &FuncFileV20180708{}
+	freeform := map[string]string{"Department": "Finance"}
+	defined := OCIDefinedTags{"Operations": {"CostCenter": "42"}}
+
+	SetOCIResourceTagsOnFuncFile(ff, freeform, defined)
+
+	if ff.Deploy == nil || ff.Deploy.OCI == nil {
+		t.Fatal("expected deploy.oci to be initialized")
+	}
+	if ff.Deploy.OCI.FreeformTags["Department"] != "Finance" {
+		t.Fatalf("expected Department freeform tag, got %#v", ff.Deploy.OCI.FreeformTags)
+	}
+	if ff.Deploy.OCI.DefinedTags["Operations"]["CostCenter"] != "42" {
+		t.Fatalf("expected Operations.CostCenter defined tag, got %#v", ff.Deploy.OCI.DefinedTags)
+	}
+}
+
+func TestParseDefinedTagValuePreservesPlainScalarsAsStrings(t *testing.T) {
+	if got := parseDefinedTagValue("10"); got != "10" {
+		t.Fatalf("expected plain numeric scalar to remain string, got %#v", got)
+	}
+	if got := parseDefinedTagValue("true"); got != "true" {
+		t.Fatalf("expected plain boolean scalar to remain string, got %#v", got)
+	}
+}
+
+func TestParseDefinedTagValueStillAllowsExplicitJSON(t *testing.T) {
+	if got := parseDefinedTagValue(`"10"`); got != "10" {
+		t.Fatalf("expected quoted JSON string to decode to string, got %#v", got)
+	}
+	obj, ok := parseDefinedTagValue(`{"level":2}`).(map[string]interface{})
+	if !ok || obj["level"] != float64(2) {
+		t.Fatalf("expected JSON object to remain supported, got %#v", obj)
+	}
+}
+
+func TestApplyOCIResourceTagFlagsToAnnotationsClearDefinedTagsUsesEmptyMap(t *testing.T) {
+	annotations, err := ApplyOCIResourceTagFlagsToAnnotations(nil, nil, []string{"dry_run_tag.example-tag=10"}, nil, nil, false, false)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations(seed) error = %v", err)
+	}
+	annotations, err = ApplyOCIResourceTagFlagsToAnnotations(annotations, nil, nil, nil, nil, false, true)
+	if err != nil {
+		t.Fatalf("ApplyOCIResourceTagFlagsToAnnotations(clear-defined) error = %v", err)
+	}
+	raw, ok := annotations[AnnotationOCIResourceDefinedTags]
+	if !ok {
+		t.Fatal("expected defined tags annotation to be present")
+	}
+	definedRaw, ok := raw.(map[string]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected defined tags annotation to be an empty map payload, got %#v", raw)
+	}
+	if len(definedRaw) != 0 {
+		t.Fatalf("expected empty defined tags payload, got %#v", definedRaw)
+	}
+}

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	SHAPE_PARAMETER = "shape"
+	SHAPE_PARAMETER  = "shape"
+	annotationSubnet = "oracle.com/oci/subnetIds"
 )
 
 type appsCmd struct {
@@ -133,7 +134,7 @@ func BashCompleteApps(c *cli.Context) {
 	}
 }
 
-func appWithFlags(c *cli.Context, app *modelsv2.App) {
+func appWithFlags(c *cli.Context, app *modelsv2.App) error {
 	if c.IsSet("syslog-url") {
 		str := c.String("syslog-url")
 		app.SyslogURL = &str
@@ -144,6 +145,86 @@ func appWithFlags(c *cli.Context, app *modelsv2.App) {
 	if len(c.StringSlice("annotation")) > 0 {
 		app.Annotations = common.ExtractAnnotations(c)
 	}
+	annotations, err := common.ApplyOCIResourceTagFlagsToAnnotations(
+		app.Annotations,
+		c.StringSlice("tag"),
+		c.StringSlice("defined-tag"),
+		c.StringSlice("remove-tag"),
+		c.StringSlice("remove-defined-tag"),
+		c.Bool("clear-freeform-tags") || c.Bool("clear-tags"),
+		c.Bool("clear-defined-tags") || c.Bool("clear-tags"),
+	)
+	if err != nil {
+		return err
+	}
+	app.Annotations = annotations
+	if err := setSubnetIDAnnotations(app, c.StringSlice("subnet-id")); err != nil {
+		return err
+	}
+	return nil
+}
+
+func normalizeSubnetIDs(subnetIDs []string) ([]string, error) {
+	if len(subnetIDs) == 0 {
+		return nil, nil
+	}
+	normalized := make([]string, 0, len(subnetIDs))
+	for _, subnetID := range subnetIDs {
+		trimmed := strings.TrimSpace(subnetID)
+		if trimmed == "" {
+			return nil, fmt.Errorf("subnet IDs must not be empty")
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized, nil
+}
+
+func subnetIDsToAnnotationValue(subnetIDs []string) []interface{} {
+	values := make([]interface{}, len(subnetIDs))
+	for i, subnetID := range subnetIDs {
+		values[i] = subnetID
+	}
+	return values
+}
+
+func setSubnetIDAnnotations(app *modelsv2.App, subnetIDs []string) error {
+	normalized, err := normalizeSubnetIDs(subnetIDs)
+	if err != nil {
+		return err
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	if app.Annotations == nil {
+		app.Annotations = make(map[string]interface{})
+	}
+	if _, exists := app.Annotations[annotationSubnet]; exists {
+		return fmt.Errorf("--subnet-id cannot be used together with --annotation %s", annotationSubnet)
+	}
+	app.Annotations[annotationSubnet] = subnetIDsToAnnotationValue(normalized)
+	return nil
+}
+
+func validateSubnetIDUpdateSupported(p provider.Provider, subnetIDs []string) error {
+	if len(subnetIDs) == 0 {
+		return nil
+	}
+	if common.IsOracleProvider(p) {
+		return fmt.Errorf("--subnet-id is not currently supported with `fn update app` for Oracle-backed apps; use the OCI CLI or recreate the app with the desired subnet IDs")
+	}
+	return nil
+}
+
+func validateSubnetIDCreateRequired(p provider.Provider, app *modelsv2.App) error {
+	if !common.IsOracleProvider(p) {
+		return nil
+	}
+	if app != nil && app.Annotations != nil {
+		if _, ok := app.Annotations[annotationSubnet]; ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("Oracle-backed app creation requires at least one subnet; use --subnet-id <ocid> (or --annotation %s='[\"<subnet-ocid>\"]')", annotationSubnet)
 }
 
 func (a *appsCmd) create(c *cli.Context) error {
@@ -151,7 +232,9 @@ func (a *appsCmd) create(c *cli.Context) error {
 		Name: c.Args().Get(0),
 	}
 
-	appWithFlags(c, app)
+	if err := appWithFlags(c, app); err != nil {
+		return err
+	}
 	// If architectures flag is not set then default it to nil
 	if c.IsSet(SHAPE_PARAMETER) {
 		shapeParam := c.String(SHAPE_PARAMETER)
@@ -165,6 +248,9 @@ func (a *appsCmd) create(c *cli.Context) error {
 			return errors.New("invalid shape specified for the application")
 		}
 		app.Shape = shapeParam
+	}
+	if err := validateSubnetIDCreateRequired(a.provider, app); err != nil {
+		return err
 	}
 	_, err := CreateApp(a.client, app)
 	return err
@@ -198,7 +284,13 @@ func (a *appsCmd) update(c *cli.Context) error {
 		return err
 	}
 
-	appWithFlags(c, app)
+	if err := validateSubnetIDUpdateSupported(a.provider, c.StringSlice("subnet-id")); err != nil {
+		return err
+	}
+
+	if err := appWithFlags(c, app); err != nil {
+		return err
+	}
 
 	if _, err = PutApp(a.client, app.ID, app); err != nil {
 		return err

--- a/objects/app/apps_test.go
+++ b/objects/app/apps_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/fnproject/fn_go/modelsv2"
+	defaultprovider "github.com/fnproject/fn_go/provider/defaultprovider"
+	fnprovideroracle "github.com/fnproject/fn_go/provider/oracle"
+)
+
+func TestSetSubnetIDAnnotations(t *testing.T) {
+	app := &modelsv2.App{}
+	err := setSubnetIDAnnotations(app, []string{" ocid1.subnet.oc1..aaaa ", "ocid1.subnet.oc1..bbbb"})
+	if err != nil {
+		t.Fatalf("setSubnetIDAnnotations() error = %v", err)
+	}
+	got, ok := app.Annotations[annotationSubnet].([]interface{})
+	if !ok {
+		t.Fatalf("expected %s annotation to be []interface{}, got %#v", annotationSubnet, app.Annotations[annotationSubnet])
+	}
+	if len(got) != 2 || got[0] != "ocid1.subnet.oc1..aaaa" || got[1] != "ocid1.subnet.oc1..bbbb" {
+		t.Fatalf("unexpected subnet annotation value: %#v", got)
+	}
+}
+
+func TestSetSubnetIDAnnotationsConflictsWithExistingAnnotation(t *testing.T) {
+	app := &modelsv2.App{Annotations: map[string]interface{}{annotationSubnet: []interface{}{"ocid1.subnet.oc1..existing"}}}
+	err := setSubnetIDAnnotations(app, []string{"ocid1.subnet.oc1..new"})
+	if err == nil {
+		t.Fatal("expected conflict error when subnet annotation already exists")
+	}
+}
+
+func TestValidateSubnetIDUpdateSupported(t *testing.T) {
+	if err := validateSubnetIDUpdateSupported(nil, []string{"ocid1.subnet.oc1..aaaa"}); err != nil {
+		t.Fatalf("expected nil provider to allow update validation, got %v", err)
+	}
+	nonOracle := &defaultprovider.Provider{FnApiUrl: &url.URL{Scheme: "http", Host: "localhost:8080"}}
+	if err := validateSubnetIDUpdateSupported(nonOracle, []string{"ocid1.subnet.oc1..aaaa"}); err != nil {
+		t.Fatalf("expected non-oracle provider to allow subnet-id update validation, got %v", err)
+	}
+	oracleProvider := &fnprovideroracle.OracleProvider{}
+	if err := validateSubnetIDUpdateSupported(oracleProvider, []string{"ocid1.subnet.oc1..aaaa"}); err == nil {
+		t.Fatal("expected oracle provider to reject subnet-id update validation")
+	}
+}
+
+func TestValidateSubnetIDCreateRequired(t *testing.T) {
+	oracleProvider := &fnprovideroracle.OracleProvider{}
+	if err := validateSubnetIDCreateRequired(oracleProvider, &modelsv2.App{}); err == nil {
+		t.Fatal("expected oracle provider to require subnet annotations on create")
+	}
+	app := &modelsv2.App{Annotations: map[string]interface{}{annotationSubnet: []interface{}{"ocid1.subnet.oc1..aaaa"}}}
+	if err := validateSubnetIDCreateRequired(oracleProvider, app); err != nil {
+		t.Fatalf("expected oracle provider create validation to pass when subnet annotation exists, got %v", err)
+	}
+	nonOracle := &defaultprovider.Provider{FnApiUrl: &url.URL{Scheme: "http", Host: "localhost:8080"}}
+	if err := validateSubnetIDCreateRequired(nonOracle, &modelsv2.App{}); err != nil {
+		t.Fatalf("expected non-oracle provider create validation to pass without subnets, got %v", err)
+	}
+}

--- a/objects/app/commands.go
+++ b/objects/app/commands.go
@@ -28,16 +28,17 @@ import (
 func Create() cli.Command {
 	a := appsCmd{}
 	return cli.Command{
-		Name:     "app",
-		Usage:    "Create a new application",
-		Category: "MANAGEMENT COMMAND",
+		Name:        "app",
+		Usage:       "Create a new application",
+		Category:    "MANAGEMENT COMMAND",
 		Description: "This command creates a new application.\n	Fn supports grouping functions into a set that defines an application (or API), making it easy to organize and deploy.\n	Applications define a namespace to organize functions and can contain configuration values that are shared across all functions in that application.",
-		Aliases: []string{"apps", "a"},
+		Aliases:     []string{"apps", "a"},
 		Before: func(c *cli.Context) error {
 			provider, err := client.CurrentProvider()
 			if err != nil {
 				return err
 			}
+			a.provider = provider
 			a.client = provider.APIClientv2()
 			return nil
 		},
@@ -52,6 +53,14 @@ func Create() cli.Command {
 				Name:  "annotation",
 				Usage: "Application annotations",
 			},
+			cli.StringSliceFlag{
+				Name:  "tag",
+				Usage: "Freeform tag in key=value form (can be specified multiple times)",
+			},
+			cli.StringSliceFlag{
+				Name:  "defined-tag",
+				Usage: "Defined tag in namespace.key=value form (can be specified multiple times)",
+			},
 			cli.StringFlag{
 				Name:  "syslog-url",
 				Usage: "Syslog URL to send application logs to",
@@ -59,6 +68,10 @@ func Create() cli.Command {
 			cli.StringFlag{
 				Name:  "shape",
 				Usage: "Valid values are GENERIC_X86, GENERIC_ARM and GENERIC_X86_ARM. Default is GENERIC_X86. Setting this to GENERIC_X86, will run the functions in the application on X86 processor architecture.\n Setting this to GENERIC_ARM, will run the functions in the application on ARM processor architecture.\n When set to 'GENERIC_X86_ARM', functions in the application are run on either X86 or ARM processor architecture.\n Accepted values are:\n GENERIC_X86, GENERIC_ARM, GENERIC_X86_ARM",
+			},
+			cli.StringSliceFlag{
+				Name:  "subnet-id",
+				Usage: "Subnet OCID for OCI Functions applications (can be specified multiple times; maps to oracle.com/oci/subnetIds)",
 			},
 		},
 	}
@@ -78,6 +91,7 @@ func List() cli.Command {
 			if err != nil {
 				return err
 			}
+			a.provider = provider
 			a.client = provider.APIClientv2()
 			return nil
 		},
@@ -115,6 +129,7 @@ func Delete() cli.Command {
 			if err != nil {
 				return err
 			}
+			a.provider = provider
 			a.client = provider.APIClientv2()
 			return nil
 		},
@@ -152,6 +167,7 @@ func Inspect() cli.Command {
 			if err != nil {
 				return err
 			}
+			a.provider = provider
 			a.client = provider.APIClientv2()
 			return nil
 		},
@@ -201,6 +217,7 @@ func Update() cli.Command {
 			if err != nil {
 				return err
 			}
+			a.provider = provider
 			a.client = provider.APIClientv2()
 			return nil
 		},
@@ -215,9 +232,41 @@ func Update() cli.Command {
 				Name:  "annotation",
 				Usage: "Application annotations",
 			},
+			cli.StringSliceFlag{
+				Name:  "tag",
+				Usage: "Freeform tag in key=value form (can be specified multiple times)",
+			},
+			cli.StringSliceFlag{
+				Name:  "defined-tag",
+				Usage: "Defined tag in namespace.key=value form (can be specified multiple times)",
+			},
+			cli.StringSliceFlag{
+				Name:  "remove-tag",
+				Usage: "Remove a freeform tag by key (can be specified multiple times)",
+			},
+			cli.StringSliceFlag{
+				Name:  "remove-defined-tag",
+				Usage: "Remove a defined tag by namespace.key (can be specified multiple times)",
+			},
+			cli.BoolFlag{
+				Name:  "clear-tags",
+				Usage: "Clear all freeform and defined tags",
+			},
+			cli.BoolFlag{
+				Name:  "clear-freeform-tags",
+				Usage: "Clear all freeform tags",
+			},
+			cli.BoolFlag{
+				Name:  "clear-defined-tags",
+				Usage: "Clear all defined tags",
+			},
 			cli.StringFlag{
 				Name:  "syslog-url",
 				Usage: "Syslog URL to send application logs to",
+			},
+			cli.StringSliceFlag{
+				Name:  "subnet-id",
+				Usage: "Subnet OCID for OCI Functions applications (accepted for non-Oracle providers; Oracle-backed update currently not supported)",
 			},
 		},
 		BashComplete: func(c *cli.Context) {

--- a/objects/fn/commands.go
+++ b/objects/fn/commands.go
@@ -44,7 +44,7 @@ func Create() cli.Command {
 			f.client = f.provider.APIClientv2()
 			return nil
 		},
-		ArgsUsage: "<app-name> <function-name> <image>",
+		ArgsUsage: "<app-name> <function-name> [image]",
 		Action:    f.create,
 		Flags:     FnFlags,
 		BashComplete: func(c *cli.Context) {

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -49,6 +49,8 @@ type fnsCmd struct {
 const (
 	annotationProvisionedConcurrencyStrategy = "oracle.com/oci/provisionedConcurrencyStrategy"
 	annotationProvisionedConcurrencyCount    = "oracle.com/oci/provisionedConcurrencyCount"
+	annotationSourceType                     = "oracle.com/oci/sourceType"
+	annotationPbfListingID                   = "oracle.com/oci/pbfListingId"
 )
 
 const annotationDetachedTimeoutSeconds = "oracle.com/oci/detachedModeTimeoutInSeconds"
@@ -120,9 +122,21 @@ var FnFlags = []cli.Flag{
 		Name:  "annotation",
 		Usage: "Function annotation (can be specified multiple times)",
 	},
+	cli.StringSliceFlag{
+		Name:  "tag",
+		Usage: "Freeform tag in key=value form (can be specified multiple times)",
+	},
+	cli.StringSliceFlag{
+		Name:  "defined-tag",
+		Usage: "Defined tag in namespace.key=value form (can be specified multiple times)",
+	},
 	cli.StringFlag{
 		Name:  "image",
 		Usage: "Function image",
+	},
+	cli.StringFlag{
+		Name:  "pbf",
+		Usage: "Create the function from a Pre-Built Function listing OCID",
 	},
 	cli.StringFlag{
 		Name:  "provisioned-concurrency",
@@ -142,6 +156,26 @@ var FnFlags = []cli.Flag{
 	},
 }
 var updateFnFlags = append(append([]cli.Flag{}, FnFlags...),
+	cli.StringSliceFlag{
+		Name:  "remove-tag",
+		Usage: "Remove a freeform tag by key (can be specified multiple times)",
+	},
+	cli.StringSliceFlag{
+		Name:  "remove-defined-tag",
+		Usage: "Remove a defined tag by namespace.key (can be specified multiple times)",
+	},
+	cli.BoolFlag{
+		Name:  "clear-tags",
+		Usage: "Clear all freeform and defined tags",
+	},
+	cli.BoolFlag{
+		Name:  "clear-freeform-tags",
+		Usage: "Clear all freeform tags",
+	},
+	cli.BoolFlag{
+		Name:  "clear-defined-tags",
+		Usage: "Clear all defined tags",
+	},
 	cli.BoolFlag{
 		Name:  "clear-on-success",
 		Usage: "Clear OCI detached success destination",
@@ -591,6 +625,9 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 	if len(ff.Annotations) != 0 {
 		fn.Annotations = ff.Annotations
 	}
+	if ff.Deploy != nil && ff.Deploy.OCI != nil {
+		fn.Annotations = common.ApplyOCIResourceTagsToAnnotations(fn.Annotations, ff.Deploy.OCI.FreeformTags, ff.Deploy.OCI.DefinedTags)
+	}
 	// do something with triggers here
 
 	return nil
@@ -598,6 +635,61 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 
 func warnUnsupportedProvisionedConcurrency() {
 	fmt.Fprintln(os.Stderr, "Warning: --provisioned-concurrency is only supported with an oracle provider and will be ignored.")
+}
+
+func setPBFSourceAnnotations(fn *models.Fn, listingID string) error {
+	listingID = strings.TrimSpace(listingID)
+	if listingID == "" {
+		return nil
+	}
+	if fn.Annotations == nil {
+		fn.Annotations = make(map[string]interface{})
+	}
+	fn.Annotations[annotationSourceType] = "PRE_BUILT_FUNCTIONS"
+	fn.Annotations[annotationPbfListingID] = listingID
+	return nil
+}
+
+func fetchCurrentPBFMemoryRequirement(p provider.Provider, listingID string) (*int64, error) {
+	oracleProvider, ok := p.(*fnprovideroracle.OracleProvider)
+	if !ok || oracleProvider == nil {
+		return nil, nil
+	}
+	mgmtClient, err := buildFunctionsManagementClient(oracleProvider)
+	if err != nil {
+		return nil, err
+	}
+	isCurrent := true
+	limit := 1
+	res, err := mgmtClient.ListPbfListingVersions(context.Background(), ocifunctions.ListPbfListingVersionsRequest{
+		PbfListingId:     &listingID,
+		IsCurrentVersion: &isCurrent,
+		Limit:            &limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(res.Items) == 0 || res.Items[0].Requirements == nil {
+		return nil, nil
+	}
+	return res.Items[0].Requirements.MinMemoryRequiredInMBs, nil
+}
+
+func resolvePBFMemory(memory uint64, minRequired *int64) (uint64, error) {
+	if minRequired == nil || *minRequired <= 0 {
+		if memory > 0 {
+			return memory, nil
+		}
+		return 0, fmt.Errorf("unable to determine the minimum memory required for this PBF; please supply --memory explicitly")
+	}
+	minimum := uint64(*minRequired)
+	if memory == 0 {
+		return minimum, nil
+	}
+	if memory < minimum {
+		return 0, fmt.Errorf("--memory %d is below the minimum required for this PBF (%d MiB)", memory, minimum)
+	}
+	return memory, nil
 }
 
 func buildFunctionsManagementClient(oracleProvider *fnprovideroracle.OracleProvider) (*ocifunctions.FunctionsManagementClient, error) {
@@ -658,6 +750,7 @@ func ApplyProvisionedConcurrency(p provider.Provider, fnID string, cfg *common.O
 func (f *fnsCmd) create(c *cli.Context) error {
 	appName := c.Args().Get(0)
 	fnName := c.Args().Get(1)
+	pbfListingID := strings.TrimSpace(c.String("pbf"))
 	pcConfig, err := common.ParseProvisionedConcurrencySpec(c.String("provisioned-concurrency"))
 	if err != nil {
 		return err
@@ -684,12 +777,45 @@ func (f *fnsCmd) create(c *cli.Context) error {
 	fn.Image = c.Args().Get(2)
 
 	WithFlags(c, fn)
+	annotations, err := common.ApplyOCIResourceTagFlagsToAnnotations(
+		fn.Annotations,
+		c.StringSlice("tag"),
+		c.StringSlice("defined-tag"),
+		nil,
+		nil,
+		false,
+		false,
+	)
+	if err != nil {
+		return err
+	}
+	fn.Annotations = annotations
 
 	if fn.Name == "" {
 		return errors.New("fnName path is missing")
 	}
-	if fn.Image == "" {
+	if fn.Image != "" && pbfListingID != "" {
+		return errors.New("--image and --pbf cannot be used together")
+	}
+	if fn.Image == "" && pbfListingID == "" {
 		return errors.New("no image specified")
+	}
+	if pbfListingID != "" {
+		if !common.IsOracleProvider(f.provider) {
+			return errors.New("--pbf is only supported with an oracle provider")
+		}
+		if err := setPBFSourceAnnotations(fn, pbfListingID); err != nil {
+			return err
+		}
+		minMemory, err := fetchCurrentPBFMemoryRequirement(f.provider, pbfListingID)
+		if err != nil {
+			return fmt.Errorf("unable to determine PBF memory requirements: %w", err)
+		}
+		resolvedMemory, err := resolvePBFMemory(fn.Memory, minMemory)
+		if err != nil {
+			return err
+		}
+		fn.Memory = resolvedMemory
 	}
 	if pcConfig != nil {
 		if !common.IsOracleProvider(f.provider) {
@@ -742,9 +868,11 @@ func (f *fnsCmd) create(c *cli.Context) error {
 // CreateFn request
 func CreateFn(r *fnclient.Fn, appID string, fn *models.Fn) (*models.Fn, error) {
 	fn.AppID = appID
-	err := common.ValidateTagImageName(fn.Image)
-	if err != nil {
-		return nil, err
+	if fn.Image != "" {
+		err := common.ValidateTagImageName(fn.Image)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resp, err := r.Fns.CreateFn(&apifns.CreateFnParams{
@@ -830,6 +958,10 @@ func GetFnByName(client *fnclient.Fn, appID, fnName string) (*models.Fn, error) 
 func (f *fnsCmd) update(c *cli.Context) error {
 	appName := c.Args().Get(0)
 	fnName := c.Args().Get(1)
+	if strings.TrimSpace(c.String("pbf")) != "" {
+		return errors.New("--pbf is only supported when creating a function")
+	}
+
 	pcConfig, err := common.ParseProvisionedConcurrencySpec(c.String("provisioned-concurrency"))
 	if err != nil {
 		return err
@@ -854,16 +986,30 @@ func (f *fnsCmd) update(c *cli.Context) error {
 		return err
 	}
 
-	app, err := app.GetAppByName(f.client, appName)
+	appObj, err := app.GetAppByName(f.client, appName)
 	if err != nil {
 		return err
 	}
-	fn, err := GetFnByName(f.client, app.ID, fnName)
+	fn, err := GetFnByName(f.client, appObj.ID, fnName)
 	if err != nil {
 		return err
 	}
 
 	WithFlags(c, fn)
+	annotations, err := common.ApplyOCIResourceTagFlagsToAnnotations(
+		fn.Annotations,
+		c.StringSlice("tag"),
+		c.StringSlice("defined-tag"),
+		c.StringSlice("remove-tag"),
+		c.StringSlice("remove-defined-tag"),
+		c.Bool("clear-freeform-tags") || c.Bool("clear-tags"),
+		c.Bool("clear-defined-tags") || c.Bool("clear-tags"),
+	)
+	if err != nil {
+		return err
+	}
+	fn.Annotations = annotations
+
 	if detachedSeconds > 0 {
 		if !common.IsOracleProvider(f.provider) {
 			warnUnsupportedDetachedTimeout()

--- a/objects/fn/fns_test.go
+++ b/objects/fn/fns_test.go
@@ -89,3 +89,67 @@ func TestSetProvisionedConcurrencyAnnotations(t *testing.T) {
 		t.Fatalf("expected count annotation %d, got %#v", count, fn.Annotations[annotationProvisionedConcurrencyCount])
 	}
 }
+
+func TestSetPBFSourceAnnotations(t *testing.T) {
+	fn := &models.Fn{}
+	if err := setPBFSourceAnnotations(fn, "ocid1.pbflisting.oc1..example"); err != nil {
+		t.Fatalf("setPBFSourceAnnotations() error = %v", err)
+	}
+	if got := fn.Annotations[annotationSourceType]; got != "PRE_BUILT_FUNCTIONS" {
+		t.Fatalf("expected PRE_BUILT_FUNCTIONS source type, got %#v", got)
+	}
+	if got := fn.Annotations[annotationPbfListingID]; got != "ocid1.pbflisting.oc1..example" {
+		t.Fatalf("expected pbf listing ocid annotation, got %#v", got)
+	}
+}
+
+func TestWithFuncFileV20180708AppliesResourceTags(t *testing.T) {
+	ff := &common.FuncFileV20180708{
+		Deploy: &common.FuncDeployConfig{
+			OCI: &common.OCIFunctionDeployConfig{
+				FreeformTags: map[string]string{"Department": "Finance"},
+				DefinedTags:  common.OCIDefinedTags{"Operations": {"CostCenter": "42"}},
+			},
+		},
+	}
+	fn := &models.Fn{}
+	if err := WithFuncFileV20180708(ff, fn); err != nil {
+		t.Fatalf("WithFuncFileV20180708() error = %v", err)
+	}
+	freeformRaw, ok := fn.Annotations[common.AnnotationOCIResourceFreeformTags].(map[string]interface{})
+	if !ok || freeformRaw["Department"] != "Finance" {
+		t.Fatalf("expected freeform tag annotation, got %#v", fn.Annotations[common.AnnotationOCIResourceFreeformTags])
+	}
+	definedRaw, ok := fn.Annotations[common.AnnotationOCIResourceDefinedTags].(map[string]map[string]interface{})
+	if !ok || definedRaw["Operations"]["CostCenter"] != "42" {
+		t.Fatalf("expected defined tag annotation, got %#v", fn.Annotations[common.AnnotationOCIResourceDefinedTags])
+	}
+}
+
+func TestCreateCommandAllowsOptionalImageForPBF(t *testing.T) {
+	cmd := Create()
+	if cmd.ArgsUsage != "<app-name> <function-name> [image]" {
+		t.Fatalf("expected optional image args usage for PBF support, got %q", cmd.ArgsUsage)
+	}
+}
+
+func TestResolvePBFMemory(t *testing.T) {
+	min := int64(512)
+	resolved, err := resolvePBFMemory(0, &min)
+	if err != nil {
+		t.Fatalf("resolvePBFMemory(auto) error = %v", err)
+	}
+	if resolved != 512 {
+		t.Fatalf("expected auto-selected memory 512, got %d", resolved)
+	}
+	resolved, err = resolvePBFMemory(1024, &min)
+	if err != nil {
+		t.Fatalf("resolvePBFMemory(override) error = %v", err)
+	}
+	if resolved != 1024 {
+		t.Fatalf("expected user-selected memory 1024, got %d", resolved)
+	}
+	if _, err := resolvePBFMemory(256, &min); err == nil {
+		t.Fatal("expected an error when memory is below the PBF minimum")
+	}
+}

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/apps.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/apps.go
@@ -31,6 +31,14 @@ func (s *appsShim) CreateApp(params *apps.CreateAppParams) (*apps.CreateAppOK, e
 	if err != nil {
 		return nil, err
 	}
+	freeformTags, err := parseFreeformTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	definedTags, err := parseDefinedTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
 
 	shape, err := v2ToOCICreateApplicationShape(params.Body.Shape)
 	if err != nil {
@@ -42,6 +50,8 @@ func (s *appsShim) CreateApp(params *apps.CreateAppParams) (*apps.CreateAppOK, e
 		DisplayName:   &params.Body.Name,
 		SubnetIds:     subnetIds,
 		Config:        params.Body.Config,
+		FreeformTags:  freeformTags,
+		DefinedTags:   definedTags,
 		SyslogUrl:     params.Body.SyslogURL,
 		Shape:         shape,
 	}
@@ -158,10 +168,20 @@ func (s *appsShim) UpdateApp(params *apps.UpdateAppParams) (*apps.UpdateAppOK, e
 
 		etag = res.Etag
 	}
+	freeformTags, err := parseFreeformTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	definedTags, err := parseDefinedTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
 
 	details := functions.UpdateApplicationDetails{
-		Config:        params.Body.Config,
-		SyslogUrl:     params.Body.SyslogURL,
+		Config:       params.Body.Config,
+		FreeformTags: freeformTags,
+		DefinedTags:  definedTags,
+		SyslogUrl:    params.Body.SyslogURL,
 	}
 
 	req := functions.UpdateApplicationRequest{
@@ -216,16 +236,17 @@ func ociAppToV2(ociApp functions.Application) *modelsv2.App {
 	annotations := make(map[string]interface{})
 	annotations[annotationCompartmentId] = *ociApp.CompartmentId
 	annotations[annotationSubnet] = ociSubnetsToAnnotationValue(ociApp.SubnetIds)
+	addTagAnnotations(annotations, ociApp.FreeformTags, ociApp.DefinedTags)
 
 	return &modelsv2.App{
-		Annotations:   annotations,
-		Config:        ociApp.Config,
-		CreatedAt:     strfmt.DateTime(ociApp.TimeCreated.Time),
-		ID:            *ociApp.Id,
-		Name:          *ociApp.DisplayName,
-		Shape:         string(ociApp.Shape),
-		SyslogURL:     ociApp.SyslogUrl,
-		UpdatedAt:     strfmt.DateTime(ociApp.TimeUpdated.Time),
+		Annotations: annotations,
+		Config:      ociApp.Config,
+		CreatedAt:   strfmt.DateTime(ociApp.TimeCreated.Time),
+		ID:          *ociApp.Id,
+		Name:        *ociApp.DisplayName,
+		Shape:       string(ociApp.Shape),
+		SyslogURL:   ociApp.SyslogUrl,
+		UpdatedAt:   strfmt.DateTime(ociApp.TimeUpdated.Time),
 	}
 }
 
@@ -233,14 +254,15 @@ func ociAppSummaryToV2(ociAppSummary functions.ApplicationSummary) *modelsv2.App
 	annotations := make(map[string]interface{})
 	annotations[annotationCompartmentId] = *ociAppSummary.CompartmentId
 	annotations[annotationSubnet] = ociSubnetsToAnnotationValue(ociAppSummary.SubnetIds)
+	addTagAnnotations(annotations, ociAppSummary.FreeformTags, ociAppSummary.DefinedTags)
 
 	return &modelsv2.App{
-		Annotations:   annotations,
-		Shape: 		   string(ociAppSummary.Shape),
-		CreatedAt:     strfmt.DateTime(ociAppSummary.TimeCreated.Time),
-		ID:            *ociAppSummary.Id,
-		Name:          *ociAppSummary.DisplayName,
-		UpdatedAt:     strfmt.DateTime(ociAppSummary.TimeUpdated.Time),
+		Annotations: annotations,
+		Shape:       string(ociAppSummary.Shape),
+		CreatedAt:   strfmt.DateTime(ociAppSummary.TimeCreated.Time),
+		ID:          *ociAppSummary.Id,
+		Name:        *ociAppSummary.DisplayName,
+		UpdatedAt:   strfmt.DateTime(ociAppSummary.TimeUpdated.Time),
 	}
 }
 

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/common.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/common.go
@@ -1,8 +1,16 @@
 package shim
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 const annotationCompartmentId = "oracle.com/oci/compartmentId"
+
+const (
+	annotationFreeformTags = "oracle.com/oci/freeformTags"
+	annotationDefinedTags  = "oracle.com/oci/definedTags"
+)
 
 // OCI update config is wholesale replacement of the map. Here we do the FnV2 server-side merge on the client instead.
 // Based on https://github.com/fnproject/fn/blob/d55e01ab7d565e9796748f2f40662e94394aff07/api/models/fn.go#L274-L285
@@ -28,4 +36,70 @@ func ctxOrBackground(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return ctx
+}
+
+func parseFreeformTagsAnnotation(annotations map[string]interface{}) (map[string]string, error) {
+	if annotations == nil || len(annotations) == 0 {
+		return nil, nil
+	}
+	raw, ok := annotations[annotationFreeformTags]
+	if !ok {
+		return nil, nil
+	}
+	converted := map[string]string{}
+	switch typed := raw.(type) {
+	case map[string]string:
+		for key, value := range typed {
+			converted[key] = value
+		}
+	case map[string]interface{}:
+		for key, value := range typed {
+			converted[key] = fmt.Sprint(value)
+		}
+	default:
+		return nil, fmt.Errorf("invalid freeform tags annotation")
+	}
+	return converted, nil
+}
+
+func parseDefinedTagsAnnotation(annotations map[string]interface{}) (map[string]map[string]interface{}, error) {
+	if annotations == nil || len(annotations) == 0 {
+		return nil, nil
+	}
+	raw, ok := annotations[annotationDefinedTags]
+	if !ok {
+		return nil, nil
+	}
+	converted := map[string]map[string]interface{}{}
+	switch typed := raw.(type) {
+	case map[string]map[string]interface{}:
+		return typed, nil
+	case map[string]interface{}:
+		for namespace, values := range typed {
+			m, ok := values.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("invalid defined tags annotation")
+			}
+			converted[namespace] = m
+		}
+		return converted, nil
+	default:
+		return nil, fmt.Errorf("invalid defined tags annotation")
+	}
+}
+
+func addTagAnnotations(annotations map[string]interface{}, freeform map[string]string, defined map[string]map[string]interface{}) {
+	if annotations == nil {
+		return
+	}
+	if len(freeform) > 0 {
+		value := map[string]interface{}{}
+		for key, tagValue := range freeform {
+			value[key] = tagValue
+		}
+		annotations[annotationFreeformTags] = value
+	}
+	if len(defined) > 0 {
+		annotations[annotationDefinedTags] = defined
+	}
 }

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/fns.go
@@ -24,6 +24,8 @@ const (
 	annotationSuccessDestinationOCID = "oracle.com/oci/successDestinationOcid"
 	annotationFailureDestinationKind = "oracle.com/oci/failureDestinationKind"
 	annotationFailureDestinationOCID = "oracle.com/oci/failureDestinationOcid"
+	annotationSourceType             = "oracle.com/oci/sourceType"
+	annotationPbfListingID           = "oracle.com/oci/pbfListingId"
 
 	invokeEndpointFmtString = "%s/20181201/functions/%s/actions/invoke"
 )
@@ -53,15 +55,34 @@ func (s *fnsShim) CreateFn(params *fns.CreateFnParams) (*fns.CreateFnOK, error) 
 	if err != nil {
 		return nil, err
 	}
+	freeformTags, err := parseFreeformTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	definedTags, err := parseDefinedTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	sourceDetails, err := parseSourceDetailsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	var imagePtr *string
+	if params.Body.Image != "" {
+		imagePtr = &params.Body.Image
+	}
 
 	details := functions.CreateFunctionDetails{
 		DisplayName:                  &params.Body.Name,
 		ApplicationId:                &params.Body.AppID,
-		Image:                        &params.Body.Image,
+		Image:                        imagePtr,
 		MemoryInMBs:                  &memory,
 		ImageDigest:                  digest,
+		SourceDetails:                sourceDetails,
 		ProvisionedConcurrencyConfig: pcConfig,
 		Config:                       params.Body.Config,
+		FreeformTags:                 freeformTags,
+		DefinedTags:                  definedTags,
 		TimeoutInSeconds:             parseTimeout(params.Body.Timeout),
 	}
 	if detachedTimeoutSeconds, err := parseDetachedTimeoutAnnotation(params.Body.Annotations); err != nil {
@@ -204,12 +225,22 @@ func (s *fnsShim) UpdateFn(params *fns.UpdateFnParams) (*fns.UpdateFnOK, error) 
 	if err != nil {
 		return nil, err
 	}
+	freeformTags, err := parseFreeformTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
+	definedTags, err := parseDefinedTagsAnnotation(params.Body.Annotations)
+	if err != nil {
+		return nil, err
+	}
 
 	details := functions.UpdateFunctionDetails{
 		Image:            imagePtr,
 		ImageDigest:      digest,
 		MemoryInMBs:      memoryPtr,
 		Config:           params.Body.Config,
+		FreeformTags:     freeformTags,
+		DefinedTags:      definedTags,
 		TimeoutInSeconds: parseTimeout(params.Body.Timeout),
 	}
 	if detachedTimeoutSeconds, err := parseDetachedTimeoutAnnotation(params.Body.Annotations); err != nil {
@@ -421,6 +452,34 @@ func parseFailureDestination(kind, ocid string) (functions.FailureDestinationDet
 	}
 }
 
+func parseSourceDetailsAnnotation(annotations map[string]interface{}) (functions.FunctionSourceDetails, error) {
+	if annotations == nil || len(annotations) == 0 {
+		return nil, nil
+	}
+	rawType, ok := annotations[annotationSourceType]
+	if !ok {
+		return nil, nil
+	}
+	sourceType, ok := rawType.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid function source type annotation")
+	}
+	switch strings.ToUpper(strings.TrimSpace(sourceType)) {
+	case "PRE_BUILT_FUNCTIONS":
+		rawListingID, ok := annotations[annotationPbfListingID]
+		if !ok {
+			return nil, fmt.Errorf("invalid pbf listing annotation")
+		}
+		listingID, ok := rawListingID.(string)
+		if !ok || strings.TrimSpace(listingID) == "" {
+			return nil, fmt.Errorf("invalid pbf listing annotation")
+		}
+		return functions.PreBuiltFunctionSourceDetails{PbfListingId: &listingID}, nil
+	default:
+		return nil, fmt.Errorf("unsupported function source type %q", sourceType)
+	}
+}
+
 func addProvisionedConcurrencyAnnotations(annotations map[string]interface{}, cfg functions.FunctionProvisionedConcurrencyConfig) {
 	strategy := "NONE"
 	var count *int
@@ -462,6 +521,8 @@ func ociFnToV2(ociFn functions.Function) *modelsv2.Fn {
 	annotations[annotationImageDigest] = imageDigest
 	annotations[annotationInvokeEndpoint] = invokeEndpoint
 	addProvisionedConcurrencyAnnotations(annotations, ociFn.ProvisionedConcurrencyConfig)
+	addTagAnnotations(annotations, ociFn.FreeformTags, ociFn.DefinedTags)
+	addSourceDetailsAnnotations(annotations, ociFn.SourceDetails)
 	if ociFn.DetachedModeTimeoutInSeconds != nil {
 		annotations[annotationDetachedTimeoutSeconds] = *ociFn.DetachedModeTimeoutInSeconds
 	}
@@ -507,6 +568,8 @@ func ociFnSummaryToV2(ociFnSummary functions.FunctionSummary) *modelsv2.Fn {
 	annotations[annotationImageDigest] = imageDigest
 	annotations[annotationInvokeEndpoint] = invokeEndpoint
 	addProvisionedConcurrencyAnnotations(annotations, ociFnSummary.ProvisionedConcurrencyConfig)
+	addTagAnnotations(annotations, ociFnSummary.FreeformTags, ociFnSummary.DefinedTags)
+	addSourceDetailsAnnotations(annotations, ociFnSummary.SourceDetails)
 	if ociFnSummary.DetachedModeTimeoutInSeconds != nil {
 		annotations[annotationDetachedTimeoutSeconds] = *ociFnSummary.DetachedModeTimeoutInSeconds
 	}
@@ -572,6 +635,19 @@ func addDestinationAnnotations(annotations map[string]interface{}, success funct
 			if typed.TopicId != nil {
 				annotations[annotationFailureDestinationOCID] = *typed.TopicId
 			}
+		}
+	}
+}
+
+func addSourceDetailsAnnotations(annotations map[string]interface{}, sourceDetails functions.FunctionSourceDetails) {
+	if annotations == nil || sourceDetails == nil {
+		return
+	}
+	switch typed := sourceDetails.(type) {
+	case functions.PreBuiltFunctionSourceDetails:
+		annotations[annotationSourceType] = "PRE_BUILT_FUNCTIONS"
+		if typed.PbfListingId != nil {
+			annotations[annotationPbfListingID] = *typed.PbfListingId
 		}
 	}
 }


### PR DESCRIPTION
This PR extends Fn CLI with additional OCI Functions usability support for:
- application subnet configuration via a dedicated --subnet-id flag
- user-friendly freeform and defined resource tag flags for applications and functions
- minimal Pre-Built Function (PBF) source-details support for function creation

The change includes -

**Application subnet usability**
- add 'fn create app --subnet-id'
- map subnet IDs to 'oracle.com/oci/subnetIds'
- validate app creation requires subnet IDs
- return a clear unsupported message for 'fn update app --subnet-id'

**Resource tags support**
- add freeform tag support:
  - --tag key=value
- add defined tag support:
  - --defined-tag namespace.key=value

- add update helpers:
  - --remove-tag
  - --remove-defined-tag
  - --clear-tags
  - --clear-freeform-tags
  - --clear-defined-tags

- support tags for:
  - fn create app
  - fn update app
  - fn create function
  - fn update function
  - fn init

- persist function tag settings to func.yaml under:
  - deploy.oci.freeform_tags
  - deploy.oci.defined_tags

- map tag settings through the Oracle shim to OCI freeformTags / definedTags
- preserve correct clear/remove semantics for defined/freeform tags
- treat plain defined-tag values as strings by default
  - e.g. --defined-tag dry_run_tag.example-tag=10

- still allow expplicit JSON-style values when needed

**PBF source-details support**

- add 'fn create function ... --pbf <pbf-listing-ocid>'
- enforce mutual exclusion between '--image' and '--pbf'
- make the positional image argument optional for the PBF create flow
- map '--pbf' to OCI 'sourceDetails' using 'PRE_BUILT_FUNCTIONS'
- automatically resolve the minimum required memory from the current PBF version
- validate user-supplied memory against PBF minimum requirement