### PR TITLE
Fix for fn inspect output for advanced OCI options

### DIFF
--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -558,26 +558,16 @@ func (a *appsCmd) inspect(c *cli.Context) error {
 
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "\t")
+	inspectData, err := buildAppInspectData(app)
+	if err != nil {
+		return fmt.Errorf("Could not build app inspect data: %v", err)
+	}
 
 	if prop == "" {
-		enc.Encode(app)
+		enc.Encode(inspectData)
 		return nil
 	}
-
-	// TODO: we really need to marshal it here just to
-	// unmarshal as map[string]interface{}?
-	data, err := json.Marshal(app)
-	if err != nil {
-		return fmt.Errorf("Could not marshal app: %v", err)
-	}
-
-	var inspect map[string]interface{}
-	err = json.Unmarshal(data, &inspect)
-	if err != nil {
-		return fmt.Errorf("Could not unmarshal data: %v", err)
-	}
-
-	jq := jsonq.NewQuery(inspect)
+	jq := jsonq.NewQuery(inspectData)
 	field, err := jq.Interface(strings.Split(prop, ".")...)
 	if err != nil {
 		return fmt.Errorf("Failed to inspect field %v", prop)
@@ -585,6 +575,37 @@ func (a *appsCmd) inspect(c *cli.Context) error {
 	enc.Encode(field)
 
 	return nil
+}
+
+func buildAppInspectData(app *modelsv2.App) (map[string]interface{}, error) {
+	data, err := json.Marshal(app)
+	if err != nil {
+		return nil, err
+	}
+
+	inspect := map[string]interface{}{}
+	if err := json.Unmarshal(data, &inspect); err != nil {
+		return nil, err
+	}
+
+	if app == nil || app.Annotations == nil {
+		return inspect, nil
+	}
+
+	if v, ok := app.Annotations[annotationOCIParityTraceConfig]; ok {
+		inspect["traceConfig"] = v
+	}
+	if v, ok := app.Annotations[annotationOCIParityNetworkSecurityGroupIds]; ok {
+		inspect["networkSecurityGroupIds"] = v
+	}
+	if v, ok := app.Annotations[annotationOCIParityImagePolicyConfig]; ok {
+		inspect["imagePolicyConfig"] = v
+	}
+	if v, ok := app.Annotations[annotationOCIParitySecurityAttributes]; ok {
+		inspect["securityAttributes"] = v
+	}
+
+	return inspect, nil
 }
 
 func (a *appsCmd) delete(c *cli.Context) error {

--- a/objects/app/apps_test.go
+++ b/objects/app/apps_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"reflect"
 	"net/url"
 	"testing"
 
@@ -8,6 +9,57 @@ import (
 	defaultprovider "github.com/fnproject/fn_go/provider/defaultprovider"
 	fnprovideroracle "github.com/fnproject/fn_go/provider/oracle"
 )
+
+func TestBuildAppInspectDataIncludesOCIParityFields(t *testing.T) {
+	app := &modelsv2.App{
+		Name: "parity-app",
+		Annotations: map[string]interface{}{
+			annotationOCIParityTraceConfig: map[string]interface{}{
+				"isEnabled": true,
+			},
+			annotationOCIParityNetworkSecurityGroupIds: []interface{}{"ocid1.nsg.oc1..aaaa"},
+			annotationOCIParityImagePolicyConfig: map[string]interface{}{
+				"isPolicyEnabled": true,
+			},
+			annotationOCIParitySecurityAttributes: map[string]interface{}{
+				"oracle-zpr": map[string]interface{}{
+					"MaxEgressCount": map[string]interface{}{
+						"value": "42",
+						"mode":  "enforce",
+					},
+				},
+			},
+		},
+	}
+
+	inspectData, err := buildAppInspectData(app)
+	if err != nil {
+		t.Fatalf("buildAppInspectData() error = %v", err)
+	}
+
+	if _, ok := inspectData["traceConfig"]; !ok {
+		t.Fatalf("expected traceConfig in inspect output, got %#v", inspectData)
+	}
+	if _, ok := inspectData["networkSecurityGroupIds"]; !ok {
+		t.Fatalf("expected networkSecurityGroupIds in inspect output, got %#v", inspectData)
+	}
+	if _, ok := inspectData["imagePolicyConfig"]; !ok {
+		t.Fatalf("expected imagePolicyConfig in inspect output, got %#v", inspectData)
+	}
+	if _, ok := inspectData["securityAttributes"]; !ok {
+		t.Fatalf("expected securityAttributes in inspect output, got %#v", inspectData)
+	}
+
+	gotNSGs, ok := inspectData["networkSecurityGroupIds"].([]interface{})
+	if !ok || len(gotNSGs) != 1 || gotNSGs[0] != "ocid1.nsg.oc1..aaaa" {
+		t.Fatalf("unexpected networkSecurityGroupIds value: %#v", inspectData["networkSecurityGroupIds"])
+	}
+
+	gotTrace, ok := inspectData["traceConfig"].(map[string]interface{})
+	if !ok || !reflect.DeepEqual(gotTrace, map[string]interface{}{"isEnabled": true}) {
+		t.Fatalf("unexpected traceConfig value: %#v", inspectData["traceConfig"])
+	}
+}
 
 func TestSetSubnetIDAnnotations(t *testing.T) {
 	app := &modelsv2.App{}

--- a/vendor/github.com/fnproject/fn_go/provider/oracle/shim/apps.go
+++ b/vendor/github.com/fnproject/fn_go/provider/oracle/shim/apps.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/fnproject/fn_go/clientv2/apps"
@@ -243,6 +244,7 @@ func ociAppToV2(ociApp functions.Application) *modelsv2.App {
 	annotations := make(map[string]interface{})
 	annotations[annotationCompartmentId] = *ociApp.CompartmentId
 	annotations[annotationSubnet] = ociSubnetsToAnnotationValue(ociApp.SubnetIds)
+	addGeneratedOCIParityAppAnnotationsFromApplication(annotations, ociApp)
 	addTagAnnotations(annotations, ociApp.FreeformTags, ociApp.DefinedTags)
 
 	return &modelsv2.App{
@@ -255,6 +257,42 @@ func ociAppToV2(ociApp functions.Application) *modelsv2.App {
 		SyslogURL:   ociApp.SyslogUrl,
 		UpdatedAt:   strfmt.DateTime(ociApp.TimeUpdated.Time),
 	}
+}
+
+func addGeneratedOCIParityAppAnnotationsFromApplication(annotations map[string]interface{}, app functions.Application) {
+	if annotations == nil {
+		return
+	}
+	if app.TraceConfig != nil {
+		if raw := marshalToMap(app.TraceConfig); raw != nil {
+			annotations[annotationOCIParityTraceConfig] = raw
+		}
+	}
+	if len(app.NetworkSecurityGroupIds) > 0 {
+		annotations[annotationOCIParityNetworkSecurityGroupIds] = ociSubnetsToAnnotationValue(app.NetworkSecurityGroupIds)
+	}
+	if app.ImagePolicyConfig != nil {
+		if raw := marshalToMap(app.ImagePolicyConfig); raw != nil {
+			annotations[annotationOCIParityImagePolicyConfig] = raw
+		}
+	}
+	if len(app.SecurityAttributes) > 0 {
+		if raw := marshalToMap(app.SecurityAttributes); raw != nil {
+			annotations[annotationOCIParitySecurityAttributes] = raw
+		}
+	}
+}
+
+func marshalToMap(v interface{}) map[string]interface{} {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return out
 }
 
 func ociAppSummaryToV2(ociAppSummary functions.ApplicationSummary) *modelsv2.App {


### PR DESCRIPTION
Fixes 'fn inspect app' output so advanced OCI app options are shown when configured.

Previously, advanced fields (for example traceConfig, networkSecurityGroupIds, imagePolicyConfig, securityAttributes) were not reliably visible in inspect output because parity annotations were not being populated on app read paths from OCI.

This PR ensures those fields are mapped from OCI app responses into annotations and then surfaced by inspect.
