### PR TITLE
Add PBF catalog commands, func.yaml, and deploy support to Fn CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,42 @@ deploy:
 
 When these OCI-specific flags are used with a non-Oracle provider or local Fn server workflows, Fn CLI accepts them and emits user-friendly warnings where the settings are not applicable.
 
-### Pre-Built Function create support
+### Pre-Built Function (PBF) support
+List available Pre-Built Functions:
+
+```sh
+fn list pbfs
+fn list pbfs --search Document
+fn list pbfs --trigger http
+fn list pbfs --output json
+```
+
+Get a specific PBF listing:
+
+```sh
+fn get pbfs <pbf-name-or-ocid>
+```
+
+List versions for a PBF:
+
+```sh
+fn list pbfs versions <pbf-name-or-ocid>
+fn list pbfs versions <pbf-name-or-ocid> --current
+```
+
+Get a specific PBF version:
+
+```sh
+fn get pbfs version <pbf-listing-version-ocid>
+```
+
+List supported PBF trigger names:
+
+```sh
+fn list pbfs triggers
+fn list pbfs triggers http
+```
+
 Create a function from a Pre-Built Function (PBF) listing OCID:
 
 ```sh
@@ -164,7 +199,42 @@ For PBF create flows:
 - Fn CLI automatically resolves the minimum required memory from the current PBF version when possible
 - if you specify `--memory`, it must be greater than or equal to the PBF minimum requirement
 
-Current limitation: `--pbf` support is currently focused on `fn create function` and is not yet persisted through `func.yaml` / deploy flows.
+Persist a PBF-backed function definition using `fn init`:
+
+```sh
+fn init --name hello-pbf --pbf <pbf-listing-ocid>
+```
+
+Example `func.yaml` for a PBF-backed function:
+
+```yaml
+deploy:
+  oci:
+    pbf:
+      listing_id: <pbf-listing-ocid>
+```
+
+Deploy a persisted PBF-backed function:
+
+```sh
+fn deploy --app <app-name>
+```
+
+For PBF-backed deploys, Fn CLI skips image build/push/sign flows and creates or updates the function using PBF source details instead.
+
+Inspect/list output also surfaces PBF-backed functions:
+
+```sh
+fn inspect function <app-name> <function-name>
+fn list functions <app-name>
+```
+
+`fn list functions` includes a `SOURCE` column, for example:
+
+```text
+NAME          IMAGE   SOURCE                                      ID
+hello-pbf             pbf:<pbf-listing-ocid>                     <function-ocid>
+```
 
 ### Detached invoke examples
 Invoke a function in detached mode:

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fnproject/cli/objects/app"
 	"github.com/fnproject/cli/objects/context"
 	"github.com/fnproject/cli/objects/fn"
+	"github.com/fnproject/cli/objects/pbf"
 	"github.com/fnproject/cli/objects/server"
 	"github.com/fnproject/cli/objects/trigger"
 	"github.com/urfave/cli"
@@ -97,6 +98,7 @@ var DeleteCmds = Cmd{
 
 var GetCmds = Cmd{
 	"config": ConfigCommand("get"),
+	"pbfs":   pbf.Get(),
 }
 
 var InspectCmds = Cmd{
@@ -110,6 +112,7 @@ var ListCmds = Cmd{
 	"config":    ConfigCommand("list"),
 	"apps":      app.List(),
 	"functions": fn.List(),
+	"pbfs":      pbf.List(),
 	"triggers":  trigger.List(),
 	"contexts":  context.List(),
 }

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -355,7 +355,8 @@ func (p *deploycmd) deployFuncV20180708(c *cli.Context, app *models.App, funcfil
 	common.WarnIfOCIManagedFunctionSettingsUnsupported(os.Stderr, p.provider, funcfile.Name, funcfile)
 
 	oracleProvider, _ := getOracleProvider()
-	if oracleProvider != nil && oracleProvider.ImageCompartmentID != "" {
+	isPBFDeploy := funcfile.Deploy != nil && funcfile.Deploy.OCI != nil && funcfile.Deploy.OCI.PBF != nil && strings.TrimSpace(funcfile.Deploy.OCI.PBF.ListingID) != ""
+	if !isPBFDeploy && oracleProvider != nil && oracleProvider.ImageCompartmentID != "" {
 		// If the provider is Oracle and ImageCompartmentID is present, we need to deploy image to the ImageCompartmentID.
 		// The repository name should be unique throughout a tenancy. We check if a repository exists in the compartment and create it if it doesn't already exist.
 		// If the creation fails, it could be because the repository name aready exists in a different compartment.
@@ -393,36 +394,42 @@ func (p *deploycmd) deployFuncV20180708(c *cli.Context, app *models.App, funcfil
 		// TODO: this whole funcfile handling needs some love, way too confusing. Only bump makes permanent changes to it.
 	}
 
-	buildArgs := c.StringSlice("build-arg")
+	if !isPBFDeploy {
+		buildArgs := c.StringSlice("build-arg")
 
-	// In case of local ignore the architectures parameter
-	shape := ""
-	if !p.local && !p.localDebug {
-		// fetch the architectures
-		shape = app.Shape
-		if shape == "" {
-			shape = common.DefaultAppShape
-			app.Shape = shape
+		// In case of local ignore the architectures parameter
+		shape := ""
+		if !p.local && !p.localDebug {
+			// fetch the architectures
+			shape = app.Shape
+			if shape == "" {
+				shape = common.DefaultAppShape
+				app.Shape = shape
+			}
+
+			if _, ok := common.ShapeMap[shape]; !ok {
+				return errors.New(fmt.Sprintf("Invalid application : %s shape: %s", app.Name, shape))
+			}
 		}
 
-		if _, ok := common.ShapeMap[shape]; !ok {
-			return errors.New(fmt.Sprintf("Invalid application : %s shape: %s", app.Name, shape))
+		_, err := common.BuildFuncV20180708(common.IsVerbose(), funcfilePath, funcfile, buildArgs, p.noCache, shape, p.localDebug)
+		if err != nil {
+			return err
 		}
-	}
 
-	_, err := common.BuildFuncV20180708(common.IsVerbose(), funcfilePath, funcfile, buildArgs, p.noCache, shape, p.localDebug)
-	if err != nil {
-		return err
-	}
-
-	if err := p.signImage(funcfile); err != nil {
-		return err
+		if err := p.signImage(funcfile); err != nil {
+			return err
+		}
 	}
 	return p.updateFunction(c, app.ID, funcfile)
 }
 
 func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.FuncFileV20180708) error {
-	fmt.Printf("Updating function %s using image %s...\n", ff.Name, ff.ImageNameV20180708())
+	if ff.Deploy != nil && ff.Deploy.OCI != nil && ff.Deploy.OCI.PBF != nil && strings.TrimSpace(ff.Deploy.OCI.PBF.ListingID) != "" {
+		fmt.Printf("Updating function %s using PBF listing %s...\n", ff.Name, ff.Deploy.OCI.PBF.ListingID)
+	} else {
+		fmt.Printf("Updating function %s using image %s...\n", ff.Name, ff.ImageNameV20180708())
+	}
 	var detachedSeconds int
 	if ff.Deploy != nil && ff.Deploy.OCI != nil && ff.Deploy.OCI.DetachedMode != nil && ff.Deploy.OCI.DetachedMode.Timeout != "" {
 		_, seconds, err := common.ParseDetachedTimeoutSpec(ff.Deploy.OCI.DetachedMode.Timeout)
@@ -440,6 +447,11 @@ func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.Func
 	fn := &models.Fn{}
 	if err := function.WithFuncFileV20180708(ff, fn); err != nil {
 		return fmt.Errorf("Error getting function with funcfile: %s", err)
+	}
+	if ff.Deploy != nil && ff.Deploy.OCI != nil && ff.Deploy.OCI.PBF != nil {
+		if err := function.ResolvePBFMemoryForListing(p.provider, fn, ff.Deploy.OCI.PBF.ListingID); err != nil {
+			return err
+		}
 	}
 	if detachedSeconds > 0 && common.IsOracleProvider(p.provider) {
 		function.SetDetachedTimeoutAnnotation(fn, detachedSeconds)

--- a/commands/init.go
+++ b/commands/init.go
@@ -143,6 +143,10 @@ func initFlags(a *initFnCmd) []cli.Flag {
 			Name:  "provisioned-concurrency",
 			Usage: "Set OCI provisioned concurrency using 'none' or 'constant:<count>'",
 		},
+		cli.StringFlag{
+			Name:  "pbf",
+			Usage: "Initialize func.yaml for a Pre-Built Function using a PBF listing OCID",
+		},
 	}
 
 	return fgs
@@ -220,6 +224,15 @@ func (a *initFnCmd) init(c *cli.Context) error {
 		return err
 	}
 	common.SetProvisionedConcurrency(a.ff, pcConfig)
+	if pbfListingID := strings.TrimSpace(c.String("pbf")); pbfListingID != "" {
+		if a.ff.Deploy == nil {
+			a.ff.Deploy = &common.FuncDeployConfig{}
+		}
+		if a.ff.Deploy.OCI == nil {
+			a.ff.Deploy.OCI = &common.OCIFunctionDeployConfig{}
+		}
+		a.ff.Deploy.OCI.PBF = &common.OCIPBFSourceConfig{ListingID: pbfListingID}
+	}
 	freeformTags, err := common.ParseFreeformTagSpecs(c.StringSlice("tag"))
 	if err != nil {
 		return err
@@ -249,7 +262,6 @@ func (a *initFnCmd) init(c *cli.Context) error {
 			return fmt.Errorf("Runtime %s is no more supported for new apps. Please use python or %s runtime for new apps.", runtime, runtime[:strings.LastIndex(runtime, ".")])
 		}
 	}
-
 	path := c.Args().First()
 	if path != "" {
 		fmt.Printf("Creating function at: ./%s\n", path)
@@ -425,6 +437,9 @@ func (a *initFnCmd) BuildFuncFileV20180708(c *cli.Context, path string) error {
 	}
 
 	if c.String("init-image") != "" {
+		return nil
+	}
+	if strings.TrimSpace(c.String("pbf")) != "" {
 		return nil
 	}
 

--- a/common/funcfile.go
+++ b/common/funcfile.go
@@ -87,10 +87,16 @@ type OCIProvisionedConcurrencyConfig struct {
 	Count    *int   `yaml:"count,omitempty" json:"count,omitempty"`
 }
 
+// OCIPBFSourceConfig stores Pre-Built Function source details for OCI Functions.
+type OCIPBFSourceConfig struct {
+	ListingID string `yaml:"listing_id,omitempty" json:"listing_id,omitempty"`
+}
+
 // OCIFunctionDeployConfig stores OCI-specific deploy configuration for a function.
 type OCIFunctionDeployConfig struct {
 	ProvisionedConcurrency *OCIProvisionedConcurrencyConfig `yaml:"provisioned_concurrency,omitempty" json:"provisioned_concurrency,omitempty"`
 	DetachedMode           *OCIDetachedModeConfig           `yaml:"detached_mode,omitempty" json:"detached_mode,omitempty"`
+	PBF                    *OCIPBFSourceConfig              `yaml:"pbf,omitempty" json:"pbf,omitempty"`
 	FreeformTags           map[string]string                `yaml:"freeform_tags,omitempty" json:"freeform_tags,omitempty"`
 	DefinedTags            OCIDefinedTags                   `yaml:"defined_tags,omitempty" json:"defined_tags,omitempty"`
 }
@@ -439,6 +445,9 @@ func (ff *FuncFileV20180708) HasOCIManagedFunctionSettings() bool {
 	if len(oci.FreeformTags) > 0 || len(oci.DefinedTags) > 0 {
 		return true
 	}
+	if oci.PBF != nil && strings.TrimSpace(oci.PBF.ListingID) != "" {
+		return true
+	}
 
 	return false
 }
@@ -459,6 +468,9 @@ func (ff *FuncFileV20180708) OCIManagedFunctionSettingNames() []string {
 		settings = append(settings, "detached_mode")
 	}
 	settings = append(settings, OCIManagedResourceTagSettingNames(ff)...)
+	if oci.PBF != nil && strings.TrimSpace(oci.PBF.ListingID) != "" {
+		settings = append(settings, "pbf")
+	}
 
 	return settings
 }

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -78,6 +78,22 @@ type provisionedConcurrencyView struct {
 	Count    *int   `json:"count,omitempty"`
 }
 
+type sourceDetailsView struct {
+	SourceType   string `json:"sourceType,omitempty"`
+	PbfListingID string `json:"pbfListingId,omitempty"`
+}
+
+func formatSourceDisplay(fn *models.Fn) string {
+	view := getSourceDetailsView(fn)
+	if view == nil {
+		return ""
+	}
+	if view.PbfListingID != "" {
+		return fmt.Sprintf("pbf:%s", view.PbfListingID)
+	}
+	return strings.ToLower(view.SourceType)
+}
+
 // SetProvisionedConcurrencyAnnotations adds the internal annotations used to
 // carry provisioned concurrency through the create payload into the OCI shim.
 func SetProvisionedConcurrencyAnnotations(fn *models.Fn, cfg *common.OCIProvisionedConcurrencyConfig) error {
@@ -382,7 +398,39 @@ func buildInspectFnMap(fn *models.Fn) (map[string]interface{}, error) {
 		}
 		inspect["provisionedConcurrency"] = pcValue
 	}
+	if source := getSourceDetailsView(fn); source != nil {
+		sourceData, err := json.Marshal(source)
+		if err != nil {
+			return nil, err
+		}
+		var sourceValue map[string]interface{}
+		if err := json.Unmarshal(sourceData, &sourceValue); err != nil {
+			return nil, err
+		}
+		inspect["sourceDetails"] = sourceValue
+	}
 	return inspect, nil
+}
+
+func getSourceDetailsView(fn *models.Fn) *sourceDetailsView {
+	if fn == nil || fn.Annotations == nil {
+		return nil
+	}
+	sourceTypeRaw, ok := fn.Annotations[annotationSourceType]
+	if !ok {
+		return nil
+	}
+	sourceType, ok := sourceTypeRaw.(string)
+	if !ok || strings.TrimSpace(sourceType) == "" {
+		return nil
+	}
+	view := &sourceDetailsView{SourceType: sourceType}
+	if listingRaw, ok := fn.Annotations[annotationPbfListingID]; ok {
+		if listingID, ok := listingRaw.(string); ok {
+			view.PbfListingID = listingID
+		}
+	}
+	return view
 }
 
 // WithSlash appends "/" to function path
@@ -413,12 +461,14 @@ func printFunctions(c *cli.Context, fns []*models.Fn) error {
 				ID                     string                      `json:"id"`
 				ProvisionedConcurrency *provisionedConcurrencyView `json:"provisionedConcurrency,omitempty"`
 				DetachedMode           *detachedModeView           `json:"detachedMode,omitempty"`
+				SourceDetails          *sourceDetailsView          `json:"sourceDetails,omitempty"`
 			}{
 				Name:                   fn.Name,
 				Image:                  fn.Image,
 				ID:                     fn.ID,
 				ProvisionedConcurrency: getProvisionedConcurrencyView(fn),
 				DetachedMode:           getDetachedModeView(fn),
+				SourceDetails:          getSourceDetailsView(fn),
 			})
 		}
 		b, err := json.MarshalIndent(newFns, "", "    ")
@@ -428,7 +478,7 @@ func printFunctions(c *cli.Context, fns []*models.Fn) error {
 		fmt.Fprint(os.Stdout, string(b))
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
-		fmt.Fprint(w, "NAME", "\t", "IMAGE", "\t", "PC", "\t", "DETACHED_TIMEOUT", "\t", "DESTINATIONS", "\t", "ID", "\n")
+		fmt.Fprint(w, "NAME", "\t", "IMAGE", "\t", "SOURCE", "\t", "PC", "\t", "DETACHED_TIMEOUT", "\t", "DESTINATIONS", "\t", "ID", "\n")
 
 		for _, f := range fns {
 			view := getDetachedModeView(f)
@@ -436,7 +486,7 @@ func printFunctions(c *cli.Context, fns []*models.Fn) error {
 			if view != nil {
 				timeout = view.Timeout
 			}
-			fmt.Fprint(w, f.Name, "\t", f.Image, "\t", formatProvisionedConcurrencyDisplay(f), "\t", timeout, "\t", formatDetachedDestinations(f), "\t", f.ID, "\t", "\n")
+			fmt.Fprint(w, f.Name, "\t", f.Image, "\t", formatSourceDisplay(f), "\t", formatProvisionedConcurrencyDisplay(f), "\t", timeout, "\t", formatDetachedDestinations(f), "\t", f.ID, "\t", "\n")
 		}
 		if err := w.Flush(); err != nil {
 			return err
@@ -493,6 +543,22 @@ func formatProvisionedConcurrencyDisplay(fn *models.Fn) string {
 	default:
 		return strings.ToLower(view.Strategy)
 	}
+}
+
+func buildCreateFnSuccessMessage(fn *models.Fn) string {
+	if fn == nil {
+		return "Successfully created function"
+	}
+	if source := getSourceDetailsView(fn); source != nil && strings.EqualFold(source.SourceType, "PRE_BUILT_FUNCTIONS") {
+		if source.PbfListingID != "" {
+			return fmt.Sprintf("Successfully created function: %s from PBF %s", fn.Name, source.PbfListingID)
+		}
+		return fmt.Sprintf("Successfully created function: %s from PBF", fn.Name)
+	}
+	if strings.TrimSpace(fn.Image) != "" {
+		return fmt.Sprintf("Successfully created function: %s with %s", fn.Name, fn.Image)
+	}
+	return fmt.Sprintf("Successfully created function: %s", fn.Name)
 }
 
 func (f *fnsCmd) list(c *cli.Context) error {
@@ -606,7 +672,8 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 			return err
 		}
 	}
-	if ff.ImageNameV20180708() != "" { // args take precedence
+	isPBFSource := ff.Deploy != nil && ff.Deploy.OCI != nil && ff.Deploy.OCI.PBF != nil && strings.TrimSpace(ff.Deploy.OCI.PBF.ListingID) != ""
+	if !isPBFSource && ff.ImageNameV20180708() != "" { // args take precedence
 		fn.Image = ff.ImageNameV20180708()
 	}
 	if ff.Timeout != nil {
@@ -627,6 +694,12 @@ func WithFuncFileV20180708(ff *common.FuncFileV20180708, fn *models.Fn) error {
 	}
 	if ff.Deploy != nil && ff.Deploy.OCI != nil {
 		fn.Annotations = common.ApplyOCIResourceTagsToAnnotations(fn.Annotations, ff.Deploy.OCI.FreeformTags, ff.Deploy.OCI.DefinedTags)
+		if ff.Deploy.OCI.PBF != nil {
+			fn.Image = ""
+			if err := setPBFSourceAnnotations(fn, ff.Deploy.OCI.PBF.ListingID); err != nil {
+				return err
+			}
+		}
 	}
 	// do something with triggers here
 
@@ -690,6 +763,23 @@ func resolvePBFMemory(memory uint64, minRequired *int64) (uint64, error) {
 		return 0, fmt.Errorf("--memory %d is below the minimum required for this PBF (%d MiB)", memory, minimum)
 	}
 	return memory, nil
+}
+
+// ResolvePBFMemoryForListing auto-selects or validates memory for a PBF-backed function.
+func ResolvePBFMemoryForListing(p provider.Provider, fn *models.Fn, listingID string) error {
+	if fn == nil || strings.TrimSpace(listingID) == "" {
+		return nil
+	}
+	minMemory, err := fetchCurrentPBFMemoryRequirement(p, listingID)
+	if err != nil {
+		return fmt.Errorf("unable to determine PBF memory requirements: %w", err)
+	}
+	resolvedMemory, err := resolvePBFMemory(fn.Memory, minMemory)
+	if err != nil {
+		return err
+	}
+	fn.Memory = resolvedMemory
+	return nil
 }
 
 func buildFunctionsManagementClient(oracleProvider *fnprovideroracle.OracleProvider) (*ocifunctions.FunctionsManagementClient, error) {
@@ -807,15 +897,9 @@ func (f *fnsCmd) create(c *cli.Context) error {
 		if err := setPBFSourceAnnotations(fn, pbfListingID); err != nil {
 			return err
 		}
-		minMemory, err := fetchCurrentPBFMemoryRequirement(f.provider, pbfListingID)
-		if err != nil {
-			return fmt.Errorf("unable to determine PBF memory requirements: %w", err)
-		}
-		resolvedMemory, err := resolvePBFMemory(fn.Memory, minMemory)
-		if err != nil {
+		if err := ResolvePBFMemoryForListing(f.provider, fn, pbfListingID); err != nil {
 			return err
 		}
-		fn.Memory = resolvedMemory
 	}
 	if pcConfig != nil {
 		if !common.IsOracleProvider(f.provider) {
@@ -890,7 +974,7 @@ func CreateFn(r *fnclient.Fn, appID string, fn *models.Fn) (*models.Fn, error) {
 		return nil, err
 	}
 
-	fmt.Println("Successfully created function:", resp.Payload.Name, "with", resp.Payload.Image)
+	fmt.Println(buildCreateFnSuccessMessage(resp.Payload))
 	return resp.Payload, nil
 }
 

--- a/objects/fn/fns_test.go
+++ b/objects/fn/fns_test.go
@@ -153,3 +153,52 @@ func TestResolvePBFMemory(t *testing.T) {
 		t.Fatal("expected an error when memory is below the PBF minimum")
 	}
 }
+
+func TestFormatSourceDisplay(t *testing.T) {
+	fn := &models.Fn{Annotations: map[string]interface{}{
+		annotationSourceType:   "PRE_BUILT_FUNCTIONS",
+		annotationPbfListingID: "ocid1.pbflisting.oc1..example",
+	}}
+	if got := formatSourceDisplay(fn); got != "pbf:ocid1.pbflisting.oc1..example" {
+		t.Fatalf("expected PBF source display, got %q", got)
+	}
+}
+
+func TestBuildCreateFnSuccessMessage(t *testing.T) {
+	imgFn := &models.Fn{Name: "hello", Image: "repo/hello:0.0.1"}
+	if got := buildCreateFnSuccessMessage(imgFn); got != "Successfully created function: hello with repo/hello:0.0.1" {
+		t.Fatalf("unexpected image success message: %q", got)
+	}
+	pbfFn := &models.Fn{Name: "hello-pbf", Annotations: map[string]interface{}{
+		annotationSourceType:   "PRE_BUILT_FUNCTIONS",
+		annotationPbfListingID: "ocid1.pbflisting.oc1..example",
+	}}
+	if got := buildCreateFnSuccessMessage(pbfFn); got != "Successfully created function: hello-pbf from PBF ocid1.pbflisting.oc1..example" {
+		t.Fatalf("unexpected PBF success message: %q", got)
+	}
+}
+
+func TestWithFuncFileV20180708AppliesPBFSource(t *testing.T) {
+	ff := &common.FuncFileV20180708{
+		Name:    "hello-pbf",
+		Version: "0.0.1",
+		Deploy: &common.FuncDeployConfig{
+			OCI: &common.OCIFunctionDeployConfig{
+				PBF: &common.OCIPBFSourceConfig{ListingID: "ocid1.pbflisting.oc1..example"},
+			},
+		},
+	}
+	fn := &models.Fn{}
+	if err := WithFuncFileV20180708(ff, fn); err != nil {
+		t.Fatalf("WithFuncFileV20180708() error = %v", err)
+	}
+	if got := fn.Annotations[annotationSourceType]; got != "PRE_BUILT_FUNCTIONS" {
+		t.Fatalf("expected PRE_BUILT_FUNCTIONS source type, got %#v", got)
+	}
+	if got := fn.Annotations[annotationPbfListingID]; got != "ocid1.pbflisting.oc1..example" {
+		t.Fatalf("expected pbf listing id annotation, got %#v", got)
+	}
+	if fn.Image != "" {
+		t.Fatalf("expected PBF-backed function to avoid image assignment during deploy/init flows, got %q", fn.Image)
+	}
+}

--- a/objects/pbf/commands.go
+++ b/objects/pbf/commands.go
@@ -1,0 +1,107 @@
+package pbf
+
+import "github.com/urfave/cli"
+
+func sharedListFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.IntFlag{Name: "limit", Usage: "Maximum number of items to return", Value: 10},
+		cli.StringFlag{Name: "output", Usage: "Output format (json)"},
+	}
+}
+
+func List() cli.Command {
+	return cli.Command{
+		Name:        "pbfs",
+		Usage:       "List Pre-Built Function listings and related resources",
+		Description: "List available OCI Pre-Built Functions (PBFs), their versions, or supported triggers.",
+		Before: func(c *cli.Context) error {
+			_, err := initPBFClient()
+			return err
+		},
+		Action: func(c *cli.Context) error {
+			cmd, err := initPBFClient()
+			if err != nil {
+				return err
+			}
+			return cmd.listListings(c)
+		},
+		Flags: append(sharedListFlags(),
+			cli.StringFlag{Name: "search", Usage: "Filter listings by partial name match"},
+			cli.StringFlag{Name: "trigger", Usage: "Filter listings by trigger name"},
+		),
+		Subcommands: []cli.Command{
+			{
+				Name:      "versions",
+				Usage:     "List versions for a PBF listing",
+				ArgsUsage: "<pbf-name-or-ocid>",
+				Before: func(c *cli.Context) error {
+					_, err := initPBFClient()
+					return err
+				},
+				Action: func(c *cli.Context) error {
+					cmd, err := initPBFClient()
+					if err != nil {
+						return err
+					}
+					return cmd.listVersions(c)
+				},
+				Flags: append(sharedListFlags(), cli.BoolFlag{Name: "current", Usage: "Show only the OCI-designated current version"}),
+			},
+			{
+				Name:      "triggers",
+				Usage:     "List supported PBF trigger names",
+				ArgsUsage: "[trigger-name]",
+				Before: func(c *cli.Context) error {
+					_, err := initPBFClient()
+					return err
+				},
+				Action: func(c *cli.Context) error {
+					cmd, err := initPBFClient()
+					if err != nil {
+						return err
+					}
+					return cmd.listTriggers(c)
+				},
+				Flags: sharedListFlags(),
+			},
+		},
+	}
+}
+
+func Get() cli.Command {
+	return cli.Command{
+		Name:        "pbfs",
+		Usage:       "Get a Pre-Built Function listing or version",
+		Description: "Get detailed information for an OCI Pre-Built Function (PBF) listing or a specific listing version.",
+		ArgsUsage:   "<pbf-name-or-ocid>",
+		Before: func(c *cli.Context) error {
+			_, err := initPBFClient()
+			return err
+		},
+		Action: func(c *cli.Context) error {
+			cmd, err := initPBFClient()
+			if err != nil {
+				return err
+			}
+			return cmd.getListing(c)
+		},
+		Subcommands: []cli.Command{
+			{
+				Name:      "version",
+				Usage:     "Get a specific PBF listing version by OCID",
+				ArgsUsage: "<pbf-listing-version-ocid>",
+				Before: func(c *cli.Context) error {
+					_, err := initPBFClient()
+					return err
+				},
+				Action: func(c *cli.Context) error {
+					cmd, err := initPBFClient()
+					if err != nil {
+						return err
+					}
+					return cmd.getVersion(c)
+				},
+			},
+		},
+	}
+}

--- a/objects/pbf/pbfs.go
+++ b/objects/pbf/pbfs.go
@@ -1,0 +1,276 @@
+package pbf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	cliClient "github.com/fnproject/cli/client"
+	fnprovideroracle "github.com/fnproject/fn_go/provider/oracle"
+	ocifunctions "github.com/oracle/oci-go-sdk/v65/functions"
+	"github.com/urfave/cli"
+)
+
+type pbfCmd struct {
+	provider *fnprovideroracle.OracleProvider
+	client   *ocifunctions.FunctionsManagementClient
+}
+
+func buildFunctionsManagementClient(provider *fnprovideroracle.OracleProvider) (*ocifunctions.FunctionsManagementClient, error) {
+	client, err := ocifunctions.NewFunctionsManagementClientWithConfigurationProvider(provider.ConfigurationProvider)
+	if err != nil {
+		return nil, err
+	}
+	if provider.FnApiUrl != nil {
+		client.Host = provider.FnApiUrl.String()
+	} else {
+		region, _ := provider.ConfigurationProvider.Region()
+		if region != "" {
+			client.SetRegion(region)
+		}
+	}
+	return &client, nil
+}
+
+func initPBFClient() (*pbfCmd, error) {
+	provider, err := cliClient.CurrentProvider()
+	if err != nil {
+		return nil, err
+	}
+	oracleProvider, ok := provider.(*fnprovideroracle.OracleProvider)
+	if !ok || oracleProvider == nil {
+		return nil, fmt.Errorf("PBF commands are only supported with an oracle provider")
+	}
+	mgmtClient, err := buildFunctionsManagementClient(oracleProvider)
+	if err != nil {
+		return nil, err
+	}
+	return &pbfCmd{provider: oracleProvider, client: mgmtClient}, nil
+}
+
+func formatSDKTime(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func formatListingTriggers(triggers []ocifunctions.Trigger) string {
+	if len(triggers) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(triggers))
+	for _, trig := range triggers {
+		if trig.Name != nil {
+			names = append(names, *trig.Name)
+		}
+	}
+	return strings.Join(names, ",")
+}
+
+func isOCID(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), "ocid1.")
+}
+
+func (p *pbfCmd) resolveListingID(identifier string) (string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", fmt.Errorf("missing PBF listing identifier")
+	}
+	if isOCID(identifier) {
+		return identifier, nil
+	}
+	limit := 1
+	req := ocifunctions.ListPbfListingsRequest{Name: &identifier, Limit: &limit}
+	res, err := p.client.ListPbfListings(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+	if len(res.Items) == 0 || res.Items[0].Id == nil {
+		return "", fmt.Errorf("PBF listing %q not found", identifier)
+	}
+	return *res.Items[0].Id, nil
+}
+
+func printListings(c *cli.Context, items []ocifunctions.PbfListingSummary) error {
+	if strings.EqualFold(c.String("output"), "json") {
+		b, err := json.MarshalIndent(items, "", "    ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(os.Stdout, string(b))
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	_, _ = fmt.Fprintln(w, "NAME\tPUBLISHER\tUPDATED\tTRIGGERS\tID")
+	for _, item := range items {
+		name := ""
+		if item.Name != nil {
+			name = *item.Name
+		}
+		publisher := ""
+		if item.PublisherDetails != nil && item.PublisherDetails.Name != nil {
+			publisher = *item.PublisherDetails.Name
+		}
+		updated := ""
+		if item.TimeUpdated != nil {
+			t := item.TimeUpdated.Time
+			updated = formatSDKTime(&t)
+		}
+		id := ""
+		if item.Id != nil {
+			id = *item.Id
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", name, publisher, updated, formatListingTriggers(item.Triggers), id)
+	}
+	return w.Flush()
+}
+
+func printListingVersions(c *cli.Context, items []ocifunctions.PbfListingVersionSummary) error {
+	if strings.EqualFold(c.String("output"), "json") {
+		b, err := json.MarshalIndent(items, "", "    ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(os.Stdout, string(b))
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	_, _ = fmt.Fprintln(w, "VERSION\tSTATE\tUPDATED\tMIN_MEMORY_MBS\tID")
+	for _, item := range items {
+		version := ""
+		if item.Name != nil {
+			version = *item.Name
+		}
+		updated := ""
+		if item.TimeUpdated != nil {
+			t := item.TimeUpdated.Time
+			updated = formatSDKTime(&t)
+		}
+		minMemory := ""
+		if item.Requirements != nil && item.Requirements.MinMemoryRequiredInMBs != nil {
+			minMemory = fmt.Sprintf("%d", *item.Requirements.MinMemoryRequiredInMBs)
+		}
+		id := ""
+		if item.Id != nil {
+			id = *item.Id
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", version, item.LifecycleState, updated, minMemory, id)
+	}
+	return w.Flush()
+}
+
+func printPBFTriggers(c *cli.Context, items []ocifunctions.TriggerSummary) error {
+	if strings.EqualFold(c.String("output"), "json") {
+		b, err := json.MarshalIndent(items, "", "    ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(os.Stdout, string(b))
+		return err
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	_, _ = fmt.Fprintln(w, "NAME")
+	for _, item := range items {
+		name := ""
+		if item.Name != nil {
+			name = *item.Name
+		}
+		_, _ = fmt.Fprintf(w, "%s\n", name)
+	}
+	return w.Flush()
+}
+
+func (p *pbfCmd) listListings(c *cli.Context) error {
+	limit := c.Int("limit")
+	req := ocifunctions.ListPbfListingsRequest{}
+	if limit > 0 {
+		req.Limit = &limit
+	}
+	if search := strings.TrimSpace(c.String("search")); search != "" {
+		req.NameContains = &search
+	}
+	if trigger := strings.TrimSpace(c.String("trigger")); trigger != "" {
+		req.Trigger = []string{trigger}
+	}
+	res, err := p.client.ListPbfListings(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	return printListings(c, res.Items)
+}
+
+func (p *pbfCmd) getListing(c *cli.Context) error {
+	listingID, err := p.resolveListingID(c.Args().First())
+	if err != nil {
+		return err
+	}
+	res, err := p.client.GetPbfListing(context.Background(), ocifunctions.GetPbfListingRequest{PbfListingId: &listingID})
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(res.PbfListing, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(os.Stdout, string(b))
+	return err
+}
+
+func (p *pbfCmd) listVersions(c *cli.Context) error {
+	listingID, err := p.resolveListingID(c.Args().First())
+	if err != nil {
+		return err
+	}
+	limit := c.Int("limit")
+	req := ocifunctions.ListPbfListingVersionsRequest{PbfListingId: &listingID}
+	if limit > 0 {
+		req.Limit = &limit
+	}
+	if c.Bool("current") {
+		current := true
+		req.IsCurrentVersion = &current
+	}
+	res, err := p.client.ListPbfListingVersions(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	return printListingVersions(c, res.Items)
+}
+
+func (p *pbfCmd) getVersion(c *cli.Context) error {
+	versionID := strings.TrimSpace(c.Args().First())
+	if versionID == "" {
+		return fmt.Errorf("missing PBF listing version identifier")
+	}
+	res, err := p.client.GetPbfListingVersion(context.Background(), ocifunctions.GetPbfListingVersionRequest{PbfListingVersionId: &versionID})
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(res.PbfListingVersion, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(os.Stdout, string(b))
+	return err
+}
+
+func (p *pbfCmd) listTriggers(c *cli.Context) error {
+	limit := c.Int("limit")
+	req := ocifunctions.ListTriggersRequest{}
+	if limit > 0 {
+		req.Limit = &limit
+	}
+	if name := strings.TrimSpace(c.Args().First()); name != "" {
+		req.Name = &name
+	}
+	res, err := p.client.ListTriggers(context.Background(), req)
+	if err != nil {
+		return err
+	}
+	return printPBFTriggers(c, res.Items)
+}

--- a/objects/pbf/pbfs_test.go
+++ b/objects/pbf/pbfs_test.go
@@ -1,0 +1,34 @@
+package pbf
+
+import (
+	"testing"
+	"time"
+
+	ocifunctions "github.com/oracle/oci-go-sdk/v65/functions"
+)
+
+func TestFormatListingTriggers(t *testing.T) {
+	name1 := "http"
+	name2 := "objectstorage"
+	got := formatListingTriggers([]ocifunctions.Trigger{{Name: &name1}, {Name: &name2}})
+	if got != "http,objectstorage" {
+		t.Fatalf("expected trigger string, got %q", got)
+	}
+}
+
+func TestFormatSDKTime(t *testing.T) {
+	ts := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	got := formatSDKTime(&ts)
+	if got == "" {
+		t.Fatal("expected non-empty formatted time")
+	}
+}
+
+func TestIsOCID(t *testing.T) {
+	if !isOCID("ocid1.pbflisting.oc1..example") {
+		t.Fatal("expected ocid to be recognized")
+	}
+	if isOCID("hello-world") {
+		t.Fatal("did not expect non-ocid to be recognized")
+	}
+}


### PR DESCRIPTION
This PR extends Fn CLI with a broader OCI Pre-Built Function (PBF) workflow, including:
- PBF catalog browse commands
- PBF-backed function create improvements
- persisted PBF source details in 'func.yaml'
- 'fn init' and 'fn deploy' support for PBF-backed functions
- inspect/list visibility for PBF-backed functions


