### PR TITLE
Support Cloud Shell on Oracle Linux 9

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -548,8 +548,8 @@ func RunBuild(verbose bool, dir, imageName, dockerfile string, buildArgs []strin
 				targetPlatform := strings.Join(platform, " ")
 				fmt.Println("TargetedPlatform: ", targetPlatform+"HostPlatform: ", hostedPlatform)
 				if targetPlatform != hostedPlatform {
-					if config.EnvIsOL8CloudShell {
-						done <- fmt.Errorf("OL8 CloudShell does not support cross-compilation and multi-arch functions builds. Please ensure the architecture of your App matches the CloudShell architecture.")
+					if config.EnvIsCloudShell {
+						done <- fmt.Errorf("Cloud Shell does not support cross-compilation or multi-architecture function builds. Ensure that your application architecture matches the Cloud Shell architecture.")
 						return
 					}
 					err := initializeContainerBuilder(containerEngineType, mappedArchitectures)
@@ -630,7 +630,7 @@ func containerEngineVersionCheck(containerEngineType string) error {
 	if err != nil {
 		return fmt.Errorf("could not check %v version: %v", containerEngineType, err)
 	}
-	if containerEngineType == "docker" && !config.EnvIsOL8CloudShell {
+	if containerEngineType == "docker" && !config.EnvIsCloudShell {
 		vMin, err := semver.NewVersion(MinRequiredDockerVersion)
 		if err != nil {
 			return fmt.Errorf("our bad, sorry... please make an issue, detailed error: %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -52,17 +52,18 @@ const (
 	EnvFnRegistry = "registry"
 	EnvFnContext  = "context"
 
-	OCI_CLI_AUTH_ENV_VAR                  = "OCI_CLI_AUTH"
-	OCI_CLI_CLOUDSHELL_ENV_VAR            = "OCI_CLI_CLOUD_SHELL"
-	OCI_CLOUDSHELL_OS_NAME                = "Oracle Linux Server"
-	OCI_CLOUDSHELL_OL8_VERSION_IDENTIFIER = "el8"
-	DEFAULT_LINUX_OS_RELEASE_FILE_PATH    = "/etc/os-release"
-	OCI_CLI_AUTH_INSTANCE_PRINCIPAL       = "instance_principal"
-	OCI_CLI_AUTH_INSTANCE_OBO_USER        = "instance_obo_user"
-	DefaultContainerEngineType            = "docker"
+	OCI_CLI_AUTH_ENV_VAR               = "OCI_CLI_AUTH"
+	OCI_CLI_CLOUDSHELL_ENV_VAR         = "OCI_CLI_CLOUD_SHELL"
+	OCI_CLOUDSHELL_OS_NAME             = "Oracle Linux Server"
+	OCI_CLOUDSHELL_OL8_PLATFORM_ID     = "platform:el8"
+	OCI_CLOUDSHELL_OL9_PLATFORM_ID     = "platform:el9"
+	DEFAULT_LINUX_OS_RELEASE_FILE_PATH = "/etc/os-release"
+	OCI_CLI_AUTH_INSTANCE_PRINCIPAL    = "instance_principal"
+	OCI_CLI_AUTH_INSTANCE_OBO_USER     = "instance_obo_user"
+	DefaultContainerEngineType         = "docker"
 )
 
-var EnvIsOL8CloudShell bool = false
+var EnvIsCloudShell bool = false
 
 var defaultRootConfigContents = &ContextMap{CurrentContext: "default", CurrentCliVersion: Version, ContainerEngineType: DefaultContainerEngineType}
 
@@ -209,21 +210,26 @@ func ensureConfiguration() error {
 		}
 	}
 
-	// This check is specific for running fn-cli on Oracle Cloud Shell based on OL8
+	// Cloud Shell uses Podman through its Docker-compatible command on both OL8 and OL9.
 	if os.Getenv(OCI_CLI_CLOUDSHELL_ENV_VAR) == "True" {
 		osrelease, err := Parse(DEFAULT_LINUX_OS_RELEASE_FILE_PATH)
 		if err != nil {
 			return fmt.Errorf("failed to parse /etc/os-relese file: %v", err)
 		}
 
-		if osrelease.Name == OCI_CLOUDSHELL_OS_NAME {
-			if strings.Contains(osrelease.PlatformID, OCI_CLOUDSHELL_OL8_VERSION_IDENTIFIER) {
-				EnvIsOL8CloudShell = true
-			}
-		}
+		EnvIsCloudShell = isCloudShellOS(osrelease)
 	}
 
 	return nil
+}
+
+func isCloudShellOS(osrelease *OSRelease) bool {
+	if osrelease.Name != OCI_CLOUDSHELL_OS_NAME {
+		return false
+	}
+
+	return osrelease.PlatformID == OCI_CLOUDSHELL_OL8_PLATFORM_ID ||
+		osrelease.PlatformID == OCI_CLOUDSHELL_OL9_PLATFORM_ID
 }
 
 // GetContextsPath : Returns the path to the contexts directory.

--- a/config/os-release-test
+++ b/config/os-release-test
@@ -1,18 +1,18 @@
 NAME="Oracle Linux Server"
-VERSION="8.10"
+VERSION="9.8"
 ID="ol"
 ID_LIKE="fedora"
 VARIANT="Server"
 VARIANT_ID="server"
-VERSION_ID="8.10"
-PLATFORM_ID="platform:el8"
-PRETTY_NAME="Oracle Linux Server 8.10"
+VERSION_ID="9.8"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Oracle Linux Server 9.8"
 ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:oracle:linux:8:10:server"
+CPE_NAME="cpe:/o:oracle:linux:9:8:server"
 HOME_URL="https://linux.oracle.com/"
 BUG_REPORT_URL="https://github.com/oracle/oracle-linux"
 
-ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
-ORACLE_BUGZILLA_PRODUCT_VERSION=8.10
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 9"
+ORACLE_BUGZILLA_PRODUCT_VERSION=9.8
 ORACLE_SUPPORT_PRODUCT="Oracle Linux"
-ORACLE_SUPPORT_PRODUCT_VERSION=8.10
+ORACLE_SUPPORT_PRODUCT_VERSION=9.8

--- a/config/osrelease_test.go
+++ b/config/osrelease_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-// This test is written for testing the parsing of file /etc/os-release on OL8 Cloud Shell
-// Please modify the test-case when we move to OL8+ on cloudshell
 func TestParse(t *testing.T) {
 
 	var path = "os-release-test"
@@ -20,7 +18,28 @@ func TestParse(t *testing.T) {
 	switch true {
 	case osrelease.Name != "Oracle Linux Server":
 		t.Errorf("Test failed on NAME: want 'Oracle Linux Server', got '%s'\n", osrelease.Name)
-	case osrelease.PlatformID != "platform:el8":
-		t.Errorf("Test failed on PLATFORM_ID: want 'platform:el8', got '%s'\n", osrelease.PlatformID)
+	case osrelease.PlatformID != OCI_CLOUDSHELL_OL9_PLATFORM_ID:
+		t.Errorf("Test failed on PLATFORM_ID: want '%s', got '%s'\n", OCI_CLOUDSHELL_OL9_PLATFORM_ID, osrelease.PlatformID)
+	}
+}
+
+func TestIsCloudShellOS(t *testing.T) {
+	tests := []struct {
+		name      string
+		osrelease OSRelease
+		want      bool
+	}{
+		{"OL8 Cloud Shell", OSRelease{Name: OCI_CLOUDSHELL_OS_NAME, PlatformID: OCI_CLOUDSHELL_OL8_PLATFORM_ID}, true},
+		{"OL9 Cloud Shell", OSRelease{Name: OCI_CLOUDSHELL_OS_NAME, PlatformID: OCI_CLOUDSHELL_OL9_PLATFORM_ID}, true},
+		{"unsupported Oracle Linux version", OSRelease{Name: OCI_CLOUDSHELL_OS_NAME, PlatformID: "platform:el10"}, false},
+		{"different operating system", OSRelease{Name: "Other Linux", PlatformID: OCI_CLOUDSHELL_OL9_PLATFORM_ID}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isCloudShellOS(&test.osrelease); got != test.want {
+				t.Errorf("isCloudShellOS() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Recognize both OL8 and OL( clod shell env
Retain cloud shell docker/podman compatability path on OL9
Make the cross-arch error message Cloud shell version neutral
Update the /etc/os-release test fixture to OL9
Add test coverage for OL8 and OL9 cloud shell detection 