### PR TITLE
Cache invoke endpoints for fn invoke

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -421,7 +421,13 @@ func (p *deploycmd) deployFuncV20180708(c *cli.Context, app *models.App, funcfil
 			return err
 		}
 	}
-	return p.updateFunction(c, app.ID, funcfile)
+	if err := p.updateFunction(c, app.ID, funcfile); err != nil {
+		return err
+	}
+	if err := common.InvalidateInvokeEndpointCacheForFunction(p.provider, app.Name, funcfile.Name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to invalidate invoke endpoint cache: %v\n", err)
+	}
+	return nil
 }
 
 func (p *deploycmd) updateFunction(c *cli.Context, appID string, ff *common.FuncFileV20180708) error {

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -47,6 +47,13 @@ type invokeCmd struct {
 	client   *clientv2.Fn
 }
 
+var (
+	getInvokeAppByName     = app.GetAppByName
+	getInvokeFnByName      = fn.GetFnByName
+	invokeFunction         = client.Invoke
+	newInvokeEndpointCache = common.NewDefaultInvokeEndpointCache
+)
+
 // InvokeFnFlags used to invoke and fn
 var InvokeFnFlags = []cli.Flag{
 	cli.StringFlag{
@@ -77,6 +84,16 @@ var InvokeFnFlags = []cli.Flag{
 		Name:  "fn-invoke-type",
 		Usage: "Invoke type for Oracle Functions: sync or detached",
 	},
+	cli.BoolFlag{
+		Name:  common.NoInvokeEndpointCacheFlag,
+		Usage: "Do not use the local function invoke endpoint cache",
+	},
+	cli.DurationFlag{
+		Name:   common.InvokeEndpointCacheTTLFlag,
+		Usage:  "How long to cache function invoke endpoints resolved by app and function name",
+		Value:  common.DefaultInvokeEndpointCacheTTL,
+		EnvVar: common.InvokeEndpointCacheTTLEnvVar,
+	},
 }
 
 var InvokeDetachedFnFlags = []cli.Flag{
@@ -104,6 +121,16 @@ var InvokeDetachedFnFlags = []cli.Flag{
 		Name:  "is-dry-run",
 		Usage: "Send the invocation as a dry run without executing the function when supported by the server",
 	},
+	cli.BoolFlag{
+		Name:  common.NoInvokeEndpointCacheFlag,
+		Usage: "Do not use the local function invoke endpoint cache",
+	},
+	cli.DurationFlag{
+		Name:   common.InvokeEndpointCacheTTLFlag,
+		Usage:  "How long to cache function invoke endpoints resolved by app and function name",
+		Value:  common.DefaultInvokeEndpointCacheTTL,
+		EnvVar: common.InvokeEndpointCacheTTLEnvVar,
+	},
 }
 
 // InvokeCommand returns call cli.command
@@ -122,15 +149,15 @@ func InvokeCommand() cli.Command {
 			cl.client = cl.provider.APIClientv2()
 			return nil
 		},
-		ArgsUsage:   "[app-name] [function-name]",
-		Flags:       InvokeFnFlags,
+		ArgsUsage: "[app-name] [function-name]",
+		Flags:     InvokeFnFlags,
 		Subcommands: []cli.Command{
 			{
-				Name:        "detached",
-				Usage:       "\tInvoke a remote function in detached mode",
-				ArgsUsage:   "[app-name] [function-name]",
-				Flags:       InvokeDetachedFnFlags,
-				Action:      cl.InvokeDetached,
+				Name:      "detached",
+				Usage:     "\tInvoke a remote function in detached mode",
+				ArgsUsage: "[app-name] [function-name]",
+				Flags:     InvokeDetachedFnFlags,
+				Action:    cl.InvokeDetached,
 				BashComplete: func(c *cli.Context) {
 					switch len(c.Args()) {
 					case 0:
@@ -169,7 +196,6 @@ func (cl *invokeCmd) invoke(c *cli.Context, forcedInvokeType string) error {
 	invokeURL := c.String("endpoint")
 
 	if invokeURL == "" {
-
 		appName := c.Args().Get(0)
 		fnName := c.Args().Get(1)
 
@@ -177,18 +203,10 @@ func (cl *invokeCmd) invoke(c *cli.Context, forcedInvokeType string) error {
 			return errors.New("missing app and function name")
 		}
 
-		app, err := app.GetAppByName(cl.client, appName)
+		var err error
+		invokeURL, err = cl.resolveInvokeEndpoint(c, appName, fnName)
 		if err != nil {
 			return err
-		}
-		fn, err := fn.GetFnByName(cl.client, app.ID, fnName)
-		if err != nil {
-			return err
-		}
-		var ok bool
-		invokeURL, ok = fn.Annotations[FnInvokeEndpointAnnotation].(string)
-		if !ok {
-			return fmt.Errorf("Fn invoke url annotation not present, %s", FnInvokeEndpointAnnotation)
 		}
 	}
 	content := stdin()
@@ -215,14 +233,14 @@ func (cl *invokeCmd) invoke(c *cli.Context, forcedInvokeType string) error {
 		}
 	}
 
-	resp, err := client.Invoke(cl.provider,
+	resp, err := invokeFunction(cl.provider,
 		client.InvokeRequest{
-			URL:         invokeURL,
-			Content:     content,
-			Env:         c.StringSlice("e"),
-			ContentType: contentType,
-			FnIntent:    fnIntent,
-			IsDryRun:    c.Bool("is-dry-run"),
+			URL:          invokeURL,
+			Content:      content,
+			Env:          c.StringSlice("e"),
+			ContentType:  contentType,
+			FnIntent:     fnIntent,
+			IsDryRun:     c.Bool("is-dry-run"),
 			FnInvokeType: invokeType,
 		},
 	)
@@ -240,6 +258,42 @@ func (cl *invokeCmd) invoke(c *cli.Context, forcedInvokeType string) error {
 	// TODO we should have a 'raw' option to output the raw http request, it may be useful, idk
 
 	return nil
+}
+
+func (cl *invokeCmd) resolveInvokeEndpoint(c *cli.Context, appName, fnName string) (string, error) {
+	cacheEnabled := !c.Bool(common.NoInvokeEndpointCacheFlag)
+	cacheTTL := c.Duration(common.InvokeEndpointCacheTTLFlag)
+	cacheKey := common.NewInvokeEndpointCacheKey(cl.provider, appName, fnName)
+
+	if cacheEnabled && cacheTTL > 0 {
+		endpoint, ok, err := newInvokeEndpointCache().Get(cacheKey, cacheTTL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: ignoring invoke endpoint cache: %v\n", err)
+		} else if ok {
+			return endpoint, nil
+		}
+	}
+
+	appObj, err := getInvokeAppByName(cl.client, appName)
+	if err != nil {
+		return "", err
+	}
+	fnObj, err := getInvokeFnByName(cl.client, appObj.ID, fnName)
+	if err != nil {
+		return "", err
+	}
+	invokeURL, ok := fnObj.Annotations[FnInvokeEndpointAnnotation].(string)
+	if !ok {
+		return "", fmt.Errorf("Fn invoke url annotation not present, %s", FnInvokeEndpointAnnotation)
+	}
+
+	if cacheEnabled && cacheTTL > 0 {
+		if err := newInvokeEndpointCache().Put(cacheKey, invokeURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: unable to update invoke endpoint cache: %v\n", err)
+		}
+	}
+
+	return invokeURL, nil
 }
 
 func outputJSON(output io.Writer, resp *http.Response) {

--- a/commands/invoke_test.go
+++ b/commands/invoke_test.go
@@ -1,0 +1,223 @@
+package commands
+
+import (
+	"flag"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	cliClient "github.com/fnproject/cli/client"
+	"github.com/fnproject/cli/common"
+	"github.com/fnproject/cli/config"
+	"github.com/fnproject/fn_go/client/version"
+	"github.com/fnproject/fn_go/clientv2"
+	"github.com/fnproject/fn_go/modelsv2"
+	"github.com/fnproject/fn_go/provider"
+	"github.com/fnproject/fn_go/provider/oracle"
+	"github.com/spf13/viper"
+	"github.com/urfave/cli"
+)
+
+type invokeCommandTestProvider struct {
+	apiURL *url.URL
+}
+
+func (p *invokeCommandTestProvider) APIClientv2() *clientv2.Fn { return nil }
+func (p *invokeCommandTestProvider) APIURL() *url.URL          { return p.apiURL }
+func (p *invokeCommandTestProvider) UnavailableResources() []provider.FnResourceType {
+	return nil
+}
+func (p *invokeCommandTestProvider) VersionClient() *version.Client { return nil }
+func (p *invokeCommandTestProvider) WrapCallTransport(rt http.RoundTripper) http.RoundTripper {
+	return rt
+}
+
+func TestInvokeUsesEndpointCacheAfterFirstResolution(t *testing.T) {
+	restore := stubInvokeCommandDependencies(t)
+	defer restore()
+
+	cachePath := t.TempDir() + "/invoke-endpoint-cache.json"
+	newInvokeEndpointCache = func() *common.InvokeEndpointCache {
+		return common.NewInvokeEndpointCache(cachePath)
+	}
+
+	var appLookups int
+	var fnLookups int
+	getInvokeAppByName = func(_ *clientv2.Fn, appName string) (*modelsv2.App, error) {
+		appLookups++
+		return &modelsv2.App{ID: "app-id", Name: appName}, nil
+	}
+	getInvokeFnByName = func(_ *clientv2.Fn, appID, fnName string) (*modelsv2.Fn, error) {
+		fnLookups++
+		return &modelsv2.Fn{
+			ID:   "fn-id",
+			Name: fnName,
+			Annotations: map[string]interface{}{
+				FnInvokeEndpointAnnotation: "https://invoke.example.com/fn",
+			},
+		}, nil
+	}
+
+	var invokedURLs []string
+	invokeFunction = func(_ provider.Provider, req cliClient.InvokeRequest) (*http.Response, error) {
+		invokedURLs = append(invokedURLs, req.URL)
+		return invokeResponse(), nil
+	}
+
+	cl := invokeCmd{provider: testInvokeProvider(t)}
+	for i := 0; i < 2; i++ {
+		if err := cl.invoke(newInvokeCLIContext(t, "app", "fn"), ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if appLookups != 1 {
+		t.Fatalf("expected one app lookup, got %d", appLookups)
+	}
+	if fnLookups != 1 {
+		t.Fatalf("expected one function lookup, got %d", fnLookups)
+	}
+	if len(invokedURLs) != 2 {
+		t.Fatalf("expected two invoke calls, got %d", len(invokedURLs))
+	}
+	for _, got := range invokedURLs {
+		if got != "https://invoke.example.com/fn" {
+			t.Fatalf("unexpected invoked URL %q", got)
+		}
+	}
+}
+
+func TestInvokeEndpointFlagBypassesEndpointCache(t *testing.T) {
+	restore := stubInvokeCommandDependencies(t)
+	defer restore()
+
+	getInvokeAppByName = func(_ *clientv2.Fn, appName string) (*modelsv2.App, error) {
+		t.Fatalf("unexpected app lookup for %s", appName)
+		return nil, nil
+	}
+	getInvokeFnByName = func(_ *clientv2.Fn, appID, fnName string) (*modelsv2.Fn, error) {
+		t.Fatalf("unexpected function lookup for %s/%s", appID, fnName)
+		return nil, nil
+	}
+	newInvokeEndpointCache = func() *common.InvokeEndpointCache {
+		t.Fatal("unexpected cache access")
+		return nil
+	}
+
+	var invokedURL string
+	invokeFunction = func(_ provider.Provider, req cliClient.InvokeRequest) (*http.Response, error) {
+		invokedURL = req.URL
+		return invokeResponse(), nil
+	}
+
+	cl := invokeCmd{provider: testInvokeProvider(t)}
+	if err := cl.invoke(newInvokeCLIContext(t, "--endpoint", "https://explicit.example.com/invoke"), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if invokedURL != "https://explicit.example.com/invoke" {
+		t.Fatalf("expected explicit endpoint, got %q", invokedURL)
+	}
+}
+
+func TestInvokeNoEndpointCacheBypassesExistingCacheEntry(t *testing.T) {
+	restore := stubInvokeCommandDependencies(t)
+	defer restore()
+
+	cachePath := t.TempDir() + "/invoke-endpoint-cache.json"
+	newInvokeEndpointCache = func() *common.InvokeEndpointCache {
+		return common.NewInvokeEndpointCache(cachePath)
+	}
+	key := common.NewInvokeEndpointCacheKey(testInvokeProvider(t), "app", "fn")
+	if err := common.NewInvokeEndpointCache(cachePath).Put(key, "https://cached.example.com/fn"); err != nil {
+		t.Fatal(err)
+	}
+
+	var appLookups int
+	var fnLookups int
+	getInvokeAppByName = func(_ *clientv2.Fn, appName string) (*modelsv2.App, error) {
+		appLookups++
+		return &modelsv2.App{ID: "app-id", Name: appName}, nil
+	}
+	getInvokeFnByName = func(_ *clientv2.Fn, appID, fnName string) (*modelsv2.Fn, error) {
+		fnLookups++
+		return &modelsv2.Fn{
+			ID:   "fn-id",
+			Name: fnName,
+			Annotations: map[string]interface{}{
+				FnInvokeEndpointAnnotation: "https://fresh.example.com/fn",
+			},
+		}, nil
+	}
+
+	var invokedURL string
+	invokeFunction = func(_ provider.Provider, req cliClient.InvokeRequest) (*http.Response, error) {
+		invokedURL = req.URL
+		return invokeResponse(), nil
+	}
+
+	cl := invokeCmd{provider: testInvokeProvider(t)}
+	if err := cl.invoke(newInvokeCLIContext(t, "--no-endpoint-cache", "app", "fn"), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if appLookups != 1 || fnLookups != 1 {
+		t.Fatalf("expected cache bypass to resolve function once, appLookups=%d fnLookups=%d", appLookups, fnLookups)
+	}
+	if invokedURL != "https://fresh.example.com/fn" {
+		t.Fatalf("expected fresh endpoint, got %q", invokedURL)
+	}
+}
+
+func stubInvokeCommandDependencies(t *testing.T) func() {
+	t.Helper()
+	viper.Reset()
+	viper.Set(config.CurrentContext, "ctx")
+	viper.Set(config.ContextProvider, "oracle")
+	viper.Set(oracle.CfgCompartmentID, "ocid1.compartment.oc1..example")
+
+	oldGetAppByName := getInvokeAppByName
+	oldGetFnByName := getInvokeFnByName
+	oldInvokeFunction := invokeFunction
+	oldNewInvokeEndpointCache := newInvokeEndpointCache
+
+	return func() {
+		getInvokeAppByName = oldGetAppByName
+		getInvokeFnByName = oldGetFnByName
+		invokeFunction = oldInvokeFunction
+		newInvokeEndpointCache = oldNewInvokeEndpointCache
+		viper.Reset()
+	}
+}
+
+func newInvokeCLIContext(t *testing.T, args ...string) *cli.Context {
+	t.Helper()
+	cmd := InvokeCommand()
+	fs := flag.NewFlagSet("invoke-test", flag.ContinueOnError)
+	for _, f := range cmd.Flags {
+		f.Apply(fs)
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	return cli.NewContext(cli.NewApp(), fs, nil)
+}
+
+func testInvokeProvider(t *testing.T) provider.Provider {
+	t.Helper()
+	apiURL, err := url.Parse("https://functions.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &invokeCommandTestProvider{apiURL: apiURL}
+}
+
+func invokeResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("ok\n")),
+	}
+}

--- a/common/invoke_endpoint_cache.go
+++ b/common/invoke_endpoint_cache.go
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fnproject/cli/config"
+	"github.com/fnproject/fn_go/provider"
+	"github.com/fnproject/fn_go/provider/oracle"
+	"github.com/gofrs/flock"
+	"github.com/spf13/viper"
+)
+
+const (
+	InvokeEndpointCacheTTLFlag = "endpoint-cache-ttl"
+	NoInvokeEndpointCacheFlag  = "no-endpoint-cache"
+
+	InvokeEndpointCacheTTLEnvVar = "FN_INVOKE_ENDPOINT_CACHE_TTL"
+
+	DefaultInvokeEndpointCacheTTL = 15 * time.Minute
+
+	invokeEndpointCacheFileName = "invoke-endpoint-cache.json"
+	invokeEndpointCacheVersion  = 1
+)
+
+// InvokeEndpointCacheKey identifies the context where a function name resolves to an invoke endpoint.
+type InvokeEndpointCacheKey struct {
+	Context       string `json:"context"`
+	Provider      string `json:"provider"`
+	APIURL        string `json:"api_url"`
+	CompartmentID string `json:"compartment_id,omitempty"`
+	AppName       string `json:"app_name"`
+	FnName        string `json:"fn_name"`
+}
+
+type invokeEndpointCacheEntry struct {
+	Key      InvokeEndpointCacheKey `json:"key"`
+	Endpoint string                 `json:"endpoint"`
+	CachedAt time.Time              `json:"cached_at"`
+}
+
+type invokeEndpointCacheData struct {
+	Version int                                 `json:"version"`
+	Entries map[string]invokeEndpointCacheEntry `json:"entries"`
+}
+
+// InvokeEndpointCache stores function invoke endpoint resolutions across CLI processes.
+type InvokeEndpointCache struct {
+	path string
+	now  func() time.Time
+}
+
+// NewDefaultInvokeEndpointCache returns the cache in the user's Fn CLI config directory.
+func NewDefaultInvokeEndpointCache() *InvokeEndpointCache {
+	return NewInvokeEndpointCache(DefaultInvokeEndpointCachePath())
+}
+
+// NewInvokeEndpointCache returns a cache backed by the given file path.
+func NewInvokeEndpointCache(path string) *InvokeEndpointCache {
+	return &InvokeEndpointCache{
+		path: path,
+		now:  time.Now,
+	}
+}
+
+// DefaultInvokeEndpointCachePath returns the default persistent invoke endpoint cache file path.
+func DefaultInvokeEndpointCachePath() string {
+	return filepath.Join(config.GetHomeDir(), ".fn", invokeEndpointCacheFileName)
+}
+
+// NewInvokeEndpointCacheKey builds a cache key from the active context and provider.
+func NewInvokeEndpointCacheKey(currentProvider provider.Provider, appName, fnName string) InvokeEndpointCacheKey {
+	apiURL := ""
+	if currentProvider != nil {
+		apiURL = urlString(currentProvider.APIURL())
+	}
+	return InvokeEndpointCacheKey{
+		Context:       viper.GetString(config.CurrentContext),
+		Provider:      viper.GetString(config.ContextProvider),
+		APIURL:        apiURL,
+		CompartmentID: viper.GetString(oracle.CfgCompartmentID),
+		AppName:       appName,
+		FnName:        fnName,
+	}
+}
+
+// Get returns a cached endpoint when it exists and has not expired.
+func (c *InvokeEndpointCache) Get(key InvokeEndpointCacheKey, ttl time.Duration) (string, bool, error) {
+	if ttl <= 0 {
+		return "", false, nil
+	}
+	if c == nil || c.path == "" {
+		return "", false, nil
+	}
+
+	data, err := readInvokeEndpointCache(c.path)
+	if err != nil {
+		return "", false, nil
+	}
+
+	entry, exists := data.Entries[key.cacheID()]
+	if !exists || entry.Endpoint == "" {
+		return "", false, nil
+	}
+	if c.now().Sub(entry.CachedAt) > ttl {
+		return "", false, nil
+	}
+
+	return entry.Endpoint, true, nil
+}
+
+// Put stores an endpoint for the given key.
+func (c *InvokeEndpointCache) Put(key InvokeEndpointCacheKey, endpoint string) error {
+	return c.withLockedData(func(data *invokeEndpointCacheData) error {
+		data.Entries[key.cacheID()] = invokeEndpointCacheEntry{
+			Key:      key,
+			Endpoint: endpoint,
+			CachedAt: c.now().UTC(),
+		}
+		return nil
+	})
+}
+
+// DeleteFunction removes the endpoint cached for a single function.
+func (c *InvokeEndpointCache) DeleteFunction(key InvokeEndpointCacheKey) error {
+	return c.withLockedData(func(data *invokeEndpointCacheData) error {
+		delete(data.Entries, key.cacheID())
+		return nil
+	})
+}
+
+// DeleteApp removes cached endpoints for every function in an app within the same provider context.
+func (c *InvokeEndpointCache) DeleteApp(key InvokeEndpointCacheKey) error {
+	return c.withLockedData(func(data *invokeEndpointCacheData) error {
+		for id, entry := range data.Entries {
+			if entry.Key.sameApp(key) {
+				delete(data.Entries, id)
+			}
+		}
+		return nil
+	})
+}
+
+// InvalidateInvokeEndpointCacheForFunction removes a cached function endpoint for the active provider context.
+func InvalidateInvokeEndpointCacheForFunction(currentProvider provider.Provider, appName, fnName string) error {
+	key := NewInvokeEndpointCacheKey(currentProvider, appName, fnName)
+	return NewDefaultInvokeEndpointCache().DeleteFunction(key)
+}
+
+// InvalidateInvokeEndpointCacheForApp removes cached function endpoints for an app in the active provider context.
+func InvalidateInvokeEndpointCacheForApp(currentProvider provider.Provider, appName string) error {
+	key := NewInvokeEndpointCacheKey(currentProvider, appName, "")
+	return NewDefaultInvokeEndpointCache().DeleteApp(key)
+}
+
+func (c *InvokeEndpointCache) withLockedData(update func(*invokeEndpointCacheData) error) error {
+	if c == nil || c.path == "" {
+		return fmt.Errorf("invoke endpoint cache path is empty")
+	}
+
+	dir := filepath.Dir(c.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	fileLock := flock.New(c.path + ".lock")
+	if err := fileLock.Lock(); err != nil {
+		return err
+	}
+	defer fileLock.Unlock()
+
+	data, err := readInvokeEndpointCache(c.path)
+	if err != nil {
+		return err
+	}
+	if err := update(data); err != nil {
+		return err
+	}
+	return writeInvokeEndpointCache(c.path, data)
+}
+
+func readInvokeEndpointCache(path string) (*invokeEndpointCacheData, error) {
+	data := &invokeEndpointCacheData{
+		Version: invokeEndpointCacheVersion,
+		Entries: map[string]invokeEndpointCacheEntry{},
+	}
+
+	content, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		return data, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 {
+		return data, nil
+	}
+	if err := json.Unmarshal(content, data); err != nil {
+		return data, nil
+	}
+	if data.Entries == nil {
+		data.Entries = map[string]invokeEndpointCacheEntry{}
+	}
+	if data.Version == 0 {
+		data.Version = invokeEndpointCacheVersion
+	}
+	return data, nil
+}
+
+func writeInvokeEndpointCache(path string, data *invokeEndpointCacheData) error {
+	if data.Version == 0 {
+		data.Version = invokeEndpointCacheVersion
+	}
+	if data.Entries == nil {
+		data.Entries = map[string]invokeEndpointCacheEntry{}
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := ioutil.TempFile(dir, ".invoke-endpoint-cache-")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func (k InvokeEndpointCacheKey) cacheID() string {
+	b, _ := json.Marshal(k)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func (k InvokeEndpointCacheKey) sameApp(other InvokeEndpointCacheKey) bool {
+	return k.Context == other.Context &&
+		k.Provider == other.Provider &&
+		k.APIURL == other.APIURL &&
+		k.CompartmentID == other.CompartmentID &&
+		k.AppName == other.AppName
+}
+
+func urlString(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.String()
+}

--- a/common/invoke_endpoint_cache_test.go
+++ b/common/invoke_endpoint_cache_test.go
@@ -1,0 +1,107 @@
+package common
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestInvokeEndpointCachePutGetAndTTL(t *testing.T) {
+	cache := NewInvokeEndpointCache(filepath.Join(t.TempDir(), "invoke-endpoint-cache.json"))
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	cache.now = func() time.Time { return now }
+
+	key := InvokeEndpointCacheKey{
+		Context:       "ctx",
+		Provider:      "oracle",
+		APIURL:        "https://functions.example.com",
+		CompartmentID: "ocid1.compartment.oc1..example",
+		AppName:       "app",
+		FnName:        "fn",
+	}
+
+	if endpoint, ok, err := cache.Get(key, time.Minute); err != nil || ok || endpoint != "" {
+		t.Fatalf("expected empty cache miss, endpoint=%q ok=%v err=%v", endpoint, ok, err)
+	}
+
+	if err := cache.Put(key, "https://invoke.example.com/fn"); err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint, ok, err := cache.Get(key, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || endpoint != "https://invoke.example.com/fn" {
+		t.Fatalf("expected cache hit, endpoint=%q ok=%v", endpoint, ok)
+	}
+
+	now = now.Add(2 * time.Minute)
+	endpoint, ok, err = cache.Get(key, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || endpoint != "" {
+		t.Fatalf("expected expired cache miss, endpoint=%q ok=%v", endpoint, ok)
+	}
+}
+
+func TestInvokeEndpointCacheDeleteFunction(t *testing.T) {
+	cache := NewInvokeEndpointCache(filepath.Join(t.TempDir(), "invoke-endpoint-cache.json"))
+	key := InvokeEndpointCacheKey{
+		Context:  "ctx",
+		Provider: "oracle",
+		APIURL:   "https://functions.example.com",
+		AppName:  "app",
+		FnName:   "fn",
+	}
+
+	if err := cache.Put(key, "https://invoke.example.com/fn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.DeleteFunction(key); err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint, ok, err := cache.Get(key, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || endpoint != "" {
+		t.Fatalf("expected deleted cache miss, endpoint=%q ok=%v", endpoint, ok)
+	}
+}
+
+func TestInvokeEndpointCacheDeleteApp(t *testing.T) {
+	cache := NewInvokeEndpointCache(filepath.Join(t.TempDir(), "invoke-endpoint-cache.json"))
+	key1 := InvokeEndpointCacheKey{Context: "ctx", Provider: "oracle", APIURL: "https://functions.example.com", AppName: "app", FnName: "fn1"}
+	key2 := InvokeEndpointCacheKey{Context: "ctx", Provider: "oracle", APIURL: "https://functions.example.com", AppName: "app", FnName: "fn2"}
+	otherApp := InvokeEndpointCacheKey{Context: "ctx", Provider: "oracle", APIURL: "https://functions.example.com", AppName: "other", FnName: "fn"}
+
+	if err := cache.Put(key1, "https://invoke.example.com/fn1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Put(key2, "https://invoke.example.com/fn2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Put(otherApp, "https://invoke.example.com/other"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.DeleteApp(InvokeEndpointCacheKey{Context: "ctx", Provider: "oracle", APIURL: "https://functions.example.com", AppName: "app"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if endpoint, ok, err := cache.Get(key1, time.Minute); err != nil || ok || endpoint != "" {
+		t.Fatalf("expected first app function to be deleted, endpoint=%q ok=%v err=%v", endpoint, ok, err)
+	}
+	if endpoint, ok, err := cache.Get(key2, time.Minute); err != nil || ok || endpoint != "" {
+		t.Fatalf("expected second app function to be deleted, endpoint=%q ok=%v err=%v", endpoint, ok, err)
+	}
+	endpoint, ok, err := cache.Get(otherApp, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || endpoint != "https://invoke.example.com/other" {
+		t.Fatalf("expected other app to remain cached, endpoint=%q ok=%v", endpoint, ok)
+	}
+}

--- a/objects/app/apps.go
+++ b/objects/app/apps.go
@@ -17,10 +17,10 @@
 package app
 
 import (
-	ocifunctions "github.com/oracle/oci-go-sdk/v65/functions"
 	"encoding/json"
 	"errors"
 	"fmt"
+	ocifunctions "github.com/oracle/oci-go-sdk/v65/functions"
 	"os"
 	"text/tabwriter"
 
@@ -684,6 +684,9 @@ func (a *appsCmd) delete(c *cli.Context) error {
 	}
 	if err := common.WaitForAppState(a.provider, app.ID, control.WaitForState, control.MaxWaitSeconds, control.WaitIntervalSeconds); err != nil {
 		return err
+	}
+	if err := common.InvalidateInvokeEndpointCacheForApp(a.provider, appName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to invalidate invoke endpoint cache: %v\n", err)
 	}
 
 	fmt.Println("App", appName, "deleted")

--- a/objects/fn/fns.go
+++ b/objects/fn/fns.go
@@ -1279,6 +1279,9 @@ func (f *fnsCmd) update(c *cli.Context) error {
 	if err := common.WaitForFunctionState(f.provider, fn.ID, control.WaitForState, control.MaxWaitSeconds, control.WaitIntervalSeconds); err != nil {
 		return err
 	}
+	if err := common.InvalidateInvokeEndpointCacheForFunction(f.provider, appName, fnName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to invalidate invoke endpoint cache: %v\n", err)
+	}
 
 	fmt.Println(appName, fnName, "updated")
 	return nil
@@ -1505,6 +1508,9 @@ func (f *fnsCmd) delete(c *cli.Context) error {
 	}
 	if err := common.WaitForFunctionState(f.provider, fn.ID, control.WaitForState, control.MaxWaitSeconds, control.WaitIntervalSeconds); err != nil {
 		return err
+	}
+	if err := common.InvalidateInvokeEndpointCacheForFunction(f.provider, appName, fnName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to invalidate invoke endpoint cache: %v\n", err)
 	}
 
 	fmt.Println("Function", fnName, "deleted")


### PR DESCRIPTION
This PR adds endpoint caching for 'fn invoke' to reduce unnecessary control-plane calls during repeated function invocations through Fn CLI.

Previously, each 'fn invoke <app> <function>' resolved the function invoke endpoint by looking up the app and function every time. For OCI Functions, that resulted in repeated 'ListApps' / 'ListFns' calls before every invoke. Customers using Fn CLI in frequent invocation loops could generate high CP traffic and hit throttling.

Changes

- Added a persistent invoke endpoint cache at '~/.fn/invoke-endpoint-cache.json'.
- Cache key includes:
  - current context
  - provider
  - API URL
  - compartment ID
  - app name
  - function name
- Added default cache TTL of '15m'.
- Added controls to disable endpoint caching for a single invoke or tune the cache TTL through a CLI flag or environment variable-
  - --no-endpoint-cache
  - --endpoint-cache-ttl
  - FN_INVOKE_ENDPOINT_CACHE_TTL
- Preserved existing '--endpoint' behaviour as a direct bypass.
- Added cache invalidation after:
  - fn deploy
  - fn update function
  - fn delete function
  - fn delete app
- Cache access is guarded for concurrent CLI invocations, and writes are performed safely via temporary-file replacement.

Manual verification:

- First fn invoke <app> <function> creates ~/.fn/invoke-endpoint-cache.json.
- Second invoke for the same app/function uses the cached endpoint.
- --no-endpoint-cache bypasses the cache.
- Successful deploy/update/delete invalidates matching cache entries.