### PR TITLE
Fix provisioned concurrency count validation

### DIFF
--- a/common/provisioned_concurrency.go
+++ b/common/provisioned_concurrency.go
@@ -9,7 +9,10 @@ import (
 const (
 	ProvisionedConcurrencyStrategyNone     = "NONE"
 	ProvisionedConcurrencyStrategyConstant = "CONSTANT"
-	ProvisionedConcurrencyCountStep        = 40
+	// OCI Functions requires every provisioned concurrency count to be a
+	// multiple of 10. The function memory determines any stricter minimum and
+	// increment, so that validation must remain service-side.
+	ProvisionedConcurrencyCountStep = 10
 )
 
 // ValidateProvisionedConcurrencyConfig validates OCI provisioned concurrency values

--- a/common/provisioned_concurrency_test.go
+++ b/common/provisioned_concurrency_test.go
@@ -14,6 +14,7 @@ func TestParseProvisionedConcurrencySpec(t *testing.T) {
 		{name: "empty", spec: "", wantNil: true},
 		{name: "none", spec: "none", strategy: ProvisionedConcurrencyStrategyNone},
 		{name: "none case insensitive", spec: "NoNe", strategy: ProvisionedConcurrencyStrategyNone},
+		{name: "constant minimum for 256 MB function", spec: "constant:20", strategy: ProvisionedConcurrencyStrategyConstant, wantCount: 20},
 		{name: "constant", spec: "constant:40", strategy: ProvisionedConcurrencyStrategyConstant, wantCount: 40},
 		{name: "constant with spaces", spec: " constant:80 ", strategy: ProvisionedConcurrencyStrategyConstant, wantCount: 80},
 		{name: "invalid missing count", spec: "constant", wantErr: true},


### PR DESCRIPTION
Fix Fn CLI validation for PC counts.
The CLI previously required every constant provisioned-concurrency count to be a multiple of 40. This incorrectly rejects valid OCI Functions configurations such as 'constant:20' for a function with 256 MB memory.
